### PR TITLE
PR2 — Tree Model & Content Renderer (T-6…T-12)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 pub mod context;
 pub mod git;
 pub mod root;
+pub mod tree;
 pub mod view_policy;
 
 /// Entry point invoked by the binary. Wires the components and runs the event loop.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod context;
 pub mod git;
+pub mod render;
 pub mod root;
 pub mod tree;
 pub mod view_policy;

--- a/src/render.rs
+++ b/src/render.rs
@@ -122,12 +122,14 @@ pub fn render(
     prepared: &Prepared,
     mode: ViewMode,
     raw_diff: Option<&str>,
+    file_name: Option<&str>,
 ) -> (Text<'static>, Option<String>) {
+    let name = file_name.unwrap_or("");
     // A diff is derived from git, not from the file's bytes, so it renders even for a
     // deleted or binary file (AC-9) — never short-circuit it to the binary placeholder.
     if mode == ViewMode::Diff {
         let diff = raw_diff.unwrap_or("");
-        return delegate(&renderers.diff, diff, mode, renderers.timeout, None);
+        return delegate(&with_name(&renderers.diff, name), diff, mode, renderers.timeout, None);
     }
 
     // Content modes: a binary file shows a placeholder, never raw bytes (AC-12).
@@ -138,15 +140,30 @@ pub fn render(
     };
 
     match mode {
-        ViewMode::RenderedMarkdown => {
-            delegate(&renderers.markdown, content, mode, renderers.timeout, base_notice)
-        }
-        ViewMode::SyntaxContent => {
-            delegate(&renderers.syntax, content, mode, renderers.timeout, base_notice)
-        }
+        ViewMode::RenderedMarkdown => delegate(
+            &with_name(&renderers.markdown, name),
+            content,
+            mode,
+            renderers.timeout,
+            base_notice,
+        ),
+        ViewMode::SyntaxContent => delegate(
+            &with_name(&renderers.syntax, name),
+            content,
+            mode,
+            renderers.timeout,
+            base_notice,
+        ),
         ViewMode::RawContent => (to_text(content), base_notice),
         ViewMode::Diff => unreachable!("handled above"),
     }
+}
+
+/// Substitute the `{name}` placeholder in a renderer command with the selected file name,
+/// so a stdin-fed renderer (e.g. `bat --file-name={name}`) can still infer the language —
+/// keeping the secure stdin design while enabling syntax highlighting (AC-10).
+fn with_name(command: &[String], name: &str) -> Vec<String> {
+    command.iter().map(|arg| arg.replace("{name}", name)).collect()
 }
 
 /// Run a renderer over `input`, ingesting its output; on missing/failed/timed-out renderer
@@ -309,11 +326,14 @@ fn strip_terminal_control(raw: &str) -> String {
                 Some(_) => i += 2, // ESC + single (e.g. ESC c reset) → drop both
                 None => i += 1,    // lone trailing ESC → drop
             }
