### PR TITLE
PR4: Session Controller, off-thread rendering, main wiring (T-18…T-20)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@
 
 # Local Claude Code tooling (skills, local settings) — not part of the plugin
 .claude/
+
+# Review-gate run logs / dismissal records — local audit trail, not part of the plugin
+.review-gate/

--- a/src/app.rs
+++ b/src/app.rs
@@ -26,6 +26,7 @@ use std::ffi::{OsStr, OsString};
 use std::io;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::Arc;
 use std::time::Duration;
 
 /// How long the input poll blocks each tick before draining finished off-thread renders, so
@@ -41,7 +42,7 @@ pub fn run() -> io::Result<()> {
     let resolved = root::resolve(&ctx);
     let baseline = git::default_baseline(&resolved);
 
-    let git: Box<dyn GitService> = Box::new(LiveGit {
+    let git: Arc<dyn GitService> = Arc::new(LiveGit {
         // In a non-repo there is no repo_root; git is never queried then, but a path is still
         // required, so fall back to the tree root.
         repo_root: resolved.repo_root.clone().unwrap_or_else(|| resolved.root.clone()),
@@ -65,14 +66,20 @@ pub fn run() -> io::Result<()> {
     outcome
 }
 
-/// Draw, read one input (or time out), drain renders; repeat until the Close intent.
+/// Draw (only when something changed), read one input (or time out), drain renders; repeat
+/// until the Close intent. Drawing only when `dirty` avoids re-walking the filesystem (the
+/// tree enumeration in `view_state`) on every idle tick.
 fn event_loop(terminal: &mut DefaultTerminal, controller: &mut Controller) -> io::Result<()> {
+    let mut dirty = true; // paint the first frame
     loop {
-        terminal.draw(|frame| {
-            controller.set_width(frame.area().width);
-            let view: ViewState = controller.view_state();
-            presenter::draw(frame, &view);
-        })?;
+        if dirty {
+            terminal.draw(|frame| {
+                controller.set_width(frame.area().width);
+                let view: ViewState = controller.view_state();
+                presenter::draw(frame, &view);
+            })?;
+            dirty = false;
+        }
 
         if event::poll(TICK)?
             && let Event::Key(key) = event::read()?
@@ -82,13 +89,17 @@ fn event_loop(terminal: &mut DefaultTerminal, controller: &mut Controller) -> io
             let fx = controller.handle(intent);
             if fx.clear {
                 terminal.clear()?; // an editor took the screen — force a full repaint
+                dirty = true;
             }
             if fx.quit {
                 return Ok(());
             }
+            dirty |= fx.redraw;
         }
-        // Surface any content finished by the render worker on the next draw (AC-23).
-        controller.poll();
+        // A render finished by the worker becomes visible on the next draw (AC-23).
+        if let Some(fx) = controller.poll() {
+            dirty |= fx.redraw;
+        }
     }
 }
 
@@ -142,12 +153,22 @@ struct LiveEditor {
 impl EditorHandoff for LiveEditor {
     fn open(&mut self, file: &Path) -> io::Result<bool> {
         let Some(editor) = self.editor.clone() else {
+            // No terminal change yet, so nothing to restore.
             return Err(io::Error::other("no editor configured (set $EDITOR)"));
         };
-        suspend_tui()?;
-        let launched = EditorLauncher::new(editor).open(file, Target::Editor, &mut ProcessSpawner);
+        // Once we touch the terminal we must always try to restore it, even if suspending or
+        // the editor itself fails — otherwise the viewer would keep running with raw mode off
+        // or outside the alternate screen.
+        let suspended = suspend_tui();
+        let launched = if suspended.is_ok() {
+            EditorLauncher::new(editor).open(file, Target::Editor, &mut ProcessSpawner)
+        } else {
+            // Don't run the editor over a half-suspended terminal.
+            Ok(())
+        };
         let resumed = resume_tui();
-        // Report the editor's own failure first, then any failure to restore the terminal.
+        // Report the first failure in order: suspend, then the editor, then restore.
+        suspended?;
         launched?;
         resumed?;
         Ok(true) // the editor drew over the screen → the run loop forces a full repaint

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,0 +1,210 @@
+//! App wiring — assemble the real components and run the terminal event loop (T-20).
+//!
+//! [`run`] is the binary's body: read the herdr launch context, resolve the root and
+//! git-presence, build the live Git Service / Content Renderer / Editor Launcher behind the
+//! controller's traits, then drive a draw → input → poll loop over a ratatui terminal until
+//! the Close intent (AC-20). The terminal is restored on every exit path — including a panic,
+//! via the hook `ratatui::try_init` installs.
+
+use crate::controller::{
+    Components, ContentProvider, Controller, EditorHandoff, GitService, RenderResult,
+};
+use crate::editor::{EditorLauncher, Spawner, Target};
+use crate::git::{self, Baseline, Status};
+use crate::presenter::{self, ViewState};
+use crate::render::{self, Prepared, Renderers};
+use crate::view_policy::ViewMode;
+use crate::{host, input, root};
+use crossterm::event::{self, Event, KeyEventKind};
+use crossterm::execute;
+use crossterm::terminal::{
+    EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
+};
+use ratatui::DefaultTerminal;
+use std::collections::BTreeMap;
+use std::ffi::{OsStr, OsString};
+use std::io;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::Duration;
+
+/// How long the input poll blocks each tick before draining finished off-thread renders, so
+/// late content appears promptly without the loop busy-spinning.
+const TICK: Duration = Duration::from_millis(50);
+
+/// Per-render wall-clock budget for an external renderer before the plain-text fallback.
+const RENDER_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Wire the components and run the viewer until the user closes it.
+pub fn run() -> io::Result<()> {
+    let ctx = host::from_env();
+    let resolved = root::resolve(&ctx);
+    let baseline = git::default_baseline(&resolved);
+
+    let git: Box<dyn GitService> = Box::new(LiveGit {
+        // In a non-repo there is no repo_root; git is never queried then, but a path is still
+        // required, so fall back to the tree root.
+        repo_root: resolved.repo_root.clone().unwrap_or_else(|| resolved.root.clone()),
+        base_hint: resolved.base_branch.clone(),
+    });
+    let content: Box<dyn ContentProvider> =
+        Box::new(LiveContent { root: resolved.root.clone(), renderers: default_renderers() });
+    let editor: Box<dyn EditorHandoff> =
+        Box::new(LiveEditor { editor: std::env::var_os("EDITOR") });
+
+    let mut controller = Controller::new(
+        resolved.root.clone(),
+        resolved.is_git_repo,
+        baseline,
+        Components { git, content, editor },
+    );
+
+    let mut terminal = ratatui::try_init()?;
+    let outcome = event_loop(&mut terminal, &mut controller);
+    ratatui::try_restore()?;
+    outcome
+}
+
+/// Draw, read one input (or time out), drain renders; repeat until the Close intent.
+fn event_loop(terminal: &mut DefaultTerminal, controller: &mut Controller) -> io::Result<()> {
+    loop {
+        terminal.draw(|frame| {
+            controller.set_width(frame.area().width);
+            let view: ViewState = controller.view_state();
+            presenter::draw(frame, &view);
+        })?;
+
+        if event::poll(TICK)?
+            && let Event::Key(key) = event::read()?
+            && key.kind == KeyEventKind::Press
+            && let Some(intent) = input::map_key(key)
+        {
+            let fx = controller.handle(intent);
+            if fx.clear {
+                terminal.clear()?; // an editor took the screen — force a full repaint
+            }
+            if fx.quit {
+                return Ok(());
+            }
+        }
+        // Surface any content finished by the render worker on the next draw (AC-23).
+        controller.poll();
+    }
+}
+
+/// The live Git Service: read-only queries against the resolved repository (AC-7/9/16).
+struct LiveGit {
+    repo_root: PathBuf,
+    base_hint: Option<String>,
+}
+
+impl GitService for LiveGit {
+    fn status(&self) -> BTreeMap<PathBuf, Status> {
+        git::status(&self.repo_root)
+    }
+    fn changed_set(&self, baseline: Baseline) -> BTreeMap<PathBuf, Status> {
+        git::changed_set(&self.repo_root, baseline, self.base_hint.as_deref())
+    }
+    fn diff(&self, rel_path: &Path, baseline: Baseline) -> String {
+        git::diff(&self.repo_root, rel_path, baseline, self.base_hint.as_deref())
+    }
+}
+
+/// The live Content Renderer: classify + delegate to the external renderers, with guards.
+struct LiveContent {
+    root: PathBuf,
+    renderers: Renderers,
+}
+
+impl ContentProvider for LiveContent {
+    fn render(&self, path: &Path, mode: ViewMode, raw_diff: Option<&str>) -> RenderResult {
+        // Diff mode renders from git's diff text, not the file bytes — so a deleted or binary
+        // file still shows its diff (AC-9); other modes classify first (binary / size guards,
+        // AC-12/13). `Prepared::Binary` is inert for the diff path inside `render`.
+        let prepared = if mode == ViewMode::Diff {
+            Prepared::Binary
+        } else {
+            render::classify(&self.root, path)
+        };
+        let name = path.file_name().and_then(OsStr::to_str);
+        let (content, notice) = render::render(&self.renderers, &prepared, mode, raw_diff, name);
+        RenderResult { content, notices: notice.into_iter().collect() }
+    }
+}
+
+/// The live Editor Launcher: spawn `$EDITOR <file>` as a blocking hand-off, suspending and
+/// restoring the TUI around it. A missing `$EDITOR` is a non-fatal error the controller
+/// surfaces as a notice.
+struct LiveEditor {
+    editor: Option<OsString>,
+}
+
+impl EditorHandoff for LiveEditor {
+    fn open(&mut self, file: &Path) -> io::Result<bool> {
+        let Some(editor) = self.editor.clone() else {
+            return Err(io::Error::other("no editor configured (set $EDITOR)"));
+        };
+        suspend_tui()?;
+        let launched = EditorLauncher::new(editor).open(file, Target::Editor, &mut ProcessSpawner);
+        let resumed = resume_tui();
+        // Report the editor's own failure first, then any failure to restore the terminal.
+        launched?;
+        resumed?;
+        Ok(true) // the editor drew over the screen → the run loop forces a full repaint
+    }
+}
+
+/// Runs the editor command and waits for it (the hand-off is synchronous, as for a terminal
+/// editor like vim). Only the local-spawn path is used by the keyboard intent; the new-pane
+/// hand-off lives in the Host Adapter (T-17) and is not reached here.
+struct ProcessSpawner;
+
+impl Spawner for ProcessSpawner {
+    fn spawn(&mut self, argv: &[OsString]) -> io::Result<()> {
+        let (prog, args) =
+            argv.split_first().ok_or_else(|| io::Error::other("empty editor command"))?;
+        let status = Command::new(prog).args(args).status()?;
+        if status.success() {
+            Ok(())
+        } else {
+            Err(io::Error::other(format!("editor exited with {status}")))
+        }
+    }
+    fn open_pane(&mut self, _editor: &OsStr, _file: &Path) -> io::Result<()> {
+        // v1's keyboard OpenInEditor uses the configured-editor path (Target::Editor); the
+        // new-pane sequence is implemented and tested in the Host Adapter (host.rs).
+        Err(io::Error::other("new-pane hand-off is not on the v1 keyboard path"))
+    }
+}
+
+/// Leave raw mode + the alternate screen so an external editor owns a clean terminal.
+fn suspend_tui() -> io::Result<()> {
+    disable_raw_mode()?;
+    execute!(io::stdout(), LeaveAlternateScreen)
+}
+
+/// Re-enter raw mode + the alternate screen after the editor returns.
+fn resume_tui() -> io::Result<()> {
+    enable_raw_mode()?;
+    execute!(io::stdout(), EnterAlternateScreen)
+}
+
+/// The default external renderers (the documented runtime deps). Each reads the untrusted
+/// content on **stdin** (never as an argument); a missing one degrades to plain text +
+/// notice (AC-24/25). `{name}` is substituted with the sanitized file name for language
+/// detection.
+fn default_renderers() -> Renderers {
+    Renderers {
+        markdown: vec!["glow".into(), "-".into()],
+        diff: vec!["delta".into()],
+        syntax: vec![
+            "bat".into(),
+            "--color=always".into(),
+            "--style=plain".into(),
+            "--paging=never".into(),
+            "--file-name={name}".into(),
+            "-".into(),
+        ],
+        timeout: RENDER_TIMEOUT,
+    }
+}

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -1,0 +1,370 @@
+//! Session Controller — orchestrate intents into coordinated state changes.
+//!
+//! Holds the ephemeral session state (root, git-presence, baseline, filter flags, per-file
+//! view overrides, cursor/expansion via the Tree Model, focus, observed width) and turns
+//! each [`Intent`] into state mutations plus a set of [`Effects`] the run loop acts on
+//! (redraw, quit, force-clear). The side-effecting components — Git Service, Content
+//! Renderer, Editor Launcher — are reached through injected traits so the controller is
+//! unit-testable with stubs; the Tree Model is the one read-only component it drives
+//! directly. No intent edits a file (AC-N3); git-only intents are inert when not in a repo
+//! (AC-26); a component failure becomes a non-fatal notice, never a crash.
+
+use crate::git::{Baseline, Status};
+use crate::intent::Intent;
+use crate::presenter::Focus;
+use crate::tree::{NodeKind, TreeModel};
+use crate::view_policy::{FileDescriptor, ViewMode, applicable_modes, default_mode};
+use ratatui::text::Text;
+use std::collections::{BTreeMap, HashMap};
+use std::io;
+use std::path::{Path, PathBuf};
+
+/// Read-only git queries the controller coordinates. Behind a trait so tests stub it and
+/// the run loop injects an implementation bound to the real repository.
+pub trait GitService {
+    /// Working-tree status per repo-root-relative path (drives tree markers, AC-7).
+    fn status(&self) -> BTreeMap<PathBuf, Status>;
+    /// The set of files changed against `baseline` (drives the changed-only filter, AC-6,
+    /// and is recomputed when the baseline toggles, AC-16).
+    fn changed_set(&self, baseline: Baseline) -> BTreeMap<PathBuf, Status>;
+    /// Raw unified diff text for one repo-root-relative path against `baseline` (AC-9).
+    fn diff(&self, rel_path: &Path, baseline: Baseline) -> String;
+}
+
+/// The rendered content pane for one file: ingested text plus any non-fatal notices
+/// (truncation AC-13, renderer fallback AC-25).
+pub struct RenderResult {
+    pub content: Text<'static>,
+    pub notices: Vec<String>,
+}
+
+/// Produce the content-pane text for `(file, mode)`. `Send` so a later task can run it on a
+/// worker thread (AC-23). Behind a trait so tests stub it instead of spawning glow/delta/bat.
+pub trait ContentProvider: Send {
+    fn render(&self, path: &Path, mode: ViewMode, raw_diff: Option<&str>) -> RenderResult;
+}
+
+/// Hand the selected file to an external editor (AC-19). Returns `Ok(true)` when the
+/// hand-off took over the terminal (the run loop must force a full repaint afterwards),
+/// `Ok(false)` for an off-screen hand-off (e.g. a new herdr pane). Behind a trait so the
+/// controller never edits or even spawns directly — and tests launch nothing.
+pub trait EditorHandoff {
+    fn open(&mut self, file: &Path) -> io::Result<bool>;
+}
+
+/// The injected components the controller orchestrates.
+pub struct Components {
+    pub git: Box<dyn GitService>,
+    pub content: Box<dyn ContentProvider>,
+    pub editor: Box<dyn EditorHandoff>,
+}
+
+/// What the run loop should do after an intent is handled.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct Effects {
+    /// Repaint the frame.
+    pub redraw: bool,
+    /// Tear down and exit (AC-20).
+    pub quit: bool,
+    /// Force a full clear before repainting — set after an external program (an editor)
+    /// has drawn over the screen, so the diffing renderer can't leave stale cells.
+    pub clear: bool,
+}
+
+impl Effects {
+    fn redraw() -> Self {
+        Effects { redraw: true, ..Default::default() }
+    }
+    fn noop() -> Self {
+        Effects::default()
+    }
+}
+
+/// The interaction orchestrator and the ephemeral session state.
+pub struct Controller {
+    root: PathBuf,
+    is_git_repo: bool,
+    baseline: Baseline,
+    show_ignored: bool,
+    changed_only: bool,
+    focus: Focus,
+    /// The pane width the run loop last observed (session state for the narrow-split flag,
+    /// AC-21); the Presenter still lays out from the live frame, never this.
+    width: u16,
+    tree: TreeModel,
+    /// Changed-set vs the active baseline, cached; recomputed on a baseline toggle (AC-16).
+    changed: BTreeMap<PathBuf, Status>,
+    /// Per-file view-mode override set by cycling (AC-11); absent ⇒ the policy default.
+    overrides: HashMap<PathBuf, ViewMode>,
+    /// The content pane's current text and its notices (truncation/fallback).
+    content: Text<'static>,
+    content_notices: Vec<String>,
+    /// A transient notice from the last action (e.g. an editor-launch failure); shown until
+    /// the next intent is handled.
+    action_notice: Option<String>,
+    git: Box<dyn GitService>,
+    provider: Box<dyn ContentProvider>,
+    editor: Box<dyn EditorHandoff>,
+}
+
+impl Controller {
+    /// Build the controller rooted at `root`. When `is_git_repo`, the initial working-tree
+    /// status (tree markers, AC-7) and the changed-set against `baseline` are loaded from
+    /// git; otherwise the viewer is a plain browser (AC-26). The initial selection's content
+    /// is rendered so the first frame is populated.
+    pub fn new(root: PathBuf, is_git_repo: bool, baseline: Baseline, components: Components) -> Self {
+        let Components { git, content, editor } = components;
+        let mut ctrl = Controller {
+            tree: TreeModel::new(root.clone()),
+            root,
+            is_git_repo,
+            baseline,
+            show_ignored: false,
+            changed_only: false,
+            focus: Focus::Tree,
+            width: 0,
+            changed: BTreeMap::new(),
+            overrides: HashMap::new(),
+            content: Text::raw(""),
+            content_notices: Vec::new(),
+            action_notice: None,
+            git,
+            provider: content,
+            editor,
+        };
+        if is_git_repo {
+            let status = ctrl.git.status();
+            ctrl.tree.set_status(&status);
+            ctrl.changed = ctrl.git.changed_set(baseline);
+        }
+        ctrl.refresh_content();
+        ctrl
+    }
+
+    // ---- state accessors (used by the Presenter wiring and tests) ----------------------
+
+    pub fn show_ignored(&self) -> bool {
+        self.show_ignored
+    }
+    pub fn changed_only(&self) -> bool {
+        self.changed_only
+    }
+    pub fn baseline(&self) -> Baseline {
+        self.baseline
+    }
+    pub fn focus(&self) -> Focus {
+        self.focus
+    }
+    pub fn tree(&self) -> &TreeModel {
+        &self.tree
+    }
+    pub fn content(&self) -> &Text<'static> {
+        &self.content
+    }
+
+    /// All notices to surface: the transient action notice (if any) followed by the content
+    /// pane's own notices.
+    pub fn notices(&self) -> Vec<String> {
+        let mut out = Vec::new();
+        if let Some(n) = &self.action_notice {
+            out.push(n.clone());
+        }
+        out.extend(self.content_notices.iter().cloned());
+        out
+    }
+
+    /// The effective view mode for the selected file (override or policy default), or `None`
+    /// when nothing / a directory is selected.
+    pub fn selected_view_mode(&self) -> Option<ViewMode> {
+        let node = self.tree.selected()?;
+        if node.kind != NodeKind::File {
+            return None;
+        }
+        Some(self.effective_mode(&node.path))
+    }
+
+    /// Record the pane width the run loop observed (session state, AC-21).
+    pub fn set_width(&mut self, width: u16) {
+        self.width = width;
+    }
+
+    // ---- intent handling ---------------------------------------------------------------
+
+    /// Apply one intent, returning the effects the run loop should act on.
+    pub fn handle(&mut self, intent: Intent) -> Effects {
+        // The action notice is transient: clear it at the top of each intent so a stale
+        // failure message does not linger past the next action.
+        self.action_notice = None;
+        match intent {
+            Intent::NavUp => self.navigate(-1),
+            Intent::NavDown => self.navigate(1),
+            Intent::Expand => self.expand(),
+            Intent::Collapse => self.collapse(),
+            Intent::ToggleIgnore => self.toggle_ignore(),
+            Intent::ToggleChangedOnly => self.toggle_changed_only(),
+            Intent::ToggleBaseline => self.toggle_baseline(),
+            Intent::CycleView => self.cycle_view(),
+            Intent::OpenInEditor => self.open_in_editor(),
+            Intent::ToggleFocus => self.toggle_focus(),
+            Intent::Close => Effects { quit: true, ..Default::default() },
+        }
+    }
+
+    fn navigate(&mut self, delta: isize) -> Effects {
+        self.tree.move_cursor(delta);
+        self.refresh_content();
+        Effects::redraw()
+    }
+
+    fn expand(&mut self) -> Effects {
+        if let Some(node) = self.tree.selected()
+            && node.kind == NodeKind::Dir
+        {
+            self.tree.expand(&node.path);
+            return Effects::redraw();
+        }
+        Effects::noop()
+    }
+
+    fn collapse(&mut self) -> Effects {
+        if let Some(node) = self.tree.selected()
+            && node.kind == NodeKind::Dir
+        {
+            self.tree.collapse(&node.path);
+            return Effects::redraw();
+        }
+        Effects::noop()
+    }
+
+    fn toggle_ignore(&mut self) -> Effects {
+        self.show_ignored = !self.show_ignored;
+        self.tree.set_show_ignored(self.show_ignored);
+        Effects::redraw()
+    }
+
+    fn toggle_changed_only(&mut self) -> Effects {
+        if !self.is_git_repo {
+            return Effects::noop(); // inert without git (AC-26)
+        }
+        self.changed_only = !self.changed_only;
+        self.tree.set_changed_only(self.changed_only, &self.changed);
+        self.refresh_content();
+        Effects::redraw()
+    }
+
+    fn toggle_baseline(&mut self) -> Effects {
+        if !self.is_git_repo {
+            return Effects::noop(); // inert without git (AC-26)
+        }
+        self.baseline = match self.baseline {
+            Baseline::Head => Baseline::Base,
+            Baseline::Base => Baseline::Head,
+        };
+        // Recompute the changed-set against the new baseline (AC-16) and keep the changed-only
+        // filter consistent with it.
+        self.changed = self.git.changed_set(self.baseline);
+        self.tree.set_changed_only(self.changed_only, &self.changed);
+        self.refresh_content(); // a diff is relative to the baseline, so it must re-render
+        Effects::redraw()
+    }
+
+    fn cycle_view(&mut self) -> Effects {
+        let Some(node) = self.tree.selected() else { return Effects::noop() };
+        if node.kind != NodeKind::File {
+            return Effects::noop();
+        }
+        let modes = applicable_modes(&self.descriptor(&node.path));
+        let current = self.effective_mode(&node.path);
+        let idx = modes.iter().position(|m| *m == current).unwrap_or(0);
+        let next = modes[(idx + 1) % modes.len()];
+        self.overrides.insert(node.path.clone(), next);
+        self.refresh_content();
+        Effects::redraw()
+    }
+
+    fn open_in_editor(&mut self) -> Effects {
+        let Some(node) = self.tree.selected() else { return Effects::noop() };
+        if node.kind != NodeKind::File {
+            return Effects::noop();
+        }
+        match self.editor.open(&node.path) {
+            // The hand-off took the terminal: force a full repaint on return.
+            Ok(true) => Effects { redraw: true, clear: true, ..Default::default() },
+            Ok(false) => Effects::redraw(),
+            Err(e) => {
+                self.action_notice = Some(format!("Could not open editor: {e}"));
+                Effects::redraw()
+            }
+        }
+    }
+
+    fn toggle_focus(&mut self) -> Effects {
+        self.focus = match self.focus {
+            Focus::Tree => Focus::Content,
+            Focus::Content => Focus::Tree,
+        };
+        Effects::redraw()
+    }
+
+    // ---- content coordination ----------------------------------------------------------
+
+    /// Re-render the content pane for the current selection. A directory or empty selection
+    /// shows nothing; a file is rendered in its effective mode, pulling the raw diff from git
+    /// for diff mode.
+    fn refresh_content(&mut self) {
+        let Some(node) = self.tree.selected() else {
+            self.content = Text::raw("");
+            self.content_notices.clear();
+            return;
+        };
+        if node.kind != NodeKind::File {
+            self.content = Text::raw("");
+            self.content_notices.clear();
+            return;
+        }
+        let mode = self.effective_mode(&node.path);
+        let raw_diff = if mode == ViewMode::Diff && self.is_git_repo {
+            self.rel(&node.path).map(|rel| self.git.diff(&rel, self.baseline))
+        } else {
+            None
+        };
+        let result = self.provider.render(&node.path, mode, raw_diff.as_deref());
+        self.content = result.content;
+        self.content_notices = result.notices;
+    }
+
+    /// The effective view mode for a file: the user's override, else the policy default.
+    fn effective_mode(&self, path: &Path) -> ViewMode {
+        self.overrides
+            .get(path)
+            .copied()
+            .unwrap_or_else(|| default_mode(&self.descriptor(path)))
+    }
+
+    /// The View Policy facts about a file: markdown by extension, changed by the cached
+    /// changed-set (so it tracks the active baseline).
+    fn descriptor(&self, path: &Path) -> FileDescriptor {
+        FileDescriptor {
+            path: path.to_path_buf(),
+            is_markdown: is_markdown(path),
+            is_changed: self.is_changed(path),
+        }
+    }
+
+    fn is_changed(&self, path: &Path) -> bool {
+        self.rel(path).map(|rel| self.changed.contains_key(&rel)).unwrap_or(false)
+    }
+
+    /// `path` made relative to the tree root (how git keys its maps); `None` if outside it.
+    fn rel(&self, path: &Path) -> Option<PathBuf> {
+        path.strip_prefix(&self.root).ok().map(Path::to_path_buf)
+    }
+}
+
+/// Whether a path names a markdown file (by extension, case-insensitive).
+fn is_markdown(path: &Path) -> bool {
+    path.extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.eq_ignore_ascii_case("md") || e.eq_ignore_ascii_case("markdown"))
+        .unwrap_or(false)
+}

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -201,11 +201,7 @@ impl Controller {
             result_rx,
             latest_seq: 0,
         };
-        if is_git_repo {
-            let status = ctrl.git.status();
-            ctrl.tree.set_status(&status);
-            ctrl.changed = ctrl.git.changed_set(baseline);
-        }
+        ctrl.refresh_git_state();
         ctrl.dispatch_render();
         ctrl
     }
@@ -376,8 +372,10 @@ impl Controller {
         }
         match self.editor.open(&node.path) {
             Ok(true) => {
-                // The editor took the terminal and may have changed the file: re-render the
-                // pane and force a full repaint (the external program drew over the screen).
+                // The editor took the terminal and may have changed the file: re-query git so
+                // status markers and the changed-set reflect the edit, re-render the pane, and
+                // force a full repaint (the external program drew over the screen).
+                self.refresh_git_state();
                 self.dispatch_render();
                 Effects { redraw: true, clear: true, ..Default::default() }
             }
@@ -397,6 +395,22 @@ impl Controller {
             Focus::Content => Focus::Tree,
         };
         Effects::redraw()
+    }
+
+    /// Re-query git for the working-tree status (tree markers, AC-7) and the changed-set
+    /// against the active baseline (AC-16), updating the tree caches. Used at launch and
+    /// after an editor hand-off returns (the file may have changed). No-op without a repo
+    /// (AC-26). This runs on the calling thread, but only on deliberate, infrequent actions
+    /// (launch, editor return, baseline toggle) — never the hot navigation path, where the
+    /// diff is fetched off-thread (AC-23).
+    fn refresh_git_state(&mut self) {
+        if !self.is_git_repo {
+            return;
+        }
+        let status = self.git.status();
+        self.tree.set_status(&status);
+        self.changed = self.git.changed_set(self.baseline);
+        self.tree.set_changed_only(self.changed_only, &self.changed);
     }
 
     // ---- content coordination ----------------------------------------------------------

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -24,12 +24,14 @@ use crate::view_policy::{FileDescriptor, ViewMode, applicable_modes, default_mod
 use ratatui::text::Text;
 use std::collections::{BTreeMap, HashMap};
 use std::io;
+use std::panic::AssertUnwindSafe;
 use std::path::{Path, PathBuf};
-use std::sync::mpsc;
+use std::sync::{Arc, mpsc};
 
 /// Read-only git queries the controller coordinates. Behind a trait so tests stub it and
-/// the run loop injects an implementation bound to the real repository.
-pub trait GitService {
+/// the run loop injects an implementation bound to the real repository. `Send + Sync` so the
+/// diff query can run on the render worker thread, off the input path (AC-23).
+pub trait GitService: Send + Sync {
     /// Working-tree status per repo-root-relative path (drives tree markers, AC-7).
     fn status(&self) -> BTreeMap<PathBuf, Status>;
     /// The set of files changed against `baseline` (drives the changed-only filter, AC-6,
@@ -62,7 +64,9 @@ pub trait EditorHandoff {
 
 /// The injected components the controller orchestrates.
 pub struct Components {
-    pub git: Box<dyn GitService>,
+    /// Shared (`Arc`) because both the controller (status / changed-set) and the render
+    /// worker (diff, off the input thread) query git.
+    pub git: Arc<dyn GitService>,
     pub content: Box<dyn ContentProvider>,
     pub editor: Box<dyn EditorHandoff>,
 }
@@ -89,12 +93,17 @@ impl Effects {
 }
 
 /// A unit of off-thread rendering work sent to the worker. `seq` orders jobs so a stale
-/// result (one whose selection has been superseded) is discarded on arrival.
+/// result (one whose selection has been superseded) is discarded on arrival. The diff itself
+/// is *not* carried here — the worker fetches it from git so nothing git-related (and no
+/// unbounded diff text) touches the input thread (AC-23).
 struct RenderJob {
     seq: u64,
     path: PathBuf,
+    /// Repo-root-relative path for the git diff query (`None` if outside the root).
+    rel: Option<PathBuf>,
     mode: ViewMode,
-    raw_diff: Option<String>,
+    baseline: Baseline,
+    is_git: bool,
 }
 
 /// The interaction orchestrator and the ephemeral session state.
@@ -119,7 +128,7 @@ pub struct Controller {
     /// A transient notice from the last action (e.g. an editor-launch failure); shown until
     /// the next intent is handled.
     action_notice: Option<String>,
-    git: Box<dyn GitService>,
+    git: Arc<dyn GitService>,
     editor: Box<dyn EditorHandoff>,
     /// Render dispatch to the worker thread (AC-23). `latest_seq` is the most recently
     /// dispatched job; a `poll`ed result with a smaller seq is stale and dropped.
@@ -135,14 +144,37 @@ impl Controller {
     /// is rendered so the first frame is populated.
     pub fn new(root: PathBuf, is_git_repo: bool, baseline: Baseline, components: Components) -> Self {
         let Components { git, content, editor } = components;
-        // The Content Renderer lives on a worker thread; the controller talks to it over a
-        // job channel and reads finished renders off a result channel (AC-23). The worker
-        // exits when the job sender (held by the controller) is dropped.
+        // The Content Renderer (and the diff query it needs) live on a worker thread; the
+        // controller talks to it over a job channel and reads finished renders off a result
+        // channel (AC-23). The worker exits when the job sender (held by the controller) is
+        // dropped.
         let (job_tx, job_rx) = mpsc::channel::<RenderJob>();
         let (result_tx, result_rx) = mpsc::channel::<(u64, RenderResult)>();
+        let worker_git = Arc::clone(&git);
         std::thread::spawn(move || {
-            while let Ok(job) = job_rx.recv() {
-                let result = content.render(&job.path, job.mode, job.raw_diff.as_deref());
+            while let Ok(mut job) = job_rx.recv() {
+                // Collapse any backlog: under rapid navigation only the most recent selection
+                // matters, so skip superseded jobs rather than render each in turn.
+                while let Ok(newer) = job_rx.try_recv() {
+                    job = newer;
+                }
+                // The diff is read here, off the input thread, so a large/slow diff never
+                // blocks input (AC-23). Other modes don't need git.
+                let raw_diff = if job.mode == ViewMode::Diff && job.is_git {
+                    job.rel.as_deref().map(|rel| worker_git.diff(rel, job.baseline))
+                } else {
+                    None
+                };
+                // A renderer panic must not kill the worker (rendering would stop forever) nor
+                // fire the global panic hook from this thread (it would reset the main thread's
+                // terminal mid-session). Contain it and surface a placeholder instead.
+                let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+                    content.render(&job.path, job.mode, raw_diff.as_deref())
+                }))
+                .unwrap_or_else(|_| RenderResult {
+                    content: Text::raw("[content unavailable — renderer error]"),
+                    notices: vec!["the renderer failed unexpectedly; showing a placeholder".into()],
+                });
                 if result_tx.send((job.seq, result)).is_err() {
                     break; // controller gone
                 }
@@ -290,6 +322,10 @@ impl Controller {
     fn toggle_ignore(&mut self) -> Effects {
         self.show_ignored = !self.show_ignored;
         self.tree.set_show_ignored(self.show_ignored);
+        // Revealing/hiding ignored entries can shift which node the cursor lands on, so the
+        // content pane must re-render for the (possibly) new selection — otherwise it shows a
+        // file that is no longer highlighted.
+        self.dispatch_render();
         Effects::redraw()
     }
 
@@ -339,12 +375,18 @@ impl Controller {
             return Effects::noop();
         }
         match self.editor.open(&node.path) {
-            // The hand-off took the terminal: force a full repaint on return.
-            Ok(true) => Effects { redraw: true, clear: true, ..Default::default() },
-            Ok(false) => Effects::redraw(),
+            Ok(true) => {
+                // The editor took the terminal and may have changed the file: re-render the
+                // pane and force a full repaint (the external program drew over the screen).
+                self.dispatch_render();
+                Effects { redraw: true, clear: true, ..Default::default() }
+            }
+            Ok(false) => Effects::redraw(), // off-screen hand-off (new pane) — no takeover
             Err(e) => {
                 self.action_notice = Some(format!("Could not open editor: {e}"));
-                Effects::redraw()
+                // The hand-off may have suspended the terminal before failing, so force a full
+                // repaint to recover from any partial screen state.
+                Effects { redraw: true, clear: true, ..Default::default() }
             }
         }
     }
@@ -360,11 +402,10 @@ impl Controller {
     // ---- content coordination ----------------------------------------------------------
 
     /// Dispatch a render of the current selection to the worker thread (AC-23) — never
-    /// blocking. A directory or empty selection clears the pane synchronously (no job). The
-    /// raw diff for diff mode is read from git on this thread (a single bounded query); the
-    /// heavy delegation to the external renderer is what runs off-thread. Every call bumps
-    /// `latest_seq`, so any still-in-flight render for the previous selection is superseded
-    /// and dropped by [`poll`].
+    /// blocking and doing **no git or rendering work on the input thread**: the worker reads
+    /// the diff and delegates to the external renderer. A directory or empty selection clears
+    /// the pane synchronously (no job). Every call bumps `latest_seq`, so any still-in-flight
+    /// render for the previous selection is superseded and dropped by [`poll`].
     fn dispatch_render(&mut self) {
         self.latest_seq += 1;
         let seq = self.latest_seq;
@@ -374,14 +415,17 @@ impl Controller {
             return self.clear_content();
         }
         let mode = self.effective_mode(&node.path);
-        let raw_diff = if mode == ViewMode::Diff && self.is_git_repo {
-            self.rel(&node.path).map(|rel| self.git.diff(&rel, self.baseline))
-        } else {
-            None
-        };
+        let rel = self.rel(&node.path);
         // If the worker has gone (channel closed) the send simply fails; the pane keeps its
         // last content rather than panicking.
-        let _ = self.job_tx.send(RenderJob { seq, path: node.path, mode, raw_diff });
+        let _ = self.job_tx.send(RenderJob {
+            seq,
+            path: node.path,
+            rel,
+            mode,
+            baseline: self.baseline,
+            is_git: self.is_git_repo,
+        });
     }
 
     /// Clear the content pane (selection is a directory / nothing).

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -18,7 +18,7 @@
 
 use crate::git::{Baseline, Status};
 use crate::intent::Intent;
-use crate::presenter::Focus;
+use crate::presenter::{Focus, ViewState};
 use crate::tree::{NodeKind, TreeModel};
 use crate::view_policy::{FileDescriptor, ViewMode, applicable_modes, default_mode};
 use ratatui::text::Text;
@@ -223,6 +223,20 @@ impl Controller {
     /// Record the pane width the run loop observed (session state, AC-21).
     pub fn set_width(&mut self, width: u16) {
         self.width = width;
+    }
+
+    /// Assemble the [`ViewState`] the Presenter draws from: the visible tree rows + cursor,
+    /// the current content and notices, focus, and the observed width (the narrow-split
+    /// input, AC-21).
+    pub fn view_state(&self) -> ViewState {
+        ViewState {
+            nodes: self.tree.visible_nodes(),
+            selected: self.tree.cursor(),
+            content: self.content.clone(),
+            notices: self.notices(),
+            focus: self.focus,
+            width: self.width,
+        }
     }
 
     // ---- intent handling ---------------------------------------------------------------

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -8,6 +8,13 @@
 //! unit-testable with stubs; the Tree Model is the one read-only component it drives
 //! directly. No intent edits a file (AC-N3); git-only intents are inert when not in a repo
 //! (AC-26); a component failure becomes a non-fatal notice, never a crash.
+//!
+//! **Rendering is off the input thread (AC-23).** Selecting a file *dispatches* a render
+//! job to a worker thread that owns the Content Renderer; `handle()` returns immediately so
+//! input never blocks on a slow external renderer. The finished text arrives later and is
+//! drained by [`Controller::poll`], which the run loop calls each tick. Jobs carry a
+//! monotonic sequence so a slow render for a file the user has since left is dropped rather
+//! than clobbering the current selection.
 
 use crate::git::{Baseline, Status};
 use crate::intent::Intent;
@@ -18,6 +25,7 @@ use ratatui::text::Text;
 use std::collections::{BTreeMap, HashMap};
 use std::io;
 use std::path::{Path, PathBuf};
+use std::sync::mpsc;
 
 /// Read-only git queries the controller coordinates. Behind a trait so tests stub it and
 /// the run loop injects an implementation bound to the real repository.
@@ -80,6 +88,15 @@ impl Effects {
     }
 }
 
+/// A unit of off-thread rendering work sent to the worker. `seq` orders jobs so a stale
+/// result (one whose selection has been superseded) is discarded on arrival.
+struct RenderJob {
+    seq: u64,
+    path: PathBuf,
+    mode: ViewMode,
+    raw_diff: Option<String>,
+}
+
 /// The interaction orchestrator and the ephemeral session state.
 pub struct Controller {
     root: PathBuf,
@@ -103,8 +120,12 @@ pub struct Controller {
     /// the next intent is handled.
     action_notice: Option<String>,
     git: Box<dyn GitService>,
-    provider: Box<dyn ContentProvider>,
     editor: Box<dyn EditorHandoff>,
+    /// Render dispatch to the worker thread (AC-23). `latest_seq` is the most recently
+    /// dispatched job; a `poll`ed result with a smaller seq is stale and dropped.
+    job_tx: mpsc::Sender<RenderJob>,
+    result_rx: mpsc::Receiver<(u64, RenderResult)>,
+    latest_seq: u64,
 }
 
 impl Controller {
@@ -114,6 +135,20 @@ impl Controller {
     /// is rendered so the first frame is populated.
     pub fn new(root: PathBuf, is_git_repo: bool, baseline: Baseline, components: Components) -> Self {
         let Components { git, content, editor } = components;
+        // The Content Renderer lives on a worker thread; the controller talks to it over a
+        // job channel and reads finished renders off a result channel (AC-23). The worker
+        // exits when the job sender (held by the controller) is dropped.
+        let (job_tx, job_rx) = mpsc::channel::<RenderJob>();
+        let (result_tx, result_rx) = mpsc::channel::<(u64, RenderResult)>();
+        std::thread::spawn(move || {
+            while let Ok(job) = job_rx.recv() {
+                let result = content.render(&job.path, job.mode, job.raw_diff.as_deref());
+                if result_tx.send((job.seq, result)).is_err() {
+                    break; // controller gone
+                }
+            }
+        });
+
         let mut ctrl = Controller {
             tree: TreeModel::new(root.clone()),
             root,
@@ -129,15 +164,17 @@ impl Controller {
             content_notices: Vec::new(),
             action_notice: None,
             git,
-            provider: content,
             editor,
+            job_tx,
+            result_rx,
+            latest_seq: 0,
         };
         if is_git_repo {
             let status = ctrl.git.status();
             ctrl.tree.set_status(&status);
             ctrl.changed = ctrl.git.changed_set(baseline);
         }
-        ctrl.refresh_content();
+        ctrl.dispatch_render();
         ctrl
     }
 
@@ -212,7 +249,7 @@ impl Controller {
 
     fn navigate(&mut self, delta: isize) -> Effects {
         self.tree.move_cursor(delta);
-        self.refresh_content();
+        self.dispatch_render();
         Effects::redraw()
     }
 
@@ -248,7 +285,7 @@ impl Controller {
         }
         self.changed_only = !self.changed_only;
         self.tree.set_changed_only(self.changed_only, &self.changed);
-        self.refresh_content();
+        self.dispatch_render();
         Effects::redraw()
     }
 
@@ -264,7 +301,7 @@ impl Controller {
         // filter consistent with it.
         self.changed = self.git.changed_set(self.baseline);
         self.tree.set_changed_only(self.changed_only, &self.changed);
-        self.refresh_content(); // a diff is relative to the baseline, so it must re-render
+        self.dispatch_render(); // a diff is relative to the baseline, so it must re-render
         Effects::redraw()
     }
 
@@ -278,7 +315,7 @@ impl Controller {
         let idx = modes.iter().position(|m| *m == current).unwrap_or(0);
         let next = modes[(idx + 1) % modes.len()];
         self.overrides.insert(node.path.clone(), next);
-        self.refresh_content();
+        self.dispatch_render();
         Effects::redraw()
     }
 
@@ -308,19 +345,19 @@ impl Controller {
 
     // ---- content coordination ----------------------------------------------------------
 
-    /// Re-render the content pane for the current selection. A directory or empty selection
-    /// shows nothing; a file is rendered in its effective mode, pulling the raw diff from git
-    /// for diff mode.
-    fn refresh_content(&mut self) {
-        let Some(node) = self.tree.selected() else {
-            self.content = Text::raw("");
-            self.content_notices.clear();
-            return;
-        };
+    /// Dispatch a render of the current selection to the worker thread (AC-23) — never
+    /// blocking. A directory or empty selection clears the pane synchronously (no job). The
+    /// raw diff for diff mode is read from git on this thread (a single bounded query); the
+    /// heavy delegation to the external renderer is what runs off-thread. Every call bumps
+    /// `latest_seq`, so any still-in-flight render for the previous selection is superseded
+    /// and dropped by [`poll`].
+    fn dispatch_render(&mut self) {
+        self.latest_seq += 1;
+        let seq = self.latest_seq;
+
+        let Some(node) = self.tree.selected() else { return self.clear_content() };
         if node.kind != NodeKind::File {
-            self.content = Text::raw("");
-            self.content_notices.clear();
-            return;
+            return self.clear_content();
         }
         let mode = self.effective_mode(&node.path);
         let raw_diff = if mode == ViewMode::Diff && self.is_git_repo {
@@ -328,9 +365,31 @@ impl Controller {
         } else {
             None
         };
-        let result = self.provider.render(&node.path, mode, raw_diff.as_deref());
-        self.content = result.content;
-        self.content_notices = result.notices;
+        // If the worker has gone (channel closed) the send simply fails; the pane keeps its
+        // last content rather than panicking.
+        let _ = self.job_tx.send(RenderJob { seq, path: node.path, mode, raw_diff });
+    }
+
+    /// Clear the content pane (selection is a directory / nothing).
+    fn clear_content(&mut self) {
+        self.content = Text::raw("");
+        self.content_notices.clear();
+    }
+
+    /// Drain finished renders from the worker, applying only the one matching the latest
+    /// dispatched selection (stale results are discarded). Returns `Some` redraw effect when
+    /// fresh content was applied, so the run loop repaints; `None` when nothing arrived.
+    pub fn poll(&mut self) -> Option<Effects> {
+        let mut applied = false;
+        while let Ok((seq, result)) = self.result_rx.try_recv() {
+            if seq == self.latest_seq {
+                self.content = result.content;
+                self.content_notices = result.notices;
+                applied = true;
+            }
+            // else: a superseded selection's render — drop it.
+        }
+        applied.then(Effects::redraw)
     }
 
     /// The effective view mode for a file: the user's override, else the policy default.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 //! Modules are added by each plan task as it lands.
 
 pub mod context;
+pub mod controller;
 pub mod editor;
 pub mod git;
 pub mod host;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 //! A library crate (the testable components) plus a thin binary (`src/main.rs` → [`run`]).
 //! Modules are added by each plan task as it lands.
 
+pub mod app;
 pub mod context;
 pub mod controller;
 pub mod editor;
@@ -18,7 +19,8 @@ pub mod view_policy;
 
 /// Entry point invoked by the binary. Wires the components and runs the event loop.
 ///
-/// Stubbed in T-1; assembled in T-20.
+/// Delegates to [`app::run`], which assembles the live components and drives the terminal
+/// loop until the user closes the viewer (AC-20).
 pub fn run() -> std::io::Result<()> {
-    Ok(())
+    app::run()
 }

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -1,0 +1,37 @@
+//! T-20 — main wiring smoke test over a real pty (AC-17 launch behavior, AC-20 close).
+//! Spawns the *built* binary in a temp dir, asserts it draws the file tree, then presses
+//! the close key and asserts a clean exit(0). External renderers (glow/delta/bat) need not
+//! be installed — the Content Renderer falls back to plain text, and the tree draws either
+//! way.
+
+mod common;
+
+use common::TempDir;
+use expectrl::process::unix::WaitStatus;
+use expectrl::{Eof, Expect, Session};
+use std::process::Command;
+use std::time::Duration;
+
+#[test]
+fn viewer_draws_a_filename_then_exits_zero_on_close() {
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("hello.txt"), "hi there\n").unwrap();
+
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_herdr-file-viewer"));
+    cmd.current_dir(dir.path());
+
+    let mut p = Session::spawn(cmd).expect("spawn the viewer in a pty");
+    p.set_expect_timeout(Some(Duration::from_secs(10)));
+
+    // The tree column lists the file in the launch directory (AC-3 display / AC-17 launch).
+    p.expect("hello.txt").expect("viewer should draw the file tree");
+
+    // The close key returns control and exits the process (AC-20).
+    p.send("q").expect("send the close key");
+    p.expect(Eof).expect("process should terminate after the close key");
+
+    match p.get_process().wait().expect("reap the viewer process") {
+        WaitStatus::Exited(_, code) => assert_eq!(code, 0, "AC-20: clean exit on close"),
+        other => panic!("expected a clean exit, got {other:?}"),
+    }
+}

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -15,14 +15,15 @@ use herdr_file_viewer::intent::Intent;
 use herdr_file_viewer::presenter::Focus;
 use herdr_file_viewer::view_policy::ViewMode;
 use ratatui::text::Text;
-use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::io;
 use std::path::{Path, PathBuf};
-use std::rc::Rc;
+use std::sync::{Arc, Mutex};
 
-/// A shared, mutable recorder the stubs append to and tests read back.
-type Recorder<T> = Rc<RefCell<Vec<T>>>;
+/// A shared, mutable recorder the stubs append to and tests read back. `Arc<Mutex<_>>`
+/// (not `Rc<RefCell<_>>`) so the Git stub is `Send + Sync` — the controller's render worker
+/// holds the Git Service on another thread.
+type Recorder<T> = Arc<Mutex<Vec<T>>>;
 
 // ---- stubs ----------------------------------------------------------------------------
 
@@ -41,7 +42,7 @@ impl GitService for StubGit {
         self.status.clone()
     }
     fn changed_set(&self, baseline: Baseline) -> BTreeMap<PathBuf, Status> {
-        self.changed_calls.borrow_mut().push(baseline);
+        self.changed_calls.lock().unwrap().push(baseline);
         self.changed.clone()
     }
     fn diff(&self, _rel_path: &Path, _baseline: Baseline) -> String {
@@ -66,7 +67,7 @@ struct StubEditor {
 }
 impl EditorHandoff for StubEditor {
     fn open(&mut self, file: &Path) -> io::Result<bool> {
-        self.opened.borrow_mut().push(file.to_path_buf());
+        self.opened.lock().unwrap().push(file.to_path_buf());
         if self.fail {
             Err(io::Error::other("no editor configured"))
         } else {
@@ -84,9 +85,9 @@ fn controller(
     editor_fails: bool,
 ) -> (Controller, Recorder<Baseline>, Recorder<PathBuf>) {
     let changed_calls = git.changed_calls.clone();
-    let opened = Rc::new(RefCell::new(Vec::new()));
+    let opened = Arc::new(Mutex::new(Vec::new()));
     let components = Components {
-        git: Box::new(git),
+        git: Arc::new(git),
         content: Box::new(StubContent),
         editor: Box::new(StubEditor { fail: editor_fails, opened: opened.clone() }),
     };
@@ -147,14 +148,14 @@ fn toggle_baseline_recomputes_the_changed_set_and_updates_state() {
     // AC-16: switching the baseline re-queries git for the changed-set against it.
     let dir = TempDir::new();
     let (mut ctrl, changed_calls, _) = controller(dir.path(), true, StubGit::default(), false);
-    changed_calls.borrow_mut().clear(); // ignore the initial load in new()
+    changed_calls.lock().unwrap().clear(); // ignore the initial load in new()
 
     assert_eq!(ctrl.baseline(), Baseline::Head);
     let fx = ctrl.handle(Intent::ToggleBaseline);
     assert_eq!(ctrl.baseline(), Baseline::Base, "baseline toggles Head→Base (AC-16)");
     assert!(fx.redraw);
     assert_eq!(
-        *changed_calls.borrow(),
+        *changed_calls.lock().unwrap(),
         vec![Baseline::Base],
         "the changed-set is recomputed against the new baseline (AC-16)"
     );
@@ -171,7 +172,7 @@ fn git_intents_are_inert_without_a_repo() {
 
     ctrl.handle(Intent::ToggleBaseline);
     assert_eq!(ctrl.baseline(), Baseline::Head, "baseline is inert without git (AC-26)");
-    assert!(changed_calls.borrow().is_empty(), "no git query is issued without a repo");
+    assert!(changed_calls.lock().unwrap().is_empty(), "no git query is issued without a repo");
 }
 
 #[test]
@@ -183,7 +184,7 @@ fn an_editor_handoff_error_becomes_a_nonfatal_notice() {
     let (mut ctrl, _, opened) = controller(dir.path(), false, StubGit::default(), true);
 
     let fx = ctrl.handle(Intent::OpenInEditor);
-    assert_eq!(opened.borrow().len(), 1, "the editor hand-off was attempted");
+    assert_eq!(opened.lock().unwrap().len(), 1, "the editor hand-off was attempted");
     assert!(!ctrl.notices().is_empty(), "the failure is surfaced as a notice");
     assert!(!fx.quit, "a component error does not end the session");
 }

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -1,0 +1,266 @@
+//! T-18 — Session Controller: intent → coordinated state change (AC-5, AC-6, AC-11,
+//! AC-16, AC-26, AC-N3). Every side-effecting component (Git Service, Content Renderer,
+//! Editor Launcher) is behind a trait and stubbed, so these tests touch no real git, no
+//! external renderer, and launch no editor. The file tree is real (over a temp dir) — the
+//! one read-only component the controller drives directly.
+
+mod common;
+
+use common::TempDir;
+use herdr_file_viewer::controller::{
+    Components, ContentProvider, Controller, EditorHandoff, GitService, RenderResult,
+};
+use herdr_file_viewer::git::{Baseline, Status};
+use herdr_file_viewer::intent::Intent;
+use herdr_file_viewer::presenter::Focus;
+use herdr_file_viewer::view_policy::ViewMode;
+use ratatui::text::Text;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::rc::Rc;
+
+/// A shared, mutable recorder the stubs append to and tests read back.
+type Recorder<T> = Rc<RefCell<Vec<T>>>;
+
+// ---- stubs ----------------------------------------------------------------------------
+
+/// A Git Service stub that records every `changed_set` baseline it is asked for and replays
+/// canned status/changed maps, so a test can assert the controller queried git correctly
+/// without a real repository.
+#[derive(Default, Clone)]
+struct StubGit {
+    status: BTreeMap<PathBuf, Status>,
+    changed: BTreeMap<PathBuf, Status>,
+    changed_calls: Recorder<Baseline>,
+}
+
+impl GitService for StubGit {
+    fn status(&self) -> BTreeMap<PathBuf, Status> {
+        self.status.clone()
+    }
+    fn changed_set(&self, baseline: Baseline) -> BTreeMap<PathBuf, Status> {
+        self.changed_calls.borrow_mut().push(baseline);
+        self.changed.clone()
+    }
+    fn diff(&self, _rel_path: &Path, _baseline: Baseline) -> String {
+        String::new()
+    }
+}
+
+/// A Content Renderer stub: returns fixed text and no notices, so the controller's content
+/// coordination runs without an external renderer.
+struct StubContent;
+impl ContentProvider for StubContent {
+    fn render(&self, _path: &Path, _mode: ViewMode, _raw_diff: Option<&str>) -> RenderResult {
+        RenderResult { content: Text::raw("stub-content"), notices: Vec::new() }
+    }
+}
+
+/// An Editor Launcher stub that either succeeds or fails on demand, and records the file it
+/// was asked to open.
+struct StubEditor {
+    fail: bool,
+    opened: Recorder<PathBuf>,
+}
+impl EditorHandoff for StubEditor {
+    fn open(&mut self, file: &Path) -> io::Result<bool> {
+        self.opened.borrow_mut().push(file.to_path_buf());
+        if self.fail {
+            Err(io::Error::other("no editor configured"))
+        } else {
+            Ok(true)
+        }
+    }
+}
+
+/// Build a controller over `root` with stubbed components. `changed_calls`/`opened` let the
+/// caller inspect what the controller asked of git / the editor.
+fn controller(
+    root: &Path,
+    is_git_repo: bool,
+    git: StubGit,
+    editor_fails: bool,
+) -> (Controller, Recorder<Baseline>, Recorder<PathBuf>) {
+    let changed_calls = git.changed_calls.clone();
+    let opened = Rc::new(RefCell::new(Vec::new()));
+    let components = Components {
+        git: Box::new(git),
+        content: Box::new(StubContent),
+        editor: Box::new(StubEditor { fail: editor_fails, opened: opened.clone() }),
+    };
+    let ctrl = Controller::new(root.to_path_buf(), is_git_repo, Baseline::Head, components);
+    (ctrl, changed_calls, opened)
+}
+
+// ---- tests ----------------------------------------------------------------------------
+
+#[test]
+fn toggle_ignore_flips_show_ignored_and_signals_redraw() {
+    // AC-5: revealing/hiding ignored files is a controller toggle that redraws.
+    let dir = TempDir::new();
+    let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
+
+    assert!(!ctrl.show_ignored(), "ignored files hidden by default (AC-4)");
+    let fx = ctrl.handle(Intent::ToggleIgnore);
+    assert!(ctrl.show_ignored(), "ToggleIgnore reveals ignored files (AC-5)");
+    assert!(fx.redraw, "a state change signals a redraw");
+
+    ctrl.handle(Intent::ToggleIgnore);
+    assert!(!ctrl.show_ignored(), "ToggleIgnore again hides them");
+}
+
+#[test]
+fn toggle_changed_only_flips_in_a_repo() {
+    // AC-6: restrict the tree to the changed-set, then restore the full tree.
+    let dir = TempDir::new();
+    let (mut ctrl, _, _) = controller(dir.path(), true, StubGit::default(), false);
+
+    assert!(!ctrl.changed_only());
+    let fx = ctrl.handle(Intent::ToggleChangedOnly);
+    assert!(ctrl.changed_only(), "ToggleChangedOnly restricts to changed files (AC-6)");
+    assert!(fx.redraw);
+
+    ctrl.handle(Intent::ToggleChangedOnly);
+    assert!(!ctrl.changed_only(), "toggling again restores the full tree");
+}
+
+#[test]
+fn cycle_view_advances_the_selected_files_mode_through_the_applicable_set() {
+    // AC-11: the view-mode override steps through applicable_modes and wraps around.
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.rs"), "fn main() {}\n").unwrap();
+    // Non-git → unchanged, non-markdown: applicable modes are [SyntaxContent, RawContent].
+    let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
+
+    assert_eq!(ctrl.selected_view_mode(), Some(ViewMode::SyntaxContent), "default mode");
+    let fx = ctrl.handle(Intent::CycleView);
+    assert_eq!(ctrl.selected_view_mode(), Some(ViewMode::RawContent), "advances to the override");
+    assert!(fx.redraw);
+    ctrl.handle(Intent::CycleView);
+    assert_eq!(ctrl.selected_view_mode(), Some(ViewMode::SyntaxContent), "cycle wraps around");
+}
+
+#[test]
+fn toggle_baseline_recomputes_the_changed_set_and_updates_state() {
+    // AC-16: switching the baseline re-queries git for the changed-set against it.
+    let dir = TempDir::new();
+    let (mut ctrl, changed_calls, _) = controller(dir.path(), true, StubGit::default(), false);
+    changed_calls.borrow_mut().clear(); // ignore the initial load in new()
+
+    assert_eq!(ctrl.baseline(), Baseline::Head);
+    let fx = ctrl.handle(Intent::ToggleBaseline);
+    assert_eq!(ctrl.baseline(), Baseline::Base, "baseline toggles Head→Base (AC-16)");
+    assert!(fx.redraw);
+    assert_eq!(
+        *changed_calls.borrow(),
+        vec![Baseline::Base],
+        "the changed-set is recomputed against the new baseline (AC-16)"
+    );
+}
+
+#[test]
+fn git_intents_are_inert_without_a_repo() {
+    // AC-26: in a non-git directory, git-only intents do nothing and never error.
+    let dir = TempDir::new();
+    let (mut ctrl, changed_calls, _) = controller(dir.path(), false, StubGit::default(), false);
+
+    ctrl.handle(Intent::ToggleChangedOnly);
+    assert!(!ctrl.changed_only(), "changed-only is inert without git (AC-26)");
+
+    ctrl.handle(Intent::ToggleBaseline);
+    assert_eq!(ctrl.baseline(), Baseline::Head, "baseline is inert without git (AC-26)");
+    assert!(changed_calls.borrow().is_empty(), "no git query is issued without a repo");
+}
+
+#[test]
+fn an_editor_handoff_error_becomes_a_nonfatal_notice() {
+    // The loop must survive a failing component, surfacing it as a notice (design: every
+    // component error is a non-fatal status, never a crash).
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.rs"), "x\n").unwrap();
+    let (mut ctrl, _, opened) = controller(dir.path(), false, StubGit::default(), true);
+
+    let fx = ctrl.handle(Intent::OpenInEditor);
+    assert_eq!(opened.borrow().len(), 1, "the editor hand-off was attempted");
+    assert!(!ctrl.notices().is_empty(), "the failure is surfaced as a notice");
+    assert!(!fx.quit, "a component error does not end the session");
+}
+
+#[test]
+fn toggle_focus_switches_columns() {
+    // AC-21 trigger: focus moves between the tree and content columns.
+    let dir = TempDir::new();
+    let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
+
+    assert_eq!(ctrl.focus(), Focus::Tree, "the tree holds focus initially");
+    ctrl.handle(Intent::ToggleFocus);
+    assert_eq!(ctrl.focus(), Focus::Content);
+    ctrl.handle(Intent::ToggleFocus);
+    assert_eq!(ctrl.focus(), Focus::Tree);
+}
+
+#[test]
+fn close_intent_signals_quit() {
+    // AC-20: the close key ends the session.
+    let dir = TempDir::new();
+    let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
+    let fx = ctrl.handle(Intent::Close);
+    assert!(fx.quit, "Close signals the run loop to exit (AC-20)");
+}
+
+#[test]
+fn navigation_moves_the_cursor_and_signals_redraw() {
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.rs"), "1\n").unwrap();
+    std::fs::write(dir.path().join("b.rs"), "2\n").unwrap();
+    let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
+
+    assert_eq!(ctrl.tree().cursor(), 0);
+    let fx = ctrl.handle(Intent::NavDown);
+    assert_eq!(ctrl.tree().cursor(), 1, "NavDown advances the cursor");
+    assert!(fx.redraw);
+    ctrl.handle(Intent::NavUp);
+    assert_eq!(ctrl.tree().cursor(), 0, "NavUp retreats the cursor");
+}
+
+#[test]
+fn no_handled_intent_mutates_the_filesystem() {
+    // AC-N1 / AC-N3: handling the entire intent vocabulary writes nothing — the viewer is
+    // read-only and exposes no edit path (the editor stub launches nothing real).
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.rs"), "fn main() {}\n").unwrap();
+    std::fs::create_dir(dir.path().join("sub")).unwrap();
+    std::fs::write(dir.path().join("sub").join("c.txt"), "c\n").unwrap();
+    let before = snapshot(dir.path());
+
+    let (mut ctrl, _, _) = controller(dir.path(), true, StubGit::default(), false);
+    for intent in Intent::ALL {
+        if intent == Intent::Close {
+            continue; // Close ends the session; exercise every other intent
+        }
+        let _ = ctrl.handle(intent);
+    }
+
+    assert_eq!(snapshot(dir.path()), before, "no intent mutated any file (AC-N1, AC-N3)");
+}
+
+/// A sorted (path, bytes) snapshot of every file under `root`, for an exact read-only check.
+fn snapshot(root: &Path) -> Vec<(PathBuf, Vec<u8>)> {
+    let mut out = Vec::new();
+    fn walk(dir: &Path, out: &mut Vec<(PathBuf, Vec<u8>)>) {
+        let mut entries: Vec<_> =
+            std::fs::read_dir(dir).unwrap().filter_map(Result::ok).map(|e| e.path()).collect();
+        entries.sort();
+        for p in entries {
+            if p.is_dir() {
+                walk(&p, out);
+            } else {
+                out.push((p.clone(), std::fs::read(&p).unwrap()));
+            }
+        }
+    }
+    walk(root, &mut out);
+    out
+}

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -190,6 +190,24 @@ fn an_editor_handoff_error_becomes_a_nonfatal_notice() {
 }
 
 #[test]
+fn successful_editor_return_refreshes_git_state() {
+    // After the editor returns the file may have changed, so the controller must re-query
+    // git — status markers (AC-7) and the changed-set — not just the content pane. Otherwise
+    // a freshly-edited file keeps its pre-edit markers/changed-only visibility.
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.rs"), "x\n").unwrap();
+    let (mut ctrl, changed_calls, opened) = controller(dir.path(), true, StubGit::default(), false);
+    changed_calls.lock().unwrap().clear(); // ignore the initial load in new()
+
+    ctrl.handle(Intent::OpenInEditor);
+    assert_eq!(opened.lock().unwrap().len(), 1, "the editor was invoked");
+    assert!(
+        !changed_calls.lock().unwrap().is_empty(),
+        "git state is re-queried after a successful editor return (AC-7/AC-16 freshness)"
+    );
+}
+
+#[test]
 fn toggle_focus_switches_columns() {
     // AC-21 trigger: focus moves between the tree and content columns.
     let dir = TempDir::new();

--- a/tests/controller_async.rs
+++ b/tests/controller_async.rs
@@ -16,6 +16,7 @@ use ratatui::text::Text;
 use std::collections::BTreeMap;
 use std::io;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 /// A renderer that sleeps before producing output — the stand-in for a slow external CLI.
@@ -67,7 +68,7 @@ fn a_select_intent_does_not_block_on_a_slow_render_and_content_arrives_later() {
 
     let delay = Duration::from_millis(150);
     let components = Components {
-        git: Box::new(NoGit),
+        git: Arc::new(NoGit),
         content: Box::new(SlowContent { delay }),
         editor: Box::new(NoEditor),
     };
@@ -79,8 +80,11 @@ fn a_select_intent_does_not_block_on_a_slow_render_and_content_arrives_later() {
     let fx = ctrl.handle(Intent::NavDown);
     let handle_took = start.elapsed();
     assert!(fx.redraw, "the select still asks for a redraw (stale content shown meanwhile)");
+    // Non-blocking proof: had handle() waited for the render it would take at least `delay`
+    // (the worker's sleep). The dispatch is an in-process channel send (sub-millisecond), so
+    // a comfortable margin below `delay` is a robust, non-flaky bound.
     assert!(
-        handle_took < delay / 2,
+        handle_took < delay,
         "handle() must not block on the slow render (took {handle_took:?}, render is {delay:?})"
     );
     // The fresh content has not arrived yet — proof the render is off-thread (AC-23).
@@ -116,7 +120,7 @@ fn a_superseded_render_does_not_overwrite_a_newer_selection() {
     std::fs::write(dir.path().join("c.rs"), "3\n").unwrap();
 
     let components = Components {
-        git: Box::new(NoGit),
+        git: Arc::new(NoGit),
         content: Box::new(SlowContent { delay: Duration::from_millis(80) }),
         editor: Box::new(NoEditor),
     };

--- a/tests/controller_async.rs
+++ b/tests/controller_async.rs
@@ -1,0 +1,147 @@
+//! T-19 — Session Controller: off-thread rendering (AC-23). A select intent must dispatch
+//! the (potentially slow) content render to a worker thread so `handle()` returns promptly
+//! and never blocks input; the rendered content then arrives as a later effect, drained by
+//! `poll()`. A deliberately slow renderer stub stands in for glow/delta/bat.
+
+mod common;
+
+use common::TempDir;
+use herdr_file_viewer::controller::{
+    Components, ContentProvider, Controller, EditorHandoff, GitService, RenderResult,
+};
+use herdr_file_viewer::git::{Baseline, Status};
+use herdr_file_viewer::intent::Intent;
+use herdr_file_viewer::view_policy::ViewMode;
+use ratatui::text::Text;
+use std::collections::BTreeMap;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+/// A renderer that sleeps before producing output — the stand-in for a slow external CLI.
+struct SlowContent {
+    delay: Duration,
+}
+impl ContentProvider for SlowContent {
+    fn render(&self, path: &Path, _mode: ViewMode, _raw_diff: Option<&str>) -> RenderResult {
+        std::thread::sleep(self.delay);
+        let name = path.file_name().unwrap().to_string_lossy().into_owned();
+        RenderResult { content: Text::raw(format!("rendered:{name}")), notices: Vec::new() }
+    }
+}
+
+struct NoGit;
+impl GitService for NoGit {
+    fn status(&self) -> BTreeMap<PathBuf, Status> {
+        BTreeMap::new()
+    }
+    fn changed_set(&self, _: Baseline) -> BTreeMap<PathBuf, Status> {
+        BTreeMap::new()
+    }
+    fn diff(&self, _: &Path, _: Baseline) -> String {
+        String::new()
+    }
+}
+
+struct NoEditor;
+impl EditorHandoff for NoEditor {
+    fn open(&mut self, _: &Path) -> io::Result<bool> {
+        Ok(false)
+    }
+}
+
+/// Flatten a content `Text` to a plain string for assertions.
+fn flatten(text: &Text) -> String {
+    text.lines
+        .iter()
+        .map(|l| l.spans.iter().map(|s| s.content.as_ref()).collect::<String>())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[test]
+fn a_select_intent_does_not_block_on_a_slow_render_and_content_arrives_later() {
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.rs"), "1\n").unwrap();
+    std::fs::write(dir.path().join("b.rs"), "2\n").unwrap();
+
+    let delay = Duration::from_millis(150);
+    let components = Components {
+        git: Box::new(NoGit),
+        content: Box::new(SlowContent { delay }),
+        editor: Box::new(NoEditor),
+    };
+    let mut ctrl =
+        Controller::new(dir.path().to_path_buf(), false, Baseline::Head, components);
+
+    // A select intent must return far faster than the render takes — it only dispatches.
+    let start = Instant::now();
+    let fx = ctrl.handle(Intent::NavDown);
+    let handle_took = start.elapsed();
+    assert!(fx.redraw, "the select still asks for a redraw (stale content shown meanwhile)");
+    assert!(
+        handle_took < delay / 2,
+        "handle() must not block on the slow render (took {handle_took:?}, render is {delay:?})"
+    );
+    // The fresh content has not arrived yet — proof the render is off-thread (AC-23).
+    assert!(
+        !flatten(ctrl.content()).contains("b.rs"),
+        "selected file's content must not be ready synchronously"
+    );
+
+    // Drain results until the latest selection's content arrives as a later effect.
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let mut redrew = false;
+    loop {
+        if let Some(p) = ctrl.poll() {
+            redrew |= p.redraw;
+        }
+        if flatten(ctrl.content()).contains("b.rs") {
+            break;
+        }
+        assert!(Instant::now() < deadline, "rendered content never arrived");
+        std::thread::sleep(Duration::from_millis(5));
+    }
+    assert!(redrew, "the arriving content signalled a redraw via poll()");
+    assert_eq!(flatten(ctrl.content()), "rendered:b.rs", "the selected file rendered");
+}
+
+#[test]
+fn a_superseded_render_does_not_overwrite_a_newer_selection() {
+    // Rapid navigation: an earlier file's slow render must not clobber the content of the
+    // file the user has since moved to (stale results are dropped by sequence).
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.rs"), "1\n").unwrap();
+    std::fs::write(dir.path().join("b.rs"), "2\n").unwrap();
+    std::fs::write(dir.path().join("c.rs"), "3\n").unwrap();
+
+    let components = Components {
+        git: Box::new(NoGit),
+        content: Box::new(SlowContent { delay: Duration::from_millis(80) }),
+        editor: Box::new(NoEditor),
+    };
+    let mut ctrl =
+        Controller::new(dir.path().to_path_buf(), false, Baseline::Head, components);
+
+    // Fire several selections back-to-back; only the last (c.rs) should win.
+    ctrl.handle(Intent::NavDown); // b.rs
+    ctrl.handle(Intent::NavDown); // c.rs
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        ctrl.poll();
+        if flatten(ctrl.content()) == "rendered:c.rs" {
+            break;
+        }
+        assert!(Instant::now() < deadline, "final selection never rendered");
+        std::thread::sleep(Duration::from_millis(5));
+    }
+    // Give any stale (a.rs/b.rs) results a chance to wrongly land, then re-check.
+    std::thread::sleep(Duration::from_millis(50));
+    ctrl.poll();
+    assert_eq!(
+        flatten(ctrl.content()),
+        "rendered:c.rs",
+        "a superseded render must not overwrite the newer selection"
+    );
+}


### PR DESCRIPTION
## PR4 — Session Controller, off-thread rendering, main wiring (T-18…T-20)

Layer 4 of the plan: the interaction orchestrator and the live run loop that ties
all prior components together into a working viewer.

### Tasks
- **T-18 — Session Controller** (`src/controller.rs`): holds the ephemeral session
  state (root, git-presence, baseline, filter flags, per-file view overrides, cursor,
  focus, observed width) and turns each `Intent` into state changes + `Effects`
  (`redraw`/`quit`/`clear`). Git Service, Content Renderer, and Editor Launcher are
  behind injected traits (`GitService`/`ContentProvider`/`EditorHandoff`) so the
  controller is unit-testable with stubs; the Tree Model is driven directly.
  - Git-only intents are inert without a repo (AC-26); a component failure becomes a
    non-fatal notice, never a crash; no intent mutates the filesystem (AC-N1/AC-N3).
  - Covers AC-5, AC-6, AC-11, AC-16, AC-20 (trigger), AC-21 (trigger), AC-26.
- **T-19 — off-thread rendering** (AC-23): the Content Renderer runs on a worker
  thread; selecting a file *dispatches* a render job and `handle()` returns
  immediately, so input never blocks on a slow external renderer. `poll()` drains
  finished renders, applying only the latest selection's (stale results dropped by a
  monotonic sequence).
- **T-20 — main wiring** (`src/app.rs`, `src/lib.rs::run()`): reads the herdr context →
  resolves root/git-presence → builds the live components → drives a draw→input→poll
  loop over a ratatui terminal (crossterm raw mode + restore, incl. ratatui's panic
  hook). Editor hand-off suspends/restores the TUI around a blocking `$EDITOR` spawn.
  Covers AC-17 (launch behavior) and AC-20.

### Tests (test-first, red→green)
- `tests/controller.rs` (10) — intent orchestration, inert-without-git, editor-error
  notice, read-only invariant over the whole intent vocabulary.
- `tests/controller_async.rs` (2) — handle() doesn't block on a slow render; a
  superseded render never clobbers a newer selection.
- `tests/cli_smoke.rs` (1, expectrl pty) — the built binary draws the tree and exits 0
  on the close key.
- Full suite: **118 passing**, 0 failing. New modules clippy-clean; release builds.

### Notes
- First commit adds `.review-gate/` to `.gitignore` (gate run logs stay local).
- The `presenter::ViewState::width` field (kept in PR3) is now read by
  `Controller::view_state()`.
- Pre-existing clippy warnings in `src/git.rs` / `tests/git_status.rs` predate this PR
  and are outside its diff.