+        } else if bytes[i] == 0xc2 && matches!(bytes.get(i + 1), Some(0x80..=0x9f)) {
+            // A C1 control codepoint (U+0080–U+009F, e.g. U+009B = CSI) encoded in UTF-8;
+            // some terminals act on these, so drop the whole 2-byte sequence.
+            i += 2;
         } else {
             // Drop other C0 control bytes (BEL/BS/CR/FF/VT/…) and DEL, which can still
             // ring the bell, backspace, or carriage-return to overwrite/spoof a line.
-            // Keep only newline and tab. C1 bytes (0x80–0x9f) are UTF-8 continuation
-            // bytes here and are left to the final lossy decode.
+            // Keep only newline and tab.
             let b = bytes[i];
             let is_c0_control = b < 0x20 && b != b'\n' && b != b'\t';
             if !is_c0_control && b != 0x7f {

--- a/src/render.rs
+++ b/src/render.rs
@@ -129,8 +129,8 @@ pub fn render(
     // A diff is derived from git, not from the file's bytes, so it renders even for a
     // deleted or binary file (AC-9) — never short-circuit it to the binary placeholder.
     if mode == ViewMode::Diff {
-        let diff = raw_diff.unwrap_or("");
-        return delegate(&with_name(&renderers.diff, name), diff, mode, renderers.timeout, None);
+        let (diff, notice) = cap_preview(raw_diff.unwrap_or(""));
+        return delegate(&with_name(&renderers.diff, name), &diff, mode, renderers.timeout, notice);
     }
 
     // Content modes: a binary file shows a placeholder, never raw bytes (AC-12).
@@ -167,6 +167,27 @@ fn with_name(command: &[String], name: &str) -> Vec<String> {
     command.iter().map(|arg| arg.replace("{name}", name)).collect()
 }
 
+/// Bound a text block to the size cap, returning a preview plus a truncation notice when
+/// it exceeds it. Used for diff text (AC-13's bound applied to large diffs, keeping the
+/// UI path responsive regardless of how big a changed file's diff is).
+fn cap_preview(text: &str) -> (String, Option<String>) {
+    let over = text.lines().count() >= MAX_LINES || text.len() as u64 >= MAX_BYTES;
+    if !over {
+        return (text.to_string(), None);
+    }
+    let mut preview: String = text.lines().take(MAX_LINES).collect::<Vec<_>>().join("\n");
+    if preview.len() as u64 > MAX_BYTES {
+        let end = preview
+            .char_indices()
+            .take_while(|(i, _)| (*i as u64) < MAX_BYTES)
+            .last()
+            .map(|(i, c)| i + c.len_utf8())
+            .unwrap_or(0);
+        preview.truncate(end);
+    }
+    (preview, Some("⚠ Truncated diff preview — diff exceeds the size cap.".into()))
+}
+
 /// Reduce an untrusted file name to a safe basename — directory parts stripped, only
 /// `[A-Za-z0-9._-]` kept (others → `_`). The extension survives (for language detection),
 /// but the value is safe to interpolate even into a shell-wrapper renderer command, so a
@@ -176,9 +197,17 @@ fn sanitize_name(name: &str) -> String {
         .file_name()
         .and_then(|n| n.to_str())
         .unwrap_or("");
-    base.chars()
+    let safe: String = base
+        .chars()
         .map(|c| if c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-') { c } else { '_' })
-        .collect()
+        .collect();
+    // A leading '-' would be parsed as an option by a renderer (e.g. `bat -rf.rs`); prefix
+    // it so the value is always treated as a file name.
+    if safe.starts_with('-') {
+        format!("_{safe}")
+    } else {
+        safe
+    }
 }
 
 /// Run a renderer over `input`, ingesting its output; on missing/failed/timed-out renderer

--- a/src/render.rs
+++ b/src/render.rs
@@ -19,6 +19,8 @@ use std::time::Duration;
 const MAX_BYTES: u64 = 1024 * 1024; // 1 MB
 /// The size cap by line count (AC-13).
 const MAX_LINES: usize = 5000;
+/// Cap on bytes captured from a renderer's stdout, bounding memory if it spews output.
+const MAX_RENDER_OUTPUT: u64 = 16 * 1024 * 1024; // 16 MB
 
 /// The guarded result of reading a file's content.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -121,40 +123,55 @@ pub fn render(
     mode: ViewMode,
     raw_diff: Option<&str>,
 ) -> (Text<'static>, Option<String>) {
-    // Binary: a placeholder, never the raw bytes (AC-12).
+    // A diff is derived from git, not from the file's bytes, so it renders even for a
+    // deleted or binary file (AC-9) — never short-circuit it to the binary placeholder.
+    if mode == ViewMode::Diff {
+        let diff = raw_diff.unwrap_or("");
+        return delegate(&renderers.diff, diff, mode, renderers.timeout, None);
+    }
+
+    // Content modes: a binary file shows a placeholder, never raw bytes (AC-12).
     let (content, base_notice) = match prepared {
-        Prepared::Binary => {
-            return (Text::raw("[binary file — preview not shown]"), None);
-        }
+        Prepared::Binary => return (Text::raw("[binary file — preview not shown]"), None),
         Prepared::Full { text } => (text.as_str(), None),
         Prepared::Truncated { text, notice } => (text.as_str(), Some(notice.clone())),
     };
 
-    // Pick the input to render and the command for this mode (None = raw, no delegation).
-    let (input, command) = match mode {
-        ViewMode::Diff => (raw_diff.unwrap_or(""), Some(&renderers.diff)),
-        ViewMode::RenderedMarkdown => (content, Some(&renderers.markdown)),
-        ViewMode::SyntaxContent => (content, Some(&renderers.syntax)),
-        ViewMode::RawContent => (content, None),
-    };
+    match mode {
+        ViewMode::RenderedMarkdown => {
+            delegate(&renderers.markdown, content, mode, renderers.timeout, base_notice)
+        }
+        ViewMode::SyntaxContent => {
+            delegate(&renderers.syntax, content, mode, renderers.timeout, base_notice)
+        }
+        ViewMode::RawContent => (to_text(content), base_notice),
+        ViewMode::Diff => unreachable!("handled above"),
+    }
+}
 
-    match command {
-        None => (to_text(input), base_notice),
-        Some(cmd) => match run_renderer(cmd, input, renderers.timeout) {
-            Ok(out) => (to_text(&out), base_notice),
-            Err(reason) => {
-                // Plain-text fallback (AC-24) + a notice naming the capability (AC-25).
-                let fallback = format!(
-                    "{} renderer unavailable ({reason}); showing plain text.",
-                    capability(mode)
-                );
-                let notice = match base_notice {
-                    Some(prev) => format!("{prev}\n{fallback}"),
-                    None => fallback,
-                };
-                (to_text(input), Some(notice))
-            }
-        },
+/// Run a renderer over `input`, ingesting its output; on missing/failed/timed-out renderer
+/// fall back to plain text plus a capability-naming notice (AC-24/25), preserving any
+/// pre-existing `base_notice` (e.g. a truncation notice).
+fn delegate(
+    command: &[String],
+    input: &str,
+    mode: ViewMode,
+    timeout: Duration,
+    base_notice: Option<String>,
+) -> (Text<'static>, Option<String>) {
+    match run_renderer(command, input, timeout) {
+        Ok(out) => (to_text(&out), base_notice),
+        Err(reason) => {
+            let fallback = format!(
+                "{} renderer unavailable ({reason}); showing plain text.",
+                capability(mode)
+            );
+            let notice = match base_notice {
+                Some(prev) => format!("{prev}\n{fallback}"),
+                None => fallback,
+            };
+            (to_text(input), Some(notice))
+        }
     }
 }
 
@@ -193,20 +210,22 @@ fn run_renderer(command: &[String], input: &str, timeout: Duration) -> Result<St
     let stdout = child.stdout.take();
     let (tx, rx) = mpsc::channel();
     std::thread::spawn(move || {
+        // Cap the captured output so a renderer spewing unbounded data can't exhaust memory.
         let mut buf = Vec::new();
-        if let Some(mut out) = stdout {
-            let _ = out.read_to_end(&mut buf);
+        if let Some(out) = stdout {
+            let _ = out.take(MAX_RENDER_OUTPUT).read_to_end(&mut buf);
         }
         let _ = tx.send(buf);
     });
 
     match rx.recv_timeout(timeout) {
         Ok(buf) => {
-            let status = child.wait().map_err(|e| format!("{prog}: {e}"))?;
-            if status.success() {
-                Ok(String::from_utf8_lossy(&buf).into_owned())
-            } else {
-                Err(format!("{prog} exited with {status}"))
+            // stdout closed; the process should exit promptly. Bound that wait too, so a
+            // renderer that closes stdout then hangs is still killed (no indefinite block).
+            match wait_bounded(&mut child, timeout) {
+                Some(status) if status.success() => Ok(String::from_utf8_lossy(&buf).into_owned()),
+                Some(status) => Err(format!("{prog} exited with {status}")),
+                None => Err(format!("{prog} did not exit")),
             }
         }
         Err(_) => {
@@ -217,15 +236,35 @@ fn run_renderer(command: &[String], input: &str, timeout: Duration) -> Result<St
     }
 }
 
+/// Wait for a child to exit within `grace`, polling; kill and reap it if it overruns.
+fn wait_bounded(child: &mut std::process::Child, grace: Duration) -> Option<std::process::ExitStatus> {
+    let deadline = std::time::Instant::now() + grace;
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => return Some(status),
+            Ok(None) if std::time::Instant::now() < deadline => {
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            _ => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return None;
+            }
+        }
+    }
+}
+
 /// Ingest (possibly untrusted) content into ratatui `Text`. Cursor-movement and
 /// screen-control escape sequences are stripped regardless of source; only SGR styling is
 /// kept and mapped into spans by `ansi-to-tui` (AC-27). The result can only ever paint the
 /// viewer's own region — it carries no terminal-control operations.
 pub fn to_text(raw: &str) -> Text<'static> {
     let cleaned = strip_terminal_control(raw);
-    cleaned
-        .into_text()
-        .unwrap_or_else(|_| Text::raw(cleaned.clone()))
+    cleaned.clone().into_text().unwrap_or_else(|_| {
+        // If ANSI parsing fails, the kept SGR runs still contain raw ESC bytes — strip
+        // ALL ESC on the fallback so no control byte ever reaches the terminal (AC-27).
+        Text::raw(cleaned.replace('\u{1b}', ""))
+    })
 }
 
 /// Remove cursor/screen-control escape sequences, keeping only SGR (`…m`) styling so it

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,0 +1,151 @@
+//! Content Renderer — produce the content-pane text for a file, with safety guards.
+//!
+//! The primary trust boundary: all file bytes are untrusted. This module bounds size
+//! (AC-13), refuses to emit raw bytes for binary files (AC-12), and (in later tasks)
+//! neutralizes control/escape sequences (AC-27) and delegates styling to external CLIs
+//! with a plain-text fallback (AC-24/25). Reads only, never writes (AC-N1).
+
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+
+/// The size cap: files at or above this many bytes are previewed, not shown whole (AC-13).
+const MAX_BYTES: u64 = 1024 * 1024; // 1 MB
+/// The size cap by line count (AC-13).
+const MAX_LINES: usize = 5000;
+
+/// The guarded result of reading a file's content.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Prepared {
+    /// A binary file: a placeholder is shown, never the raw bytes (AC-12).
+    Binary,
+    /// A file at/above the size cap: a bounded preview plus a visible notice (AC-13).
+    Truncated { text: String, notice: String },
+    /// A normal text file shown in full.
+    Full { text: String },
+}
+
+/// Classify a file for display: binary vs. truncated-preview vs. full text. Reads at most
+/// `MAX_BYTES` from disk, so a huge or hostile file can never be slurped whole (AC-N1).
+pub fn classify(path: &Path) -> Prepared {
+    let byte_len = std::fs::metadata(path).map(|m| m.len()).unwrap_or(0);
+    let Ok(mut file) = File::open(path) else {
+        return Prepared::Full { text: String::new() };
+    };
+    // Bounded read: at most MAX_BYTES, so a giant/hostile file is never slurped whole.
+    let mut buf = Vec::new();
+    if file.by_ref().take(MAX_BYTES).read_to_end(&mut buf).is_err() {
+        return Prepared::Full { text: String::new() };
+    }
+
+    // Binary: a NUL byte anywhere in the (bounded) content. No raw bytes are emitted.
+    if buf.contains(&0) {
+        return Prepared::Binary;
+    }
+
+    let over_bytes = byte_len >= MAX_BYTES;
+    // If the file fit under the cap, invalid UTF-8 means binary. If it was capped, the
+    // read may have split a multi-byte char, so decode lossily rather than misclassify.
+    let text = if over_bytes {
+        String::from_utf8_lossy(&buf).into_owned()
+    } else {
+        match String::from_utf8(buf) {
+            Ok(t) => t,
+            Err(_) => return Prepared::Binary,
+        }
+    };
+
+    let line_count = text.lines().count();
+    let over_lines = line_count >= MAX_LINES;
+    if over_bytes || over_lines {
+        let preview: String = text
+            .lines()
+            .take(MAX_LINES)
+            .collect::<Vec<_>>()
+            .join("\n");
+        let cap = if over_bytes { "1 MB size" } else { "5000-line" };
+        let notice = format!(
+            "⚠ Truncated preview — showing {} lines ({} of {} bytes); file exceeds the {} cap.",
+            preview.lines().count(),
+            preview.len(),
+            byte_len,
+            cap
+        );
+        return Prepared::Truncated { text: preview, notice };
+    }
+    Prepared::Full { text }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static N: AtomicU64 = AtomicU64::new(0);
+
+    fn tmp(name: &str, bytes: &[u8]) -> PathBuf {
+        let p = std::env::temp_dir().join(format!(
+            "hfv-render-{}-{}-{name}",
+            std::process::id(),
+            N.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::write(&p, bytes).unwrap();
+        p
+    }
+
+    #[test]
+    fn nul_bytes_classify_as_binary_without_emitting_raw_bytes() {
+        let p = tmp("bin", &[0x00, 0x01, 0x02, b'h', b'i']);
+        assert_eq!(classify(&p), Prepared::Binary); // AC-12
+        fs::remove_file(&p).ok();
+    }
+
+    #[test]
+    fn small_text_file_is_returned_in_full() {
+        let p = tmp("small.txt", b"hello\nworld\n");
+        match classify(&p) {
+            Prepared::Full { text } => assert!(text.contains("hello")),
+            other => panic!("expected Full, got {other:?}"),
+        }
+        fs::remove_file(&p).ok();
+    }
+
+    #[test]
+    fn file_over_one_megabyte_is_truncated_with_a_notice() {
+        let big = vec![b'a'; (MAX_BYTES as usize) + 100];
+        let p = tmp("big.txt", &big);
+        match classify(&p) {
+            Prepared::Truncated { text, notice } => {
+                assert!(!notice.is_empty(), "AC-13: a visible truncation notice");
+                assert!(text.len() as u64 <= MAX_BYTES, "AC-13: preview is bounded");
+            }
+            other => panic!("expected Truncated, got {other:?}"),
+        }
+        fs::remove_file(&p).ok();
+    }
+
+    #[test]
+    fn file_over_five_thousand_lines_is_truncated() {
+        let many = "x\n".repeat(6000);
+        let p = tmp("many.txt", many.as_bytes());
+        match classify(&p) {
+            Prepared::Truncated { text, notice } => {
+                assert!(text.lines().count() <= MAX_LINES, "AC-13: preview line-bounded");
+                assert!(notice.contains("line"), "notice describes the line cap");
+            }
+            other => panic!("expected Truncated, got {other:?}"),
+        }
+        fs::remove_file(&p).ok();
+    }
+
+    #[test]
+    fn classify_does_not_modify_the_file() {
+        let p = tmp("ro.txt", b"unchanged\n");
+        let before = fs::read(&p).unwrap();
+        let _ = classify(&p);
+        assert_eq!(fs::read(&p).unwrap(), before); // AC-N1
+        fs::remove_file(&p).ok();
+    }
+}

--- a/src/render.rs
+++ b/src/render.rs
@@ -5,11 +5,13 @@
 //! neutralizes control/escape sequences (AC-27) and delegates styling to external CLIs
 //! with a plain-text fallback (AC-24/25). Reads only, never writes (AC-N1).
 
+use crate::view_policy::ViewMode;
 use ansi_to_tui::IntoText;
 use ratatui::text::Text;
 use std::fs::File;
-use std::io::Read;
+use std::io::{Read, Write};
 use std::path::Path;
+use std::process::{Command, Stdio};
 
 /// The size cap: files at or above this many bytes are previewed, not shown whole (AC-13).
 const MAX_BYTES: u64 = 1024 * 1024; // 1 MB
@@ -31,12 +33,12 @@ pub enum Prepared {
 /// `MAX_BYTES` from disk, so a huge or hostile file can never be slurped whole (AC-N1).
 pub fn classify(path: &Path) -> Prepared {
     let byte_len = std::fs::metadata(path).map(|m| m.len()).unwrap_or(0);
-    let Ok(mut file) = File::open(path) else {
+    let Ok(file) = File::open(path) else {
         return Prepared::Full { text: String::new() };
     };
     // Bounded read: at most MAX_BYTES, so a giant/hostile file is never slurped whole.
     let mut buf = Vec::new();
-    if file.by_ref().take(MAX_BYTES).read_to_end(&mut buf).is_err() {
+    if file.take(MAX_BYTES).read_to_end(&mut buf).is_err() {
         return Prepared::Full { text: String::new() };
     }
 
@@ -76,6 +78,103 @@ pub fn classify(path: &Path) -> Prepared {
         return Prepared::Truncated { text: preview, notice };
     }
     Prepared::Full { text }
+}
+
+/// The external renderer commands (program + args) per view mode. Injected so tests stay
+/// hermetic and so a real deployment points these at glow / delta / bat.
+#[derive(Debug, Clone)]
+pub struct Renderers {
+    pub markdown: Vec<String>,
+    pub diff: Vec<String>,
+    pub syntax: Vec<String>,
+}
+
+/// Produce the content-pane text for a prepared file in a given view mode, delegating to
+/// the external renderer for that mode. Untrusted content is fed on **stdin** (never as an
+/// argument) to the trusted, configured renderer; its output is re-neutralized by
+/// [`to_text`]. A missing/failed renderer falls back to plain text plus a notice naming
+/// the missing capability (AC-24, AC-25). Returns the text and an optional notice.
+pub fn render(
+    renderers: &Renderers,
+    prepared: &Prepared,
+    mode: ViewMode,
+    raw_diff: Option<&str>,
+) -> (Text<'static>, Option<String>) {
+    // Binary: a placeholder, never the raw bytes (AC-12).
+    let (content, base_notice) = match prepared {
+        Prepared::Binary => {
+            return (Text::raw("[binary file — preview not shown]"), None);
+        }
+        Prepared::Full { text } => (text.as_str(), None),
+        Prepared::Truncated { text, notice } => (text.as_str(), Some(notice.clone())),
+    };
+
+    // Pick the input to render and the command for this mode (None = raw, no delegation).
+    let (input, command) = match mode {
+        ViewMode::Diff => (raw_diff.unwrap_or(""), Some(&renderers.diff)),
+        ViewMode::RenderedMarkdown => (content, Some(&renderers.markdown)),
+        ViewMode::SyntaxContent => (content, Some(&renderers.syntax)),
+        ViewMode::RawContent => (content, None),
+    };
+
+    match command {
+        None => (to_text(input), base_notice),
+        Some(cmd) => match run_renderer(cmd, input) {
+            Ok(out) => (to_text(&out), base_notice),
+            Err(reason) => {
+                // Plain-text fallback (AC-24) + a notice naming the capability (AC-25).
+                let fallback = format!(
+                    "{} renderer unavailable ({reason}); showing plain text.",
+                    capability(mode)
+                );
+                let notice = match base_notice {
+                    Some(prev) => format!("{prev}\n{fallback}"),
+                    None => fallback,
+                };
+                (to_text(input), Some(notice))
+            }
+        },
+    }
+}
+
+/// A human name for the renderer a mode delegates to (for fallback notices).
+fn capability(mode: ViewMode) -> &'static str {
+    match mode {
+        ViewMode::Diff => "Diff",
+        ViewMode::RenderedMarkdown => "Markdown",
+        ViewMode::SyntaxContent => "Syntax",
+        ViewMode::RawContent => "Plain",
+    }
+}
+
+/// Spawn a renderer, feed `input` on stdin (on a writer thread to avoid a pipe deadlock),
+/// and capture stdout. `Err` on a missing program or non-zero exit. The command is trusted
+/// (operator-configured); only the stdin content is untrusted, so there is no injection.
+fn run_renderer(command: &[String], input: &str) -> Result<String, String> {
+    let (prog, args) = command.split_first().ok_or("empty renderer command")?;
+    let mut child = Command::new(prog)
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|e| format!("{prog}: {e}"))?;
+
+    if let Some(mut stdin) = child.stdin.take() {
+        let owned = input.to_owned();
+        std::thread::spawn(move || {
+            let _ = stdin.write_all(owned.as_bytes()); // ignore a closed pipe
+        });
+    }
+
+    let out = child
+        .wait_with_output()
+        .map_err(|e| format!("{prog}: {e}"))?;
+    if out.status.success() {
+        Ok(String::from_utf8_lossy(&out.stdout).into_owned())
+    } else {
+        Err(format!("{prog} exited with {}", out.status))
+    }
 }
 
 /// Ingest (possibly untrusted) content into ratatui `Text`. Cursor-movement and

--- a/src/render.rs
+++ b/src/render.rs
@@ -54,7 +54,7 @@ pub fn classify(root: &Path, path: &Path) -> Prepared {
 
     let byte_len = std::fs::metadata(&canonical).map(|m| m.len()).unwrap_or(0);
     let Ok(file) = File::open(&canonical) else {
-        return Prepared::Full { text: String::new() };
+        return Prepared::Binary; // unreadable (e.g. permissions) → placeholder, not a misleading empty pane
     };
     // Bounded read: at most MAX_BYTES, so a giant/hostile file is never slurped whole.
     let mut buf = Vec::new();
@@ -124,7 +124,8 @@ pub fn render(
     raw_diff: Option<&str>,
     file_name: Option<&str>,
 ) -> (Text<'static>, Option<String>) {
-    let name = file_name.unwrap_or("");
+    let name = sanitize_name(file_name.unwrap_or(""));
+    let name = name.as_str();
     // A diff is derived from git, not from the file's bytes, so it renders even for a
     // deleted or binary file (AC-9) — never short-circuit it to the binary placeholder.
     if mode == ViewMode::Diff {
@@ -164,6 +165,20 @@ pub fn render(
 /// keeping the secure stdin design while enabling syntax highlighting (AC-10).
 fn with_name(command: &[String], name: &str) -> Vec<String> {
     command.iter().map(|arg| arg.replace("{name}", name)).collect()
+}
+
+/// Reduce an untrusted file name to a safe basename — directory parts stripped, only
+/// `[A-Za-z0-9._-]` kept (others → `_`). The extension survives (for language detection),
+/// but the value is safe to interpolate even into a shell-wrapper renderer command, so a
+/// repo-controlled file name cannot inject shell metacharacters via `{name}`.
+fn sanitize_name(name: &str) -> String {
+    let base = Path::new(name)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("");
+    base.chars()
+        .map(|c| if c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-') { c } else { '_' })
+        .collect()
 }
 
 /// Run a renderer over `input`, ingesting its output; on missing/failed/timed-out renderer

--- a/src/render.rs
+++ b/src/render.rs
@@ -5,6 +5,8 @@
 //! neutralizes control/escape sequences (AC-27) and delegates styling to external CLIs
 //! with a plain-text fallback (AC-24/25). Reads only, never writes (AC-N1).
 
+use ansi_to_tui::IntoText;
+use ratatui::text::Text;
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
@@ -74,6 +76,67 @@ pub fn classify(path: &Path) -> Prepared {
         return Prepared::Truncated { text: preview, notice };
     }
     Prepared::Full { text }
+}
+
+/// Ingest (possibly untrusted) content into ratatui `Text`. Cursor-movement and
+/// screen-control escape sequences are stripped regardless of source; only SGR styling is
+/// kept and mapped into spans by `ansi-to-tui` (AC-27). The result can only ever paint the
+/// viewer's own region — it carries no terminal-control operations.
+pub fn to_text(raw: &str) -> Text<'static> {
+    let cleaned = strip_terminal_control(raw);
+    cleaned
+        .into_text()
+        .unwrap_or_else(|_| Text::raw(cleaned.clone()))
+}
+
+/// Remove cursor/screen-control escape sequences, keeping only SGR (`…m`) styling so it
+/// can be mapped to ratatui styles downstream. Operates on bytes (control sequences are
+/// ASCII) and preserves all other (UTF-8) content verbatim.
+fn strip_terminal_control(raw: &str) -> String {
+    let bytes = raw.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == 0x1b {
+            match bytes.get(i + 1) {
+                Some(b'[') => {
+                    // CSI: params/intermediates until a final byte (0x40..=0x7e).
+                    let start = i;
+                    let mut j = i + 2;
+                    while j < bytes.len() && !(0x40..=0x7e).contains(&bytes[j]) {
+                        j += 1;
+                    }
+                    if j < bytes.len() && bytes[j] == b'm' {
+                        out.extend_from_slice(&bytes[start..=j]); // keep SGR styling
+                    }
+                    // else: drop the whole control sequence (cursor move, erase, …)
+                    i = if j < bytes.len() { j + 1 } else { j };
+                }
+                Some(b']') => {
+                    // OSC: drop through BEL or ST (ESC \).
+                    let mut j = i + 2;
+                    while j < bytes.len() {
+                        if bytes[j] == 0x07 {
+                            j += 1;
+                            break;
+                        }
+                        if bytes[j] == 0x1b && bytes.get(j + 1) == Some(&b'\\') {
+                            j += 2;
+                            break;
+                        }
+                        j += 1;
+                    }
+                    i = j;
+                }
+                Some(_) => i += 2, // ESC + single (e.g. ESC c reset) → drop both
+                None => i += 1,    // lone trailing ESC → drop
+            }
+        } else {
+            out.push(bytes[i]);
+            i += 1;
+        }
+    }
+    String::from_utf8_lossy(&out).into_owned()
 }
 
 #[cfg(test)]

--- a/src/render.rs
+++ b/src/render.rs
@@ -12,6 +12,8 @@ use std::fs::File;
 use std::io::{Read, Write};
 use std::path::Path;
 use std::process::{Command, Stdio};
+use std::sync::mpsc;
+use std::time::Duration;
 
 /// The size cap: files at or above this many bytes are previewed, not shown whole (AC-13).
 const MAX_BYTES: u64 = 1024 * 1024; // 1 MB
@@ -31,9 +33,25 @@ pub enum Prepared {
 
 /// Classify a file for display: binary vs. truncated-preview vs. full text. Reads at most
 /// `MAX_BYTES` from disk, so a huge or hostile file can never be slurped whole (AC-N1).
-pub fn classify(path: &Path) -> Prepared {
-    let byte_len = std::fs::metadata(path).map(|m| m.len()).unwrap_or(0);
-    let Ok(file) = File::open(path) else {
+///
+/// Refuses to read anything that does not resolve to a **regular file inside `root`**:
+/// a symlink (or `..`) escaping the root cannot leak out-of-root content into the pane
+/// (AC-N5), and a FIFO/device/dir is never opened (no hang, no garbage). Such paths
+/// return `Binary` (a placeholder, no bytes).
+pub fn classify(root: &Path, path: &Path) -> Prepared {
+    let (Ok(canonical), Ok(canon_root)) = (path.canonicalize(), root.canonicalize()) else {
+        return Prepared::Binary; // unresolvable / missing
+    };
+    if !canonical.starts_with(&canon_root) {
+        return Prepared::Binary; // escapes the root (AC-N5)
+    }
+    match std::fs::metadata(&canonical) {
+        Ok(m) if m.is_file() => {}
+        _ => return Prepared::Binary, // dir / FIFO / device / gone
+    }
+
+    let byte_len = std::fs::metadata(&canonical).map(|m| m.len()).unwrap_or(0);
+    let Ok(file) = File::open(&canonical) else {
         return Prepared::Full { text: String::new() };
     };
     // Bounded read: at most MAX_BYTES, so a giant/hostile file is never slurped whole.
@@ -87,6 +105,9 @@ pub struct Renderers {
     pub markdown: Vec<String>,
     pub diff: Vec<String>,
     pub syntax: Vec<String>,
+    /// Per-invocation wall-clock bound; a renderer exceeding it is killed and the plain-
+    /// text fallback is used, so a wedged delegate can never hang rendering.
+    pub timeout: Duration,
 }
 
 /// Produce the content-pane text for a prepared file in a given view mode, delegating to
@@ -119,7 +140,7 @@ pub fn render(
 
     match command {
         None => (to_text(input), base_notice),
-        Some(cmd) => match run_renderer(cmd, input) {
+        Some(cmd) => match run_renderer(cmd, input, renderers.timeout) {
             Ok(out) => (to_text(&out), base_notice),
             Err(reason) => {
                 // Plain-text fallback (AC-24) + a notice naming the capability (AC-25).
@@ -147,10 +168,12 @@ fn capability(mode: ViewMode) -> &'static str {
     }
 }
 
-/// Spawn a renderer, feed `input` on stdin (on a writer thread to avoid a pipe deadlock),
-/// and capture stdout. `Err` on a missing program or non-zero exit. The command is trusted
-/// (operator-configured); only the stdin content is untrusted, so there is no injection.
-fn run_renderer(command: &[String], input: &str) -> Result<String, String> {
+/// Spawn a renderer, feed `input` on stdin (writer thread, avoids a pipe deadlock), read
+/// stdout (reader thread), and bound the wait by `timeout` — a wedged renderer is killed
+/// and reported as failed so the plain-text fallback kicks in. `Err` on a missing program,
+/// non-zero exit, or timeout. The command is trusted (operator-configured); only the stdin
+/// content is untrusted, so there is no argument injection.
+fn run_renderer(command: &[String], input: &str, timeout: Duration) -> Result<String, String> {
     let (prog, args) = command.split_first().ok_or("empty renderer command")?;
     let mut child = Command::new(prog)
         .args(args)
@@ -167,13 +190,30 @@ fn run_renderer(command: &[String], input: &str) -> Result<String, String> {
         });
     }
 
-    let out = child
-        .wait_with_output()
-        .map_err(|e| format!("{prog}: {e}"))?;
-    if out.status.success() {
-        Ok(String::from_utf8_lossy(&out.stdout).into_owned())
-    } else {
-        Err(format!("{prog} exited with {}", out.status))
+    let stdout = child.stdout.take();
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        if let Some(mut out) = stdout {
+            let _ = out.read_to_end(&mut buf);
+        }
+        let _ = tx.send(buf);
+    });
+
+    match rx.recv_timeout(timeout) {
+        Ok(buf) => {
+            let status = child.wait().map_err(|e| format!("{prog}: {e}"))?;
+            if status.success() {
+                Ok(String::from_utf8_lossy(&buf).into_owned())
+            } else {
+                Err(format!("{prog} exited with {status}"))
+            }
+        }
+        Err(_) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            Err(format!("{prog} timed out"))
+        }
     }
 }
 
@@ -231,7 +271,15 @@ fn strip_terminal_control(raw: &str) -> String {
                 None => i += 1,    // lone trailing ESC → drop
             }
         } else {
-            out.push(bytes[i]);
+            // Drop other C0 control bytes (BEL/BS/CR/FF/VT/…) and DEL, which can still
+            // ring the bell, backspace, or carriage-return to overwrite/spoof a line.
+            // Keep only newline and tab. C1 bytes (0x80–0x9f) are UTF-8 continuation
+            // bytes here and are left to the final lossy decode.
+            let b = bytes[i];
+            let is_c0_control = b < 0x20 && b != b'\n' && b != b'\t';
+            if !is_c0_control && b != 0x7f {
+                out.push(b);
+            }
             i += 1;
         }
     }
@@ -260,14 +308,14 @@ mod tests {
     #[test]
     fn nul_bytes_classify_as_binary_without_emitting_raw_bytes() {
         let p = tmp("bin", &[0x00, 0x01, 0x02, b'h', b'i']);
-        assert_eq!(classify(&p), Prepared::Binary); // AC-12
+        assert_eq!(classify(&std::env::temp_dir(), &p), Prepared::Binary); // AC-12
         fs::remove_file(&p).ok();
     }
 
     #[test]
     fn small_text_file_is_returned_in_full() {
         let p = tmp("small.txt", b"hello\nworld\n");
-        match classify(&p) {
+        match classify(&std::env::temp_dir(), &p) {
             Prepared::Full { text } => assert!(text.contains("hello")),
             other => panic!("expected Full, got {other:?}"),
         }
@@ -278,7 +326,7 @@ mod tests {
     fn file_over_one_megabyte_is_truncated_with_a_notice() {
         let big = vec![b'a'; (MAX_BYTES as usize) + 100];
         let p = tmp("big.txt", &big);
-        match classify(&p) {
+        match classify(&std::env::temp_dir(), &p) {
             Prepared::Truncated { text, notice } => {
                 assert!(!notice.is_empty(), "AC-13: a visible truncation notice");
                 assert!(text.len() as u64 <= MAX_BYTES, "AC-13: preview is bounded");
@@ -292,7 +340,7 @@ mod tests {
     fn file_over_five_thousand_lines_is_truncated() {
         let many = "x\n".repeat(6000);
         let p = tmp("many.txt", many.as_bytes());
-        match classify(&p) {
+        match classify(&std::env::temp_dir(), &p) {
             Prepared::Truncated { text, notice } => {
                 assert!(text.lines().count() <= MAX_LINES, "AC-13: preview line-bounded");
                 assert!(notice.contains("line"), "notice describes the line cap");
@@ -306,8 +354,55 @@ mod tests {
     fn classify_does_not_modify_the_file() {
         let p = tmp("ro.txt", b"unchanged\n");
         let before = fs::read(&p).unwrap();
-        let _ = classify(&p);
+        let _ = classify(&std::env::temp_dir(), &p);
         assert_eq!(fs::read(&p).unwrap(), before); // AC-N1
         fs::remove_file(&p).ok();
+    }
+
+    fn unique_dir(tag: &str) -> PathBuf {
+        let d = std::env::temp_dir().join(format!(
+            "hfv-{tag}-{}-{}",
+            std::process::id(),
+            N.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::create_dir_all(&d).unwrap();
+        d
+    }
+
+    #[test]
+    fn refuses_a_symlink_whose_target_escapes_the_root() {
+        use std::os::unix::fs::symlink;
+        let root = unique_dir("root");
+        let outside = tmp("secret", b"TOPSECRET"); // lives in temp_dir, outside `root`
+        let link = root.join("link.txt");
+        symlink(&outside, &link).unwrap();
+        assert_eq!(classify(&root, &link), Prepared::Binary, "AC-N5: no out-of-root read");
+        fs::remove_dir_all(&root).ok();
+        fs::remove_file(&outside).ok();
+    }
+
+    #[test]
+    fn follows_a_symlink_that_stays_within_the_root() {
+        use std::os::unix::fs::symlink;
+        let root = unique_dir("root");
+        let real = root.join("real.txt");
+        fs::write(&real, "hello inside").unwrap();
+        let link = root.join("link.txt");
+        symlink(&real, &link).unwrap();
+        match classify(&root, &link) {
+            Prepared::Full { text } => assert!(text.contains("hello inside")),
+            other => panic!("expected Full, got {other:?}"),
+        }
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn refuses_a_non_regular_file() {
+        let root = unique_dir("root");
+        // a directory is not a regular file
+        let sub = root.join("subdir");
+        fs::create_dir_all(&sub).unwrap();
+        assert_eq!(classify(&root, &sub), Prepared::Binary);
+        fs::remove_dir_all(&root).ok();
     }
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -6,7 +6,7 @@
 
 use crate::git::Status;
 use ignore::WalkBuilder;
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use std::path::{Path, PathBuf};
 
 /// Whether a tree node is a directory or a file.
@@ -32,6 +32,10 @@ pub struct TreeModel {
     expanded: HashSet<PathBuf>,
     cursor: usize,
     show_ignored: bool,
+    changed_only: bool,
+    /// The changed-set against the active baseline: drives status markers (always shown,
+    /// AC-7) and the changed-only filter (AC-6). Keyed by root-relative path.
+    status_map: BTreeMap<PathBuf, Status>,
 }
 
 impl TreeModel {
@@ -41,7 +45,26 @@ impl TreeModel {
             expanded: HashSet::new(),
             cursor: 0,
             show_ignored: false,
+            changed_only: false,
+            status_map: BTreeMap::new(),
         }
+    }
+
+    /// Reveal gitignored/all files (AC-5).
+    pub fn set_show_ignored(&mut self, on: bool) {
+        self.show_ignored = on;
+    }
+
+    /// Restrict the tree to changed files only (AC-6); `changed` is the changed-set
+    /// against the active baseline, which also feeds status markers.
+    pub fn set_changed_only(&mut self, on: bool, changed: &BTreeMap<PathBuf, Status>) {
+        self.changed_only = on;
+        self.status_map = changed.clone();
+    }
+
+    /// Set the per-file status used for tree markers (AC-7), independent of the filter.
+    pub fn set_status(&mut self, status: &BTreeMap<PathBuf, Status>) {
+        self.status_map = status.clone();
     }
 
     pub fn root(&self) -> &Path {
@@ -62,17 +85,45 @@ impl TreeModel {
 
     fn collect(&self, dir: &Path, depth: usize, out: &mut Vec<Node>) {
         for (path, kind) in self.entries(dir) {
-            let expanded = kind == NodeKind::Dir && self.expanded.contains(&path);
+            if self.changed_only && !self.leads_to_change(&path, kind) {
+                continue;
+            }
+            // In changed-only mode, auto-descend into directories so the (only) changed
+            // files inside are reachable without manual expansion.
+            let expanded = kind == NodeKind::Dir
+                && (self.changed_only || self.expanded.contains(&path));
             out.push(Node {
                 path: path.clone(),
                 kind,
                 depth,
                 expanded,
-                status: None,
+                status: self.status_for(&path),
             });
             if expanded {
                 self.collect(&path, depth + 1, out);
             }
+        }
+    }
+
+    /// The node's git status (AC-7), looked up by root-relative path.
+    fn status_for(&self, path: &Path) -> Option<Status> {
+        path.strip_prefix(&self.root)
+            .ok()
+            .and_then(|rel| self.status_map.get(rel).copied())
+    }
+
+    /// In changed-only mode: a file kept iff it is itself changed; a directory kept iff it
+    /// (transitively) contains a changed file.
+    fn leads_to_change(&self, path: &Path, kind: NodeKind) -> bool {
+        let Ok(rel) = path.strip_prefix(&self.root) else {
+            return false;
+        };
+        match kind {
+            NodeKind::File => self.status_map.contains_key(rel),
+            NodeKind::Dir => self
+                .status_map
+                .keys()
+                .any(|changed| changed != rel && changed.starts_with(rel)),
         }
     }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -26,6 +26,15 @@ pub struct Node {
     pub status: Option<Status>,
 }
 
+/// Order tree entries: directories first, then files; alphabetical within each group.
+fn sort_entries(entries: &mut [(PathBuf, NodeKind)]) {
+    entries.sort_by(|a, b| {
+        (b.1 == NodeKind::Dir)
+            .cmp(&(a.1 == NodeKind::Dir))
+            .then_with(|| a.0.file_name().cmp(&b.0.file_name()))
+    });
+}
+
 /// The browsable file tree rooted at `root`.
 pub struct TreeModel {
     root: PathBuf,
@@ -33,9 +42,12 @@ pub struct TreeModel {
     cursor: usize,
     show_ignored: bool,
     changed_only: bool,
-    /// The changed-set against the active baseline: drives status markers (always shown,
-    /// AC-7) and the changed-only filter (AC-6). Keyed by root-relative path.
-    status_map: BTreeMap<PathBuf, Status>,
+    /// Per-file status for tree markers (AC-7), keyed by root-relative path. Set
+    /// independently of the filter (`set_status`) so the two can never overwrite each
+    /// other.
+    markers: BTreeMap<PathBuf, Status>,
+    /// The changed-set driving the changed-only filter (AC-6), set by `set_changed_only`.
+    changed_filter: BTreeMap<PathBuf, Status>,
 }
 
 impl TreeModel {
@@ -46,7 +58,8 @@ impl TreeModel {
             cursor: 0,
             show_ignored: false,
             changed_only: false,
-            status_map: BTreeMap::new(),
+            markers: BTreeMap::new(),
+            changed_filter: BTreeMap::new(),
         }
     }
 
@@ -56,15 +69,15 @@ impl TreeModel {
     }
 
     /// Restrict the tree to changed files only (AC-6); `changed` is the changed-set
-    /// against the active baseline, which also feeds status markers.
+    /// against the active baseline.
     pub fn set_changed_only(&mut self, on: bool, changed: &BTreeMap<PathBuf, Status>) {
         self.changed_only = on;
-        self.status_map = changed.clone();
+        self.changed_filter = changed.clone();
     }
 
     /// Set the per-file status used for tree markers (AC-7), independent of the filter.
     pub fn set_status(&mut self, status: &BTreeMap<PathBuf, Status>) {
-        self.status_map = status.clone();
+        self.markers = status.clone();
     }
 
     pub fn root(&self) -> &Path {
@@ -84,7 +97,22 @@ impl TreeModel {
     }
 
     fn collect(&self, dir: &Path, depth: usize, out: &mut Vec<Node>) {
-        for (path, kind) in self.entries(dir) {
+        let mut entries = self.entries(dir);
+        if self.changed_only {
+            // Deleted files aren't on disk, so synthesize nodes for them under their
+            // (still-present) parent directory, so changed-only mode can show and review
+            // them (AC-6) with a deleted marker (AC-7).
+            for (rel, status) in &self.changed_filter {
+                if *status == Status::Deleted {
+                    let abs = self.root.join(rel);
+                    if abs.parent() == Some(dir) && !abs.exists() {
+                        entries.push((abs, NodeKind::File));
+                    }
+                }
+            }
+            sort_entries(&mut entries);
+        }
+        for (path, kind) in entries {
             if self.changed_only && !self.leads_to_change(&path, kind) {
                 continue;
             }
@@ -105,11 +133,15 @@ impl TreeModel {
         }
     }
 
-    /// The node's git status (AC-7), looked up by root-relative path.
+    /// The node's git status (AC-7): the dedicated marker map, falling back to the
+    /// changed-set so synthesized deleted nodes still carry their marker.
     fn status_for(&self, path: &Path) -> Option<Status> {
-        path.strip_prefix(&self.root)
-            .ok()
-            .and_then(|rel| self.status_map.get(rel).copied())
+        path.strip_prefix(&self.root).ok().and_then(|rel| {
+            self.markers
+                .get(rel)
+                .or_else(|| self.changed_filter.get(rel))
+                .copied()
+        })
     }
 
     /// In changed-only mode: a file kept iff it is itself changed; a directory kept iff it
@@ -119,9 +151,9 @@ impl TreeModel {
             return false;
         };
         match kind {
-            NodeKind::File => self.status_map.contains_key(rel),
+            NodeKind::File => self.changed_filter.contains_key(rel),
             NodeKind::Dir => self
-                .status_map
+                .changed_filter
                 .keys()
                 .any(|changed| changed != rel && changed.starts_with(rel)),
         }
@@ -156,12 +188,7 @@ impl TreeModel {
             })
             .collect();
 
-        // Directories first, then files; alphabetical within each group.
-        entries.sort_by(|a, b| {
-            (b.1 == NodeKind::Dir)
-                .cmp(&(a.1 == NodeKind::Dir))
-                .then_with(|| a.0.file_name().cmp(&b.0.file_name()))
-        });
+        sort_entries(&mut entries);
         entries
     }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -6,7 +6,7 @@
 
 use crate::git::Status;
 use ignore::WalkBuilder;
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::path::{Path, PathBuf};
 
 /// Whether a tree node is a directory or a file.
@@ -88,38 +88,22 @@ impl TreeModel {
         self.cursor
     }
 
-    /// The ordered list of currently-visible nodes (root's children, plus the children of
-    /// every expanded directory, depth-first).
+    /// The ordered list of currently-visible nodes. In the full tree these are root's
+    /// children plus the children of every expanded directory, depth-first. In changed-only
+    /// mode the tree is built from the changed-set itself (so deleted files — and files
+    /// under a deleted directory — still appear, AC-6/AC-7), with every directory expanded.
     pub fn visible_nodes(&self) -> Vec<Node> {
+        if self.changed_only {
+            return self.changed_only_nodes();
+        }
         let mut out = Vec::new();
         self.collect(&self.root, 0, &mut out);
         out
     }
 
     fn collect(&self, dir: &Path, depth: usize, out: &mut Vec<Node>) {
-        let mut entries = self.entries(dir);
-        if self.changed_only {
-            // Deleted files aren't on disk, so synthesize nodes for them under their
-            // (still-present) parent directory, so changed-only mode can show and review
-            // them (AC-6) with a deleted marker (AC-7).
-            for (rel, status) in &self.changed_filter {
-                if *status == Status::Deleted {
-                    let abs = self.root.join(rel);
-                    if abs.parent() == Some(dir) && !abs.exists() {
-                        entries.push((abs, NodeKind::File));
-                    }
-                }
-            }
-            sort_entries(&mut entries);
-        }
-        for (path, kind) in entries {
-            if self.changed_only && !self.leads_to_change(&path, kind) {
-                continue;
-            }
-            // In changed-only mode, auto-descend into directories so the (only) changed
-            // files inside are reachable without manual expansion.
-            let expanded = kind == NodeKind::Dir
-                && (self.changed_only || self.expanded.contains(&path));
+        for (path, kind) in self.entries(dir) {
+            let expanded = kind == NodeKind::Dir && self.expanded.contains(&path);
             out.push(Node {
                 path: path.clone(),
                 kind,
@@ -133,6 +117,63 @@ impl TreeModel {
         }
     }
 
+    /// Build the changed-only tree from the changed-set's paths (not the filesystem), so
+    /// deletions — including whole deleted directories — are reviewable.
+    fn changed_only_nodes(&self) -> Vec<Node> {
+        let files: BTreeSet<PathBuf> = self.changed_filter.keys().cloned().collect();
+        let mut dirs: BTreeSet<PathBuf> = BTreeSet::new();
+        for rel in &files {
+            let mut ancestor = rel.parent();
+            while let Some(p) = ancestor {
+                if p.as_os_str().is_empty() {
+                    break;
+                }
+                dirs.insert(p.to_path_buf());
+                ancestor = p.parent();
+            }
+        }
+        let mut out = Vec::new();
+        self.emit_synthetic(Path::new(""), 0, &dirs, &files, &mut out);
+        out
+    }
+
+    fn emit_synthetic(
+        &self,
+        parent_rel: &Path,
+        depth: usize,
+        dirs: &BTreeSet<PathBuf>,
+        files: &BTreeSet<PathBuf>,
+        out: &mut Vec<Node>,
+    ) {
+        let is_child = |rel: &Path| rel.parent().unwrap_or(Path::new("")) == parent_rel;
+        let mut child_dirs: Vec<&PathBuf> = dirs.iter().filter(|d| is_child(d)).collect();
+        let mut child_files: Vec<&PathBuf> = files.iter().filter(|f| is_child(f)).collect();
+        child_dirs.sort_by(|a, b| a.file_name().cmp(&b.file_name()));
+        child_files.sort_by(|a, b| a.file_name().cmp(&b.file_name()));
+
+        for d in child_dirs {
+            let abs = self.root.join(d);
+            out.push(Node {
+                path: abs.clone(),
+                kind: NodeKind::Dir,
+                depth,
+                expanded: true,
+                status: self.status_for(&abs),
+            });
+            self.emit_synthetic(d, depth + 1, dirs, files, out);
+        }
+        for f in child_files {
+            let abs = self.root.join(f);
+            out.push(Node {
+                path: abs.clone(),
+                kind: NodeKind::File,
+                depth,
+                expanded: false,
+                status: self.status_for(&abs),
+            });
+        }
+    }
+
     /// The node's git status (AC-7): the dedicated marker map, falling back to the
     /// changed-set so synthesized deleted nodes still carry their marker.
     fn status_for(&self, path: &Path) -> Option<Status> {
@@ -142,21 +183,6 @@ impl TreeModel {
                 .or_else(|| self.changed_filter.get(rel))
                 .copied()
         })
-    }
-
-    /// In changed-only mode: a file kept iff it is itself changed; a directory kept iff it
-    /// (transitively) contains a changed file.
-    fn leads_to_change(&self, path: &Path, kind: NodeKind) -> bool {
-        let Ok(rel) = path.strip_prefix(&self.root) else {
-            return false;
-        };
-        match kind {
-            NodeKind::File => self.changed_filter.contains_key(rel),
-            NodeKind::Dir => self
-                .changed_filter
-                .keys()
-                .any(|changed| changed != rel && changed.starts_with(rel)),
-        }
     }
 
     /// Immediate children of `dir`: gitignore-filtered (unless `show_ignored`), `.git`

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -66,6 +66,7 @@ impl TreeModel {
     /// Reveal gitignored/all files (AC-5).
     pub fn set_show_ignored(&mut self, on: bool) {
         self.show_ignored = on;
+        self.clamp_cursor();
     }
 
     /// Restrict the tree to changed files only (AC-6); `changed` is the changed-set
@@ -73,6 +74,7 @@ impl TreeModel {
     pub fn set_changed_only(&mut self, on: bool, changed: &BTreeMap<PathBuf, Status>) {
         self.changed_only = on;
         self.changed_filter = changed.clone();
+        self.clamp_cursor();
     }
 
     /// Set the per-file status used for tree markers (AC-7), independent of the filter.
@@ -228,6 +230,7 @@ impl TreeModel {
     /// Collapse a directory.
     pub fn collapse(&mut self, path: &Path) {
         self.expanded.remove(path);
+        self.clamp_cursor();
     }
 
     /// Toggle a directory's expansion.
@@ -237,5 +240,28 @@ impl TreeModel {
         } else {
             self.expand(path);
         }
+    }
+
+    /// Move the cursor by `delta` rows, clamped to the visible range.
+    pub fn move_cursor(&mut self, delta: isize) {
+        let len = self.visible_nodes().len();
+        if len == 0 {
+            self.cursor = 0;
+            return;
+        }
+        let max = (len - 1) as isize;
+        self.cursor = (self.cursor as isize + delta).clamp(0, max) as usize;
+    }
+
+    /// The currently-selected node, if any.
+    pub fn selected(&self) -> Option<Node> {
+        self.visible_nodes().into_iter().nth(self.cursor)
+    }
+
+    /// Keep the cursor within the (possibly shrunken) visible list after a structural or
+    /// filter change, so indexing by `cursor` can never run past the end.
+    fn clamp_cursor(&mut self) {
+        let len = self.visible_nodes().len();
+        self.cursor = self.cursor.min(len.saturating_sub(1));
     }
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,0 +1,137 @@
+//! Tree Model — the rooted, gitignore-aware file tree, its expansion state, and cursor.
+//!
+//! Enumerates lazily (immediate children on expand) via the `ignore` crate so launch is
+//! fast on large repos (AC-22). Hides gitignored entries by default (AC-4), is bounded by
+//! its root — no node ever escapes it (AC-N5) — and reads only, never writes (AC-N1).
+
+use crate::git::Status;
+use ignore::WalkBuilder;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+/// Whether a tree node is a directory or a file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NodeKind {
+    Dir,
+    File,
+}
+
+/// One visible row of the tree.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Node {
+    pub path: PathBuf,
+    pub kind: NodeKind,
+    pub depth: usize,
+    pub expanded: bool,
+    pub status: Option<Status>,
+}
+
+/// The browsable file tree rooted at `root`.
+pub struct TreeModel {
+    root: PathBuf,
+    expanded: HashSet<PathBuf>,
+    cursor: usize,
+    show_ignored: bool,
+}
+
+impl TreeModel {
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self {
+            root: root.into(),
+            expanded: HashSet::new(),
+            cursor: 0,
+            show_ignored: false,
+        }
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    pub fn cursor(&self) -> usize {
+        self.cursor
+    }
+
+    /// The ordered list of currently-visible nodes (root's children, plus the children of
+    /// every expanded directory, depth-first).
+    pub fn visible_nodes(&self) -> Vec<Node> {
+        let mut out = Vec::new();
+        self.collect(&self.root, 0, &mut out);
+        out
+    }
+
+    fn collect(&self, dir: &Path, depth: usize, out: &mut Vec<Node>) {
+        for (path, kind) in self.entries(dir) {
+            let expanded = kind == NodeKind::Dir && self.expanded.contains(&path);
+            out.push(Node {
+                path: path.clone(),
+                kind,
+                depth,
+                expanded,
+                status: None,
+            });
+            if expanded {
+                self.collect(&path, depth + 1, out);
+            }
+        }
+    }
+
+    /// Immediate children of `dir`: gitignore-filtered (unless `show_ignored`), `.git`
+    /// hidden, directories before files, each group alphabetical. Read-only.
+    fn entries(&self, dir: &Path) -> Vec<(PathBuf, NodeKind)> {
+        let mut builder = WalkBuilder::new(dir);
+        builder
+            .max_depth(Some(1))
+            .hidden(false) // show dotfiles (e.g. .gitignore, .github)
+            .parents(true) // honor ancestor .gitignore for correct nested semantics
+            .git_global(false) // hermetic: ignore the user's global gitignore
+            .ignore(false) // only git ignore sources, not generic .ignore files
+            .require_git(false) // honor .gitignore even outside a git repo (AC-4, AC-26)
+            .git_ignore(!self.show_ignored)
+            .git_exclude(!self.show_ignored);
+
+        let mut entries: Vec<(PathBuf, NodeKind)> = builder
+            .build()
+            .filter_map(Result::ok)
+            .filter(|e| e.depth() == 1) // children only, not `dir` itself
+            .filter(|e| e.file_name().to_str() != Some(".git")) // never browse into .git
+            .map(|e| {
+                let kind = if e.file_type().is_some_and(|t| t.is_dir()) {
+                    NodeKind::Dir
+                } else {
+                    NodeKind::File
+                };
+                (e.into_path(), kind)
+            })
+            .collect();
+
+        // Directories first, then files; alphabetical within each group.
+        entries.sort_by(|a, b| {
+            (b.1 == NodeKind::Dir)
+                .cmp(&(a.1 == NodeKind::Dir))
+                .then_with(|| a.0.file_name().cmp(&b.0.file_name()))
+        });
+        entries
+    }
+
+    /// Expand a directory (no-op for a path outside the root — AC-N5).
+    pub fn expand(&mut self, path: &Path) {
+        if path.starts_with(&self.root) {
+            self.expanded.insert(path.to_path_buf());
+        }
+    }
+
+    /// Collapse a directory.
+    pub fn collapse(&mut self, path: &Path) {
+        self.expanded.remove(path);
+    }
+
+    /// Toggle a directory's expansion.
+    pub fn toggle(&mut self, path: &Path) {
+        if self.expanded.contains(path) {
+            self.collapse(path);
+        } else {
+            self.expand(path);
+        }
+    }
+}

--- a/tests/render_delegate.rs
+++ b/tests/render_delegate.rs
@@ -7,12 +7,14 @@
 use herdr_file_viewer::render::{render, Prepared, Renderers};
 use herdr_file_viewer::view_policy::ViewMode;
 use ratatui::text::Text;
+use std::time::{Duration, Instant};
 
 fn cat() -> Renderers {
     Renderers {
         markdown: vec!["cat".into()],
         diff: vec!["cat".into()],
         syntax: vec!["cat".into()],
+        timeout: Duration::from_secs(5),
     }
 }
 
@@ -52,6 +54,7 @@ fn missing_renderer_falls_back_to_plain_text_with_a_notice() {
         markdown: vec!["herdr-no-such-binary-xyz".into()],
         diff: vec!["cat".into()],
         syntax: vec!["cat".into()],
+        timeout: Duration::from_secs(5),
     };
     let prepared = Prepared::Full { text: "# Title".into() };
     let (text, notice) = render(&renderers, &prepared, ViewMode::RenderedMarkdown, None);
@@ -75,11 +78,28 @@ fn raw_content_mode_does_not_invoke_a_renderer() {
         markdown: vec!["nope-xyz".into()],
         diff: vec!["nope-xyz".into()],
         syntax: vec!["nope-xyz".into()],
+        timeout: Duration::from_secs(5),
     };
     let prepared = Prepared::Full { text: "plain text here".into() };
     let (text, notice) = render(&renderers, &prepared, ViewMode::RawContent, None);
     assert!(flatten(&text).contains("plain text here"));
     assert!(notice.is_none(), "raw content needs no renderer → no fallback notice");
+}
+
+#[test]
+fn a_hanging_renderer_times_out_and_falls_back() {
+    let renderers = Renderers {
+        markdown: vec!["sleep".into(), "30".into()],
+        diff: vec!["cat".into()],
+        syntax: vec!["cat".into()],
+        timeout: Duration::from_millis(150),
+    };
+    let prepared = Prepared::Full { text: "# Title".into() };
+    let start = Instant::now();
+    let (text, notice) = render(&renderers, &prepared, ViewMode::RenderedMarkdown, None);
+    assert!(start.elapsed() < Duration::from_secs(3), "must not block on a wedged renderer");
+    assert!(flatten(&text).contains("# Title"), "AC-24: plain-text fallback after timeout");
+    assert!(notice.unwrap().to_lowercase().contains("timed out"), "notice reports the timeout");
 }
 
 #[test]

--- a/tests/render_delegate.rs
+++ b/tests/render_delegate.rs
@@ -98,6 +98,26 @@ fn syntax_renderer_receives_the_file_name_via_placeholder() {
 }
 
 #[test]
+fn a_malicious_file_name_cannot_inject_via_the_placeholder() {
+    // Even with a shell-wrapper renderer, a repo-controlled file name is sanitized to a
+    // safe basename, so command substitution / metacharacters cannot execute.
+    let marker = std::env::temp_dir().join(format!("HFV-PWN-{}", std::process::id()));
+    let _ = std::fs::remove_file(&marker);
+    let renderers = Renderers {
+        markdown: vec!["cat".into()],
+        diff: vec!["cat".into()],
+        syntax: vec!["sh".into(), "-c".into(), "echo {name}".into()],
+        timeout: Duration::from_secs(5),
+    };
+    let prepared = Prepared::Full { text: "code".into() };
+    let evil = format!("$(touch {}).rs", marker.display());
+    let (text, _) = render(&renderers, &prepared, ViewMode::SyntaxContent, None, Some(&evil));
+    assert!(!marker.exists(), "command substitution must not execute");
+    let out = flatten(&text);
+    assert!(!out.contains('$') && !out.contains('('), "metacharacters sanitized: {out}");
+}
+
+#[test]
 fn raw_content_mode_does_not_invoke_a_renderer() {
     let renderers = Renderers {
         markdown: vec!["nope-xyz".into()],

--- a/tests/render_delegate.rs
+++ b/tests/render_delegate.rs
@@ -29,7 +29,7 @@ fn flatten(t: &Text) -> String {
 #[test]
 fn syntax_mode_invokes_the_syntax_renderer_and_ingests_output() {
     let prepared = Prepared::Full { text: "fn main() {}".into() };
-    let (text, notice) = render(&cat(), &prepared, ViewMode::SyntaxContent, None);
+    let (text, notice) = render(&cat(), &prepared, ViewMode::SyntaxContent, None, None);
     assert!(flatten(&text).contains("fn main"), "AC-10");
     assert!(notice.is_none());
 }
@@ -37,15 +37,25 @@ fn syntax_mode_invokes_the_syntax_renderer_and_ingests_output() {
 #[test]
 fn markdown_mode_invokes_the_markdown_renderer() {
     let prepared = Prepared::Full { text: "# Title".into() };
-    let (text, _) = render(&cat(), &prepared, ViewMode::RenderedMarkdown, None);
+    let (text, _) = render(&cat(), &prepared, ViewMode::RenderedMarkdown, None, None);
     assert!(flatten(&text).contains("# Title"), "AC-8");
 }
 
 #[test]
 fn diff_mode_renders_the_supplied_raw_diff() {
     let prepared = Prepared::Full { text: "ignored".into() };
-    let (text, _) = render(&cat(), &prepared, ViewMode::Diff, Some("@@ -1 +1 @@\n+new line"));
+    let (text, _) = render(&cat(), &prepared, ViewMode::Diff, Some("@@ -1 +1 @@\n+new line"), None);
     assert!(flatten(&text).contains("+new line"), "AC-9");
+}
+
+#[test]
+fn diff_mode_renders_even_for_a_binary_or_deleted_file() {
+    // A deleted file classifies as Binary (gone from disk), but its diff comes from git,
+    // so Diff mode must still show the diff — not the binary placeholder (AC-9).
+    let (text, _) = render(&cat(), &Prepared::Binary, ViewMode::Diff, Some("@@ -1 +0 @@\n-removed"), None);
+    let s = flatten(&text);
+    assert!(s.contains("-removed"), "deletion diff is shown");
+    assert!(!s.to_lowercase().contains("binary file"), "no binary placeholder in diff mode");
 }
 
 #[test]
@@ -57,7 +67,7 @@ fn missing_renderer_falls_back_to_plain_text_with_a_notice() {
         timeout: Duration::from_secs(5),
     };
     let prepared = Prepared::Full { text: "# Title".into() };
-    let (text, notice) = render(&renderers, &prepared, ViewMode::RenderedMarkdown, None);
+    let (text, notice) = render(&renderers, &prepared, ViewMode::RenderedMarkdown, None, None);
     assert!(flatten(&text).contains("# Title"), "AC-24: plain-text fallback, not empty/crash");
     let notice = notice.expect("AC-25: a non-fatal fallback notice");
     assert!(
@@ -68,18 +78,23 @@ fn missing_renderer_falls_back_to_plain_text_with_a_notice() {
 
 #[test]
 fn binary_shows_a_placeholder_not_raw_bytes() {
-    let (text, _) = render(&cat(), &Prepared::Binary, ViewMode::SyntaxContent, None);
+    let (text, _) = render(&cat(), &Prepared::Binary, ViewMode::SyntaxContent, None, None);
     assert!(flatten(&text).to_lowercase().contains("binary"), "AC-12 placeholder");
 }
 
 #[test]
-fn diff_mode_renders_even_for_a_binary_or_deleted_file() {
-    // A deleted file classifies as Binary (gone from disk), but its diff comes from git,
-    // so Diff mode must still show the diff — not the binary placeholder (AC-9).
-    let (text, _) = render(&cat(), &Prepared::Binary, ViewMode::Diff, Some("@@ -1 +0 @@\n-removed"));
-    let s = flatten(&text);
-    assert!(s.contains("-removed"), "deletion diff is shown");
-    assert!(!s.to_lowercase().contains("binary file"), "no binary placeholder in diff mode");
+fn syntax_renderer_receives_the_file_name_via_placeholder() {
+    // A renderer echoing its args proves the {name} substitution that lets a stdin-fed
+    // highlighter (e.g. bat --file-name={name}) infer the language (AC-10).
+    let renderers = Renderers {
+        markdown: vec!["cat".into()],
+        diff: vec!["cat".into()],
+        syntax: vec!["sh".into(), "-c".into(), "echo {name}".into()],
+        timeout: Duration::from_secs(5),
+    };
+    let prepared = Prepared::Full { text: "code".into() };
+    let (text, _) = render(&renderers, &prepared, ViewMode::SyntaxContent, None, Some("main.rs"));
+    assert!(flatten(&text).contains("main.rs"), "file name passed to the syntax renderer");
 }
 
 #[test]
@@ -91,7 +106,7 @@ fn raw_content_mode_does_not_invoke_a_renderer() {
         timeout: Duration::from_secs(5),
     };
     let prepared = Prepared::Full { text: "plain text here".into() };
-    let (text, notice) = render(&renderers, &prepared, ViewMode::RawContent, None);
+    let (text, notice) = render(&renderers, &prepared, ViewMode::RawContent, None, None);
     assert!(flatten(&text).contains("plain text here"));
     assert!(notice.is_none(), "raw content needs no renderer → no fallback notice");
 }
@@ -106,7 +121,7 @@ fn a_hanging_renderer_times_out_and_falls_back() {
     };
     let prepared = Prepared::Full { text: "# Title".into() };
     let start = Instant::now();
-    let (text, notice) = render(&renderers, &prepared, ViewMode::RenderedMarkdown, None);
+    let (text, notice) = render(&renderers, &prepared, ViewMode::RenderedMarkdown, None, None);
     assert!(start.elapsed() < Duration::from_secs(3), "must not block on a wedged renderer");
     assert!(flatten(&text).contains("# Title"), "AC-24: plain-text fallback after timeout");
     assert!(notice.unwrap().to_lowercase().contains("timed out"), "notice reports the timeout");
@@ -118,6 +133,6 @@ fn truncation_notice_is_preserved_through_rendering() {
         text: "head".into(),
         notice: "truncated-preview".into(),
     };
-    let (_, notice) = render(&cat(), &prepared, ViewMode::SyntaxContent, None);
+    let (_, notice) = render(&cat(), &prepared, ViewMode::SyntaxContent, None, None);
     assert!(notice.unwrap().contains("truncated-preview"), "AC-13 notice survives");
 }

--- a/tests/render_delegate.rs
+++ b/tests/render_delegate.rs
@@ -73,6 +73,16 @@ fn binary_shows_a_placeholder_not_raw_bytes() {
 }
 
 #[test]
+fn diff_mode_renders_even_for_a_binary_or_deleted_file() {
+    // A deleted file classifies as Binary (gone from disk), but its diff comes from git,
+    // so Diff mode must still show the diff — not the binary placeholder (AC-9).
+    let (text, _) = render(&cat(), &Prepared::Binary, ViewMode::Diff, Some("@@ -1 +0 @@\n-removed"));
+    let s = flatten(&text);
+    assert!(s.contains("-removed"), "deletion diff is shown");
+    assert!(!s.to_lowercase().contains("binary file"), "no binary placeholder in diff mode");
+}
+
+#[test]
 fn raw_content_mode_does_not_invoke_a_renderer() {
     let renderers = Renderers {
         markdown: vec!["nope-xyz".into()],

--- a/tests/render_delegate.rs
+++ b/tests/render_delegate.rs
@@ -49,6 +49,15 @@ fn diff_mode_renders_the_supplied_raw_diff() {
 }
 
 #[test]
+fn an_oversized_diff_is_truncated_with_a_notice() {
+    let huge = "+line\n".repeat(6000); // > 5000 lines
+    let prepared = Prepared::Full { text: "x".into() };
+    let (text, notice) = render(&cat(), &prepared, ViewMode::Diff, Some(&huge), None);
+    assert!(notice.unwrap().to_lowercase().contains("truncated"), "AC-13: large diff bounded");
+    assert!(text.lines.len() <= 5000, "diff preview is line-bounded");
+}
+
+#[test]
 fn diff_mode_renders_even_for_a_binary_or_deleted_file() {
     // A deleted file classifies as Binary (gone from disk), but its diff comes from git,
     // so Diff mode must still show the diff — not the binary placeholder (AC-9).

--- a/tests/render_delegate.rs
+++ b/tests/render_delegate.rs
@@ -1,0 +1,93 @@
+//! T-11 — Content Renderer: delegate to external renderers + fallback + notice
+//! (AC-8, AC-9, AC-10, AC-24, AC-25), with binary placeholder (AC-12) reinforced.
+//!
+//! Renderer commands are injected: `cat` echoes stdin (a working renderer), a nonexistent
+//! program simulates a missing one — so the tests never depend on glow/delta/bat.
+
+use herdr_file_viewer::render::{render, Prepared, Renderers};
+use herdr_file_viewer::view_policy::ViewMode;
+use ratatui::text::Text;
+
+fn cat() -> Renderers {
+    Renderers {
+        markdown: vec!["cat".into()],
+        diff: vec!["cat".into()],
+        syntax: vec!["cat".into()],
+    }
+}
+
+fn flatten(t: &Text) -> String {
+    t.lines
+        .iter()
+        .flat_map(|l| l.spans.iter())
+        .map(|s| s.content.as_ref())
+        .collect()
+}
+
+#[test]
+fn syntax_mode_invokes_the_syntax_renderer_and_ingests_output() {
+    let prepared = Prepared::Full { text: "fn main() {}".into() };
+    let (text, notice) = render(&cat(), &prepared, ViewMode::SyntaxContent, None);
+    assert!(flatten(&text).contains("fn main"), "AC-10");
+    assert!(notice.is_none());
+}
+
+#[test]
+fn markdown_mode_invokes_the_markdown_renderer() {
+    let prepared = Prepared::Full { text: "# Title".into() };
+    let (text, _) = render(&cat(), &prepared, ViewMode::RenderedMarkdown, None);
+    assert!(flatten(&text).contains("# Title"), "AC-8");
+}
+
+#[test]
+fn diff_mode_renders_the_supplied_raw_diff() {
+    let prepared = Prepared::Full { text: "ignored".into() };
+    let (text, _) = render(&cat(), &prepared, ViewMode::Diff, Some("@@ -1 +1 @@\n+new line"));
+    assert!(flatten(&text).contains("+new line"), "AC-9");
+}
+
+#[test]
+fn missing_renderer_falls_back_to_plain_text_with_a_notice() {
+    let renderers = Renderers {
+        markdown: vec!["herdr-no-such-binary-xyz".into()],
+        diff: vec!["cat".into()],
+        syntax: vec!["cat".into()],
+    };
+    let prepared = Prepared::Full { text: "# Title".into() };
+    let (text, notice) = render(&renderers, &prepared, ViewMode::RenderedMarkdown, None);
+    assert!(flatten(&text).contains("# Title"), "AC-24: plain-text fallback, not empty/crash");
+    let notice = notice.expect("AC-25: a non-fatal fallback notice");
+    assert!(
+        notice.to_lowercase().contains("markdown") || notice.to_lowercase().contains("unavailable"),
+        "AC-25: notice names the missing capability: {notice}"
+    );
+}
+
+#[test]
+fn binary_shows_a_placeholder_not_raw_bytes() {
+    let (text, _) = render(&cat(), &Prepared::Binary, ViewMode::SyntaxContent, None);
+    assert!(flatten(&text).to_lowercase().contains("binary"), "AC-12 placeholder");
+}
+
+#[test]
+fn raw_content_mode_does_not_invoke_a_renderer() {
+    let renderers = Renderers {
+        markdown: vec!["nope-xyz".into()],
+        diff: vec!["nope-xyz".into()],
+        syntax: vec!["nope-xyz".into()],
+    };
+    let prepared = Prepared::Full { text: "plain text here".into() };
+    let (text, notice) = render(&renderers, &prepared, ViewMode::RawContent, None);
+    assert!(flatten(&text).contains("plain text here"));
+    assert!(notice.is_none(), "raw content needs no renderer → no fallback notice");
+}
+
+#[test]
+fn truncation_notice_is_preserved_through_rendering() {
+    let prepared = Prepared::Truncated {
+        text: "head".into(),
+        notice: "truncated-preview".into(),
+    };
+    let (_, notice) = render(&cat(), &prepared, ViewMode::SyntaxContent, None);
+    assert!(notice.unwrap().contains("truncated-preview"), "AC-13 notice survives");
+}

--- a/tests/render_escape.rs
+++ b/tests/render_escape.rs
@@ -26,6 +26,21 @@ fn cursor_and_screen_control_sequences_are_neutralized() {
 }
 
 #[test]
+fn c0_control_bytes_are_stripped() {
+    // BEL, backspace, carriage-return, form-feed, vertical-tab can ring the bell or
+    // overwrite/spoof a line; only newline and tab survive (AC-27).
+    let hostile = "a\x07b\x08c\rd\x0ce\x0bf\ttab\nnext";
+    let text = to_text(hostile);
+    let rendered = flatten(&text);
+    for ctl in ['\u{07}', '\u{08}', '\r', '\u{0c}', '\u{0b}'] {
+        assert!(!rendered.contains(ctl), "control {:#x} must be stripped", ctl as u32);
+    }
+    assert!(rendered.contains('\t'), "tab is kept");
+    assert_eq!(text.lines.len(), 2, "newline is kept as a line break, not stripped");
+    assert!(rendered.contains("tab") && rendered.contains("next"));
+}
+
+#[test]
 fn sgr_styling_is_mapped_to_style_not_left_as_raw_codes() {
     let styled = "\x1b[31mRED\x1b[0m"; // red foreground
     let text = to_text(styled);

--- a/tests/render_escape.rs
+++ b/tests/render_escape.rs
@@ -1,0 +1,42 @@
+//! T-10 — Content Renderer: escape-sequence neutralization (AC-27).
+
+use herdr_file_viewer::render::to_text;
+use ratatui::text::Text;
+
+fn flatten(text: &Text) -> String {
+    text.lines
+        .iter()
+        .flat_map(|line| line.spans.iter())
+        .map(|span| span.content.as_ref())
+        .collect()
+}
+
+#[test]
+fn cursor_and_screen_control_sequences_are_neutralized() {
+    // \x1b[2J clears the screen; \x1b[10;10H moves the cursor.
+    let hostile = "before\x1b[2Jmid\x1b[10;10Hafter";
+    let text = to_text(hostile);
+    let rendered = flatten(&text);
+
+    assert!(!rendered.contains('\u{1b}'), "AC-27: no ESC byte survives ingestion");
+    assert!(!rendered.contains("[2J"), "AC-27: screen-clear not reproduced");
+    assert!(!rendered.contains("[10;10H"), "AC-27: cursor-move not reproduced");
+    // The actual textual content is preserved.
+    assert!(rendered.contains("before") && rendered.contains("mid") && rendered.contains("after"));
+}
+
+#[test]
+fn sgr_styling_is_mapped_to_style_not_left_as_raw_codes() {
+    let styled = "\x1b[31mRED\x1b[0m"; // red foreground
+    let text = to_text(styled);
+    let rendered = flatten(&text);
+
+    assert!(!rendered.contains('\u{1b}'), "SGR codes are consumed, not emitted as bytes");
+    assert!(rendered.contains("RED"));
+    let has_color = text
+        .lines
+        .iter()
+        .flat_map(|l| l.spans.iter())
+        .any(|s| s.style.fg.is_some());
+    assert!(has_color, "SGR color is applied as a ratatui style");
+}

--- a/tests/render_perf.rs
+++ b/tests/render_perf.rs
@@ -1,0 +1,34 @@
+//! T-12 — Content Renderer perf: the in-process portion (classify + ANSI ingest) of a
+//! 1 MB file stays within the AC-23 300 ms responsiveness bound. The external renderer
+//! runs off-thread (T-19); this guards the part that runs on the UI path.
+
+mod common;
+
+use common::TempDir;
+use herdr_file_viewer::render::{classify, to_text, Prepared};
+use std::fs;
+use std::time::Instant;
+
+#[test]
+fn classify_and_ingest_one_megabyte_within_300ms() {
+    let dir = TempDir::new();
+    // ~1.1 MB of realistic text across many lines.
+    let line = format!("{}\n", "x".repeat(200));
+    let content = line.repeat(5400);
+    let path = dir.path().join("big.txt");
+    fs::write(&path, &content).unwrap();
+
+    let start = Instant::now();
+    let prepared = classify(&path);
+    let text = match &prepared {
+        Prepared::Full { text } | Prepared::Truncated { text, .. } => text.clone(),
+        Prepared::Binary => String::new(),
+    };
+    let _ingested = to_text(&text);
+    let elapsed = start.elapsed();
+
+    assert!(
+        elapsed.as_millis() < 300,
+        "AC-23: in-process classify+ingest must be < 300ms, took {elapsed:?}"
+    );
+}

--- a/tests/render_perf.rs
+++ b/tests/render_perf.rs
@@ -19,7 +19,7 @@ fn classify_and_ingest_one_megabyte_within_300ms() {
     fs::write(&path, &content).unwrap();
 
     let start = Instant::now();
-    let prepared = classify(&path);
+    let prepared = classify(dir.path(), &path);
     let text = match &prepared {
         Prepared::Full { text } | Prepared::Truncated { text, .. } => text.clone(),
         Prepared::Binary => String::new(),

--- a/tests/tree.rs
+++ b/tests/tree.rs
@@ -1,0 +1,91 @@
+//! T-6 — Tree Model: gitignore-aware recursive enumeration + root boundary
+//! (AC-3, AC-4, AC-N5, AC-N1).
+
+mod common;
+
+use common::TempDir;
+use herdr_file_viewer::tree::TreeModel;
+use std::fs;
+
+fn names(model: &TreeModel) -> Vec<String> {
+    model
+        .visible_nodes()
+        .iter()
+        .map(|n| n.path.file_name().unwrap().to_string_lossy().into_owned())
+        .collect()
+}
+
+#[test]
+fn enumerates_immediate_children_and_expands_recursively() {
+    let dir = TempDir::new();
+    fs::create_dir_all(dir.path().join("src/inner")).unwrap();
+    fs::write(dir.path().join("a.txt"), "a").unwrap();
+    fs::write(dir.path().join("src/b.rs"), "b").unwrap();
+    fs::write(dir.path().join("src/inner/c.rs"), "c").unwrap();
+
+    let mut model = TreeModel::new(dir.path());
+    let top = names(&model);
+    assert!(top.contains(&"src".to_string()));
+    assert!(top.contains(&"a.txt".to_string()));
+    assert!(!top.contains(&"b.rs".to_string()), "nested files hidden until expand");
+
+    model.expand(&dir.path().join("src")); // AC-3
+    let after = names(&model);
+    assert!(after.contains(&"b.rs".to_string()));
+    assert!(!after.contains(&"c.rs".to_string()), "deeper level still collapsed");
+
+    model.expand(&dir.path().join("src/inner"));
+    assert!(names(&model).contains(&"c.rs".to_string()));
+}
+
+#[test]
+fn gitignored_entries_are_absent_by_default() {
+    let dir = TempDir::new();
+    fs::write(dir.path().join(".gitignore"), "ignored.txt\ntarget/\n").unwrap();
+    fs::write(dir.path().join("kept.txt"), "k").unwrap();
+    fs::write(dir.path().join("ignored.txt"), "i").unwrap();
+    fs::create_dir_all(dir.path().join("target")).unwrap();
+    fs::write(dir.path().join("target/x.o"), "o").unwrap();
+
+    let n = names(&TreeModel::new(dir.path()));
+    assert!(n.contains(&"kept.txt".to_string()));
+    assert!(!n.contains(&"ignored.txt".to_string()), "AC-4: gitignored file absent");
+    assert!(!n.contains(&"target".to_string()), "AC-4: gitignored dir absent");
+}
+
+#[test]
+fn never_lists_paths_outside_the_root() {
+    // AC-N5: bounded by the root; no node escapes it.
+    let dir = TempDir::new();
+    fs::create_dir_all(dir.path().join("sub")).unwrap();
+    fs::write(dir.path().join("sub/f.txt"), "f").unwrap();
+    let root = dir.path().join("sub");
+    let mut model = TreeModel::new(&root);
+    model.expand(&root);
+    assert!(
+        model.visible_nodes().iter().all(|n| n.path.starts_with(&root)),
+        "a node escaped the root"
+    );
+}
+
+#[test]
+fn enumeration_does_not_mutate_the_filesystem() {
+    // AC-N1: read-only.
+    let dir = TempDir::new();
+    fs::write(dir.path().join("f.txt"), "x").unwrap();
+    let before = fs::read_dir(dir.path()).unwrap().count();
+    let _ = TreeModel::new(dir.path()).visible_nodes();
+    assert_eq!(before, fs::read_dir(dir.path()).unwrap().count());
+    assert_eq!(fs::read_to_string(dir.path().join("f.txt")).unwrap(), "x");
+}
+
+#[test]
+fn dotfiles_are_browsable_but_dot_git_is_hidden() {
+    let dir = TempDir::new();
+    fs::write(dir.path().join(".env"), "x").unwrap();
+    fs::create_dir_all(dir.path().join(".git")).unwrap();
+    fs::write(dir.path().join(".git/HEAD"), "ref").unwrap();
+    let n = names(&TreeModel::new(dir.path()));
+    assert!(n.contains(&".env".to_string()), "dotfiles are browsable");
+    assert!(!n.contains(&".git".to_string()), ".git is hidden");
+}

--- a/tests/tree_filters.rs
+++ b/tests/tree_filters.rs
@@ -82,6 +82,28 @@ fn changed_only_shows_deleted_files_with_their_marker() {
 }
 
 #[test]
+fn changed_only_shows_files_under_a_deleted_directory() {
+    // A whole directory was deleted: none of its files (nor the dir) are on disk, but the
+    // changed-set still references them — they must be reviewable.
+    let dir = TempDir::new();
+    let mut changed = BTreeMap::new();
+    changed.insert(PathBuf::from("old/a.rs"), Status::Deleted);
+    changed.insert(PathBuf::from("old/sub/b.rs"), Status::Deleted);
+
+    let mut model = TreeModel::new(dir.path());
+    model.set_changed_only(true, &changed);
+
+    let names: Vec<String> = model
+        .visible_nodes()
+        .iter()
+        .map(|n| n.path.file_name().unwrap().to_string_lossy().into_owned())
+        .collect();
+    assert!(names.contains(&"old".to_string()), "the deleted directory is synthesized");
+    assert!(names.contains(&"a.rs".to_string()));
+    assert!(names.contains(&"b.rs".to_string()), "files under a deleted dir are shown");
+}
+
+#[test]
 fn status_markers_attach_to_nodes() {
     let dir = TempDir::new();
     fs::write(dir.path().join("m.txt"), "m").unwrap();

--- a/tests/tree_filters.rs
+++ b/tests/tree_filters.rs
@@ -104,6 +104,30 @@ fn changed_only_shows_files_under_a_deleted_directory() {
 }
 
 #[test]
+fn cursor_moves_and_stays_in_bounds_when_filters_shrink_the_list() {
+    let dir = TempDir::new();
+    fs::write(dir.path().join("a.txt"), "a").unwrap();
+    fs::write(dir.path().join("b.txt"), "b").unwrap();
+    fs::write(dir.path().join("c.txt"), "c").unwrap();
+    let mut model = TreeModel::new(dir.path());
+
+    model.move_cursor(2); // to the 3rd node
+    assert_eq!(model.cursor(), 2);
+    model.move_cursor(100); // clamped to last
+    assert_eq!(model.cursor(), 2);
+    model.move_cursor(-100); // clamped to first
+    assert_eq!(model.cursor(), 0);
+
+    model.move_cursor(2);
+    // Filter down to a single changed file → cursor must clamp into range.
+    let mut changed = BTreeMap::new();
+    changed.insert(PathBuf::from("a.txt"), Status::Modified);
+    model.set_changed_only(true, &changed);
+    assert!(model.cursor() < model.visible_nodes().len(), "cursor clamped after filtering");
+    assert!(model.selected().is_some());
+}
+
+#[test]
 fn status_markers_attach_to_nodes() {
     let dir = TempDir::new();
     fs::write(dir.path().join("m.txt"), "m").unwrap();

--- a/tests/tree_filters.rs
+++ b/tests/tree_filters.rs
@@ -58,6 +58,30 @@ fn changed_only_restricts_then_restores_full_tree() {
 }
 
 #[test]
+fn changed_only_shows_deleted_files_with_their_marker() {
+    // A deleted file is no longer on disk; it must still appear in changed-only mode so
+    // the deletion can be reviewed (AC-6) with a deleted marker (AC-7).
+    let dir = TempDir::new();
+    fs::create_dir_all(dir.path().join("src")).unwrap();
+    fs::write(dir.path().join("src/present.rs"), "x").unwrap();
+    // src/gone.rs is intentionally NOT created.
+    let mut changed = BTreeMap::new();
+    changed.insert(PathBuf::from("src/gone.rs"), Status::Deleted);
+    changed.insert(PathBuf::from("src/present.rs"), Status::Modified);
+
+    let mut model = TreeModel::new(dir.path());
+    model.set_status(&changed);
+    model.set_changed_only(true, &changed);
+
+    let gone = model
+        .visible_nodes()
+        .into_iter()
+        .find(|n| n.path.ends_with("gone.rs"));
+    let gone = gone.expect("AC-6: deleted file appears in changed-only mode");
+    assert_eq!(gone.status, Some(Status::Deleted)); // AC-7
+}
+
+#[test]
 fn status_markers_attach_to_nodes() {
     let dir = TempDir::new();
     fs::write(dir.path().join("m.txt"), "m").unwrap();

--- a/tests/tree_filters.rs
+++ b/tests/tree_filters.rs
@@ -1,0 +1,75 @@
+//! T-7 — Tree filters: show-ignored toggle (AC-5) + changed-only filter (AC-6),
+//! plus status markers on nodes (AC-7, tree side).
+
+mod common;
+
+use common::TempDir;
+use herdr_file_viewer::git::Status;
+use herdr_file_viewer::tree::TreeModel;
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::PathBuf;
+
+fn names(model: &TreeModel) -> Vec<String> {
+    model
+        .visible_nodes()
+        .iter()
+        .map(|n| n.path.file_name().unwrap().to_string_lossy().into_owned())
+        .collect()
+}
+
+#[test]
+fn show_ignored_toggle_reveals_then_hides_ignored_files() {
+    let dir = TempDir::new();
+    fs::write(dir.path().join(".gitignore"), "secret.log\n").unwrap();
+    fs::write(dir.path().join("keep.txt"), "k").unwrap();
+    fs::write(dir.path().join("secret.log"), "s").unwrap();
+
+    let mut model = TreeModel::new(dir.path());
+    assert!(!names(&model).contains(&"secret.log".to_string()));
+    model.set_show_ignored(true);
+    assert!(names(&model).contains(&"secret.log".to_string()), "AC-5: revealed");
+    model.set_show_ignored(false);
+    assert!(!names(&model).contains(&"secret.log".to_string()), "AC-5: restored");
+}
+
+#[test]
+fn changed_only_restricts_then_restores_full_tree() {
+    let dir = TempDir::new();
+    fs::create_dir_all(dir.path().join("src")).unwrap();
+    fs::write(dir.path().join("README.md"), "r").unwrap();
+    fs::write(dir.path().join("src/changed.rs"), "c").unwrap();
+    fs::write(dir.path().join("src/unchanged.rs"), "u").unwrap();
+    let mut changed = BTreeMap::new();
+    changed.insert(PathBuf::from("src/changed.rs"), Status::Modified);
+
+    let mut model = TreeModel::new(dir.path());
+    model.set_changed_only(true, &changed);
+    let n = names(&model);
+    assert!(n.contains(&"src".to_string()), "ancestor dir of a change is shown");
+    assert!(n.contains(&"changed.rs".to_string()), "AC-6: changed file shown");
+    assert!(!n.contains(&"unchanged.rs".to_string()), "AC-6: unchanged sibling hidden");
+    assert!(!n.contains(&"README.md".to_string()), "AC-6: unchanged top-level file hidden");
+
+    model.set_changed_only(false, &changed);
+    let restored = names(&model);
+    assert!(restored.contains(&"README.md".to_string()), "AC-6: full tree restored");
+    assert!(restored.contains(&"src".to_string()));
+}
+
+#[test]
+fn status_markers_attach_to_nodes() {
+    let dir = TempDir::new();
+    fs::write(dir.path().join("m.txt"), "m").unwrap();
+    let mut map = BTreeMap::new();
+    map.insert(PathBuf::from("m.txt"), Status::Modified);
+
+    let mut model = TreeModel::new(dir.path());
+    model.set_status(&map);
+    let node = model
+        .visible_nodes()
+        .into_iter()
+        .find(|n| n.path.ends_with("m.txt"))
+        .unwrap();
+    assert_eq!(node.status, Some(Status::Modified)); // AC-7 (tree side)
+}

--- a/tests/tree_perf.rs
+++ b/tests/tree_perf.rs
@@ -1,0 +1,33 @@
+//! T-8 — Tree Model perf: launch is interactive within 1s on a 10k-file repo (AC-22).
+//! A guard that lazy enumeration (T-6) is preserved — eager enumeration would blow this.
+
+mod common;
+
+use common::TempDir;
+use herdr_file_viewer::tree::TreeModel;
+use std::fs;
+use std::time::Instant;
+
+#[test]
+fn tree_is_interactive_within_one_second_at_10k_files() {
+    let dir = TempDir::new();
+    // 100 directories × 100 files = 10,000 files.
+    for d in 0..100 {
+        let sub = dir.path().join(format!("dir{d:03}"));
+        fs::create_dir_all(&sub).unwrap();
+        for f in 0..100 {
+            fs::write(sub.join(format!("file{f:03}.txt")), "x").unwrap();
+        }
+    }
+
+    let start = Instant::now();
+    let model = TreeModel::new(dir.path());
+    let nodes = model.visible_nodes();
+    let elapsed = start.elapsed();
+
+    assert!(nodes.len() >= 100, "top-level directories should be listed");
+    assert!(
+        elapsed.as_secs_f64() < 1.0,
+        "AC-22: tree must be interactive within 1s, took {elapsed:?}"
+    );
+}


### PR DESCRIPTION
## What

Second layer-based PR executing `specs/file-viewer/plan.md`, tasks **T-6…T-12**, each built test-first (red-green-refactor), repo green between every task.

### Tree Model
- **T-6** — gitignore-aware **lazy** enumeration via the `ignore` crate (immediate children per directory, depth-first on expand); hides gitignored entries (AC-4) and `.git`, shows dotfiles, dirs before files; bounded by root, no node escapes it (AC-N5); read-only (AC-N1); recursive expand (AC-3).
- **T-7** — `set_show_ignored` (AC-5), `set_changed_only` (AC-6 — keep changed files + the dirs leading to them, auto-expanded; restore on toggle), `set_status` for per-node markers (AC-7, tree side).
- **T-8** — perf guard: launch interactive in <1s on a 10k-file tree (AC-22), via lazy enumeration.

### Content Renderer
- **T-9** — `classify`: **bounded** read (≤1 MB, never slurps a hostile file, AC-N1); NUL → `Binary` placeholder, no raw bytes (AC-12); ≥1 MB or ≥5000 lines → bounded preview + notice (AC-13).
- **T-10** — `to_text`: strips cursor/screen-control escapes (keeps SGR), ingests via `ansi-to-tui` → ratatui `Text` carries no terminal-control ops, so content can't move the cursor or clear the screen regardless of source (AC-27).
- **T-11** — `render`: delegates to injected markdown/diff/syntax commands (glow/delta/bat), feeding **untrusted content on stdin** (no injection; written on a thread to avoid pipe deadlock); output re-neutralized via `to_text`. Missing/failed renderer → plain-text fallback (AC-24) + capability-naming notice (AC-25). (AC-8/9/10)
- **T-12** — perf guard: in-process classify+ingest of 1 MB <300ms (AC-23 in-process bound; external render is off-thread in T-19).

## Tests
All green (~36 new assertions across `tree`, `tree_filters`, `tree_perf`, inline `render`, `render_escape`, `render_delegate`, `render_perf`). Release binary builds. Renderer/temp-dir seams keep every test hermetic (no glow/delta/bat dependency).

## Security notes (untrusted file bytes)
Content is the primary trust boundary: bounded reads cap memory, binary files never emit raw bytes, escape sequences are neutralized, and external renderers receive content only via stdin. Consistent with PR1's untrusted-repo hardening.