### PR TITLE
Live-install fixes + content navigation (scroll/wrap/resize), tree colors, renderer fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,29 +13,36 @@ hand-off to an *external* editor — the viewer itself only reads.
 
 - **Tree, scoped to your work** — rooted at the worktree root inside a git repo, else the
   launch directory. Honors `.gitignore` (toggle to reveal ignored files).
-- **Git woven in** — per-file status markers (`M`/`A`/`D`/`?`), a changed-files-only filter,
-  and a baseline you can switch between the merge-base of your branch and `HEAD`.
+- **Git woven in** — per-file status markers (`M`/`A`/`D`/`?`), **colored** so changes read at
+  a glance (changed files and folders containing changes are red, new files green); a
+  changed-files-only filter; and a baseline you can switch between the merge-base of your
+  branch and `HEAD`.
 - **The right view per file** — a changed file shows its **diff**; a markdown file renders;
-  anything else is shown as syntax-highlighted content. Cycle the view to override.
+  anything else is shown as syntax-highlighted content with line numbers. Cycle the view to
+  override.
+- **Navigable content** — scroll the content pane in all four directions, toggle line
+  wrapping, and resize the tree/content split; the layout reflows when the pane is resized.
 - **Keyboard-first** — every function has a key; no mouse required.
 
 ## Install
 
-The plugin builds from source. herdr runs the build step declared in the manifest
-(`herdr-plugin.toml`) at install time:
+Requirements: **Rust 1.96+** (edition 2024) and Cargo; **herdr 0.7.0+**, on **Linux** or
+**macOS**.
 
-```toml
-[[build]]
-command = ["cargo", "build", "--release"]
+**Install through herdr** — herdr runs the manifest's `[[build]]` step
+(`cargo build --release`) at install time, producing `./target/release/herdr-file-viewer`,
+which the viewer pane launches:
+
+```bash
+# from a published GitHub repo (owner/repo[/subdir]):
+herdr plugin install <owner>/<repo>
+
+# or, for local development, link this checkout in place:
+cargo build --release            # plugin link does NOT run the [[build]] step, so build first
+herdr plugin link /path/to/herdr-file-viewer
 ```
 
-So installing it through herdr produces `./target/release/herdr-file-viewer`, which the
-viewer pane launches. Requirements:
-
-- **Rust 1.96+** (edition 2024) and Cargo.
-- **herdr 0.7.0+**, on **Linux** or **macOS**.
-
-To build manually:
+Confirm it registered with `herdr plugin list`. To build manually outside herdr:
 
 ```bash
 cargo build --release
@@ -65,35 +72,55 @@ content cannot inject a command or drive the terminal.
 ## Summoning the viewer
 
 The viewer opens **only** in response to an explicit action — there are no event hooks and no
-automatic invocation. The manifest declares one action:
+automatic invocation. The manifest declares a `[[panes]]` entry (the split-pane viewer) and an
+`[[actions]]` whose command opens it:
 
 ```toml
+[[panes]]
+id = "file-viewer"
+placement = "split"
+command = ["./target/release/herdr-file-viewer"]
+
 [[actions]]
 id = "open-file-viewer"
 title = "Open file viewer"
-pane = "file-viewer"
+command = ["bash", "scripts/open-file-viewer.sh"]   # opens the pane via the herdr CLI
 ```
 
-Bind this action to a key in your herdr configuration (see your herdr docs for the action
-keybinding syntax). Invoking it opens the viewer in a **split** pane beside your current work.
+Summon it by invoking the action:
+
+```bash
+herdr plugin action invoke open-file-viewer --plugin herdr-file-viewer
+```
+
+It opens the viewer in a **split** pane beside your current work. Bind the action to a key in
+your herdr configuration for one-press access (see your herdr docs for the keybinding syntax).
 
 ## Keys
 
 | Key | Action |
 | --- | --- |
-| `↑` / `k`, `↓` / `j` | Move the tree cursor |
-| `→` / `l` | Expand the selected directory |
-| `←` / `h` | Collapse the selected directory |
+| `↑` / `k`, `↓` / `j` | Move the tree cursor — or **scroll the content pane** vertically when it is focused |
+| `→` / `l` | Expand the selected directory — or **scroll the content pane right** when it is focused |
+| `←` / `h` | Collapse the selected directory — or **scroll the content pane left** when it is focused |
 | `i` | Toggle gitignored files |
 | `c` | Toggle changed-files-only |
 | `b` | Toggle the diff baseline (base branch ⇄ `HEAD`) |
 | `v` | Cycle the content view mode |
 | `e` | Open the selected file in `$EDITOR` |
 | `Tab` | Move focus between the tree and content columns |
+| `<` / `>` | Narrow / widen the tree column (move the divider) |
+| `w` | Toggle line wrapping for the content pane |
 | `q` / `Esc` | Close the viewer and return to the prior pane |
 
-All character keys act only when no modifier is held, so terminal chords (e.g. `Ctrl+C`) are
-never intercepted.
+`Tab` to the content pane, then the arrow keys (or `h`/`j`/`k`/`l`) scroll it in all four
+directions; `Tab` back to the tree to move between files. Long lines wrap in prose (markdown /
+plain text); diffs and code keep their original lines so columns stay aligned — scroll
+sideways with `←`/`→`, or press `w` to wrap them instead. The layout reflows automatically
+when the pane is resized.
+
+Character keys act only when no control chord is held (so terminal chords like `Ctrl+C` are
+never intercepted); `Shift` is permitted, for keys such as `<` and `>`.
 
 ### Opening in an editor
 

--- a/docs/manual-verification.md
+++ b/docs/manual-verification.md
@@ -27,26 +27,42 @@ This procedure verifies the remaining **live-host** behavior.
 ## Procedure
 
 1. **Install / link the plugin into herdr.**
-   Register this plugin's directory with your herdr installation (per your herdr plugin-
-   install docs) so herdr reads `herdr-plugin.toml`. Bind the `open-file-viewer` action to a
-   key in your herdr config.
+   Build the binary, then register the checkout (a linked plugin does **not** run the
+   `[[build]]` step, so build first):
+
+   ```bash
+   cargo build --release
+   herdr plugin link /path/to/herdr-file-viewer
+   herdr plugin list                       # confirm `herdr-file-viewer` is listed + enabled
+   ```
+
+   (Or `herdr plugin install <owner>/<repo>` from a published repo, which runs the build.)
 
 2. **Open a workspace and note the current pane.**
    Start herdr in (or `cd` to) the directory you want to browse. Note which pane currently
    has focus — call it the *origin* pane.
 
 3. **Invoke the action.**
-   Press the key you bound to `open-file-viewer`.
+
+   ```bash
+   herdr plugin action invoke open-file-viewer --plugin herdr-file-viewer
+   ```
+
+   (Or press the key you bound to the action.)
    - ✅ **AC-17:** the viewer opens in a **new split pane beside** the origin pane (not full-
      screen, not replacing it). The origin pane is still visible. The viewer shows the file
      tree on the left and a content pane on the right.
 
 4. **Exercise it briefly (sanity, not exhaustive).**
    - Navigate with `j`/`k`; the content pane updates to the selected file.
-   - If this is a git worktree: confirm status markers (`M`/`A`/`D`/`?`) appear, press `c`
-     to filter to changed files, and select a changed file to see its diff.
+   - If this is a git worktree: confirm colored status markers (`M`/`A`/`D`/`?` — changed
+     red, new green, folders-with-changes red), press `c` to filter to changed files, and
+     select a changed file to see its diff.
+   - Press `Tab` to focus the content pane, then scroll with the arrows (`←`/`→` horizontally,
+     `↑`/`↓` vertically), `w` to toggle wrapping, and `<`/`>` to resize the split.
    - Press `e` on a file (with `$EDITOR` set) and confirm your editor opens on that file, then
      exit the editor and confirm the viewer redraws cleanly.
+   - Resize the pane (e.g. `herdr pane resize`) and confirm the layout reflows to the new size.
 
 5. **Close the viewer.**
    Press `q` (or `Esc`).

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -4,6 +4,7 @@
 # user's current work. The viewer appears ONLY in response to an explicit action
 # (its keybinding) — there are no event hooks and no automatic invocation (AC-N4).
 
+id = "herdr-file-viewer"
 name = "herdr-file-viewer"
 version = "0.1.0"
 description = "A git-aware, read-only file viewer: a keyboard-driven TUI in a herdr split pane."
@@ -24,9 +25,10 @@ placement = "split"
 command = ["./target/release/herdr-file-viewer"]
 
 # The action that summons the viewer (bound to a keybinding in herdr config). This is
-# the only way the viewer is opened — there is no [[events]] hook (AC-N4).
+# the only way the viewer is opened — there is no [[events]] hook (AC-N4). herdr actions
+# run a `command`; the launcher script opens the [[panes]] entry below as a split.
 [[actions]]
 id = "open-file-viewer"
 title = "Open file viewer"
 description = "Open the git-aware file viewer in a split pane beside the current work."
-pane = "file-viewer"
+command = ["bash", "scripts/open-file-viewer.sh"]

--- a/scripts/open-file-viewer.sh
+++ b/scripts/open-file-viewer.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Launcher for the `open-file-viewer` action: open the viewer's pane as a split
+# beside the current work. herdr actions run a command (they have no declarative
+# "open this pane" field), so the action shells out to the herdr CLI here, using
+# $HERDR_BIN_PATH (herdr injects it; fall back to `herdr` on PATH).
+set -euo pipefail
+
+herdr_bin="${HERDR_BIN_PATH:-herdr}"
+
+exec "$herdr_bin" plugin pane open \
+  --plugin herdr-file-viewer \
+  --entrypoint file-viewer \
+  --placement split \
+  --direction right \
+  --focus

--- a/src/app.rs
+++ b/src/app.rs
@@ -76,35 +76,47 @@ fn event_loop(terminal: &mut DefaultTerminal, controller: &mut Controller) -> io
             terminal.draw(|frame| {
                 controller.set_width(frame.area().width);
                 let view: ViewState = controller.view_state();
-                presenter::draw(frame, &view);
+                let (cw, ch) = presenter::draw(frame, &view);
+                // Feed the drawn content viewport back so content scrolling can be clamped to
+                // it on the next intent.
+                controller.set_content_viewport(cw, ch);
             })?;
             dirty = false;
         }
 
-        if event::poll(TICK)?
-            && let Event::Key(key) = event::read()?
-            && key.kind == KeyEventKind::Press
-            && let Some(intent) = input::map_key(key)
-        {
-            let fx = controller.handle(intent);
-            if fx.clear {
-                // An external program (an editor) drew over the screen, so force a full
-                // repaint: `terminal.clear()` resets ratatui's back buffer so the next draw
-                // rewrites every cell (a plain redraw would only diff against the stale
-                // buffer and skip cells). `clear()` first issues a cursor-position (DSR)
-                // query to preserve the cursor; a real interactive terminal answers it, so
-                // this succeeds and the repaint is full. We make it best-effort because a
-                // terminal that never answers (e.g. a headless/test pty) must not crash the
-                // viewer — there the repaint is skipped and the pane may stay stale until the
-                // next change, which is strictly better than aborting (constitution: the loop
-                // never crashes). The e2e editor test exercises exactly this failure path.
-                let _ = terminal.clear();
-                dirty = true;
+        if event::poll(TICK)? {
+            match event::read()? {
+                Event::Key(key)
+                    if key.kind == KeyEventKind::Press
+                        && let Some(intent) = input::map_key(key) =>
+                {
+                    let fx = controller.handle(intent);
+                    if fx.clear {
+                        // An external program (an editor) drew over the screen, so force a
+                        // full repaint: `terminal.clear()` resets ratatui's back buffer so the
+                        // next draw rewrites every cell (a plain redraw would only diff against
+                        // the stale buffer and skip cells). `clear()` first issues a cursor-
+                        // position (DSR) query to preserve the cursor; a real interactive
+                        // terminal answers it, so this succeeds and the repaint is full. We
+                        // make it best-effort because a terminal that never answers (e.g. a
+                        // headless/test pty) must not crash the viewer — there the repaint is
+                        // skipped and the pane may stay stale until the next change, which is
+                        // strictly better than aborting (constitution: the loop never crashes).
+                        // The e2e editor test exercises exactly this failure path.
+                        let _ = terminal.clear();
+                        dirty = true;
+                    }
+                    if fx.quit {
+                        return Ok(());
+                    }
+                    dirty |= fx.redraw;
+                }
+                // The pane was resized: redraw so the two-column layout and content reflow to
+                // the new geometry. `terminal.draw` autoresizes its buffers before drawing, so
+                // marking the frame dirty is enough.
+                Event::Resize(_, _) => dirty = true,
+                _ => {}
             }
-            if fx.quit {
-                return Ok(());
-            }
-            dirty |= fx.redraw;
         }
         // A render finished by the worker becomes visible on the next draw (AC-23).
         if let Some(fx) = controller.poll() {
@@ -226,16 +238,56 @@ fn resume_tui() -> io::Result<()> {
 /// detection.
 fn default_renderers() -> Renderers {
     Renderers {
-        markdown: vec!["glow".into(), "-".into()],
+        // `-s dark` forces a concrete glamour style (glow's default `auto` downgrades to the
+        // plain "notty" renderer when stdout is a pipe — as the viewer always captures it —
+        // leaving `#`, `**`, etc. as literal text). `-w 0` disables glow's own wrapping/line-
+        // padding: otherwise it pads every line to 80 cols, and in a narrower pane the trailing
+        // padding wraps to a blank row after each line ("gaps"). With `-w 0` the Presenter's
+        // own wrap reflows the text to the actual pane width.
+        markdown: vec!["glow".into(), "-s".into(), "dark".into(), "-w".into(), "0".into(), "-".into()],
+        // delta already colorizes piped output (its default), and has no `--color=always` flag.
         diff: vec!["delta".into()],
         syntax: vec![
             "bat".into(),
             "--color=always".into(),
-            "--style=plain".into(),
+            // `numbers` shows a line-number gutter (still shown when piped, given --color).
+            "--style=numbers".into(),
             "--paging=never".into(),
             "--file-name={name}".into(),
             "-".into(),
         ],
         timeout: RENDER_TIMEOUT,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn markdown_renderer_forces_a_concrete_glow_style() {
+        // Regression: glow's default `auto` style degrades to the plain "notty" renderer when
+        // stdout is a pipe (as the viewer always captures it), leaving literal `#`/`**`. A
+        // concrete style must be forced or markdown renders as near-raw text.
+        let r = default_renderers();
+        assert!(r.markdown.iter().any(|a| a == "-s"), "glow style flag present: {:?}", r.markdown);
+        assert!(r.markdown.iter().any(|a| a == "dark"), "a concrete style is named: {:?}", r.markdown);
+        // `-w 0` must follow `-w`: it disables glow's line-padding that otherwise wraps to
+        // blank-row gaps in a narrow pane.
+        let w = r.markdown.iter().position(|a| a == "-w");
+        assert!(
+            w.is_some_and(|i| r.markdown.get(i + 1).is_some_and(|v| v == "0")),
+            "glow width disabled with `-w 0`: {:?}",
+            r.markdown
+        );
+    }
+
+    #[test]
+    fn syntax_renderer_forces_color_and_line_numbers() {
+        // bat, like glow, must be told to colorize since its output is piped, not a TTY; and
+        // `--style=numbers` shows the line-number gutter the viewer wants for code.
+        let r = default_renderers();
+        assert!(r.syntax.iter().any(|a| a == "--color=always"), "bat color forced: {:?}", r.syntax);
+        assert!(r.syntax.iter().any(|a| a == "--style=numbers"), "bat line numbers: {:?}", r.syntax);
     }
 }

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -19,7 +19,7 @@
 use crate::git::{Baseline, Status};
 use crate::intent::Intent;
 use crate::presenter::{Focus, ViewState};
-use crate::tree::{NodeKind, TreeModel};
+use crate::tree::{Node, NodeKind, TreeModel};
 use crate::view_policy::{FileDescriptor, ViewMode, applicable_modes, default_mode};
 use ratatui::text::Text;
 use std::collections::{BTreeMap, HashMap};
@@ -288,8 +288,15 @@ impl Controller {
     /// Record the content viewport `(width, height)` the Presenter last drew into, so content
     /// scrolling can be clamped to it. Called by the run loop after each draw.
     pub fn set_content_viewport(&mut self, width: u16, height: u16) {
+        if width == self.content_width && height == self.content_height {
+            return; // unchanged — avoid recomputing the clamp on every (mostly idle) draw
+        }
         self.content_width = width;
         self.content_height = height;
+        // A smaller viewport shrinks the max offset, so an existing scroll could now point past
+        // the end, leaving blank space; re-clamp both axes to the new geometry.
+        self.content_scroll = self.content_scroll.min(self.max_content_scroll());
+        self.content_hscroll = self.content_hscroll.min(self.max_content_hscroll());
     }
 
     /// The content scroll offset (lines). Exposed for the Presenter wiring and tests.
@@ -301,27 +308,39 @@ impl Controller {
     /// the current content and notices, focus, and the observed width (the narrow-split
     /// input, AC-21).
     pub fn view_state(&self) -> ViewState {
+        // Build the visible node list once and read the selection from it, rather than calling
+        // `tree.selected()` (which re-runs the gitignore-aware filesystem walk) a second time
+        // for the wrap decision — `visible_nodes()` is the hot, per-frame path.
+        let nodes = self.tree.visible_nodes();
+        let selected = self.tree.cursor();
+        let wrap = self.wrap_for(nodes.get(selected));
         ViewState {
-            nodes: self.tree.visible_nodes(),
-            selected: self.tree.cursor(),
+            nodes,
+            selected,
             content: self.content.clone(),
             notices: self.notices(),
             focus: self.focus,
             width: self.width,
             content_scroll: self.content_scroll,
             content_hscroll: self.content_hscroll,
-            wrap: self.effective_wrap(),
+            wrap,
             split_pct: self.split_pct,
         }
     }
 
-    /// Whether the content pane should wrap long lines: yes for prose (rendered markdown and
-    /// plain text), no for diffs and code, whose column alignment must be preserved.
-    fn wrap_content(&self) -> bool {
-        matches!(
-            self.selected_view_mode(),
-            Some(ViewMode::RenderedMarkdown | ViewMode::RawContent)
-        )
+    /// Whether the content pane wraps for `node`: forced on by the `w` override, else the
+    /// per-mode default — prose (rendered markdown / plain text) wraps; diffs and code stay
+    /// unwrapped so their columns align. Takes the node so the draw path needn't re-walk.
+    fn wrap_for(&self, node: Option<&Node>) -> bool {
+        if self.wrap_override {
+            return true;
+        }
+        match node {
+            Some(n) if n.kind == NodeKind::File => {
+                matches!(self.effective_mode(&n.path), ViewMode::RenderedMarkdown | ViewMode::RawContent)
+            }
+            _ => false,
+        }
     }
 
     // ---- intent handling ---------------------------------------------------------------
@@ -380,14 +399,18 @@ impl Controller {
         self.rendered_line_count().saturating_sub(self.content_height)
     }
 
-    /// How many lines the content occupies once laid out. Without wrapping each source line
-    /// is one row; with wrapping a line spans `ceil(width / viewport_width)` rows — estimated
-    /// from each line's display width (matches ratatui's per-wrapped-line scrolling).
+    /// How many lines the content occupies once laid out. Without wrapping each source line is
+    /// one row; with wrapping a line spans roughly `width / viewport_width` rows. ratatui wraps
+    /// at word boundaries, which can leave a partial row that `ceil` undercounts — making the
+    /// bottom of wrapped prose unreachable — so we use `floor(width / w) + 1` per line, a tight
+    /// upper bound (exact for lines that fit; at most one row generous), so the last line is
+    /// always reachable. Over-shooting only risks a little blank space, which ratatui renders
+    /// harmlessly; undershooting would hide content.
     fn rendered_line_count(&self) -> u16 {
         let lines = &self.content.lines;
         let count = if self.effective_wrap() {
             let w = self.content_width.max(1) as usize;
-            lines.iter().map(|l| l.width().max(1).div_ceil(w)).sum::<usize>()
+            lines.iter().map(|l| l.width() / w + 1).sum::<usize>()
         } else {
             lines.len()
         };
@@ -543,10 +566,11 @@ impl Controller {
         Effects::redraw()
     }
 
-    /// Whether the content pane wraps right now: the per-mode default (prose wraps, code/diffs
-    /// don't), unless the user has forced wrap on with the `w` toggle.
+    /// Whether the content pane wraps the current selection (the `w` override or the per-mode
+    /// default). Off the per-frame path — the scroll-clamp helpers call it on a keypress —
+    /// so resolving the selected node via `tree.selected()` here is fine.
     fn effective_wrap(&self) -> bool {
-        self.wrap_override || self.wrap_content()
+        self.wrap_for(self.tree.selected().as_ref())
     }
 
     /// Re-query git for the working-tree status (tree markers, AC-7) and the changed-set

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -28,6 +28,16 @@ use std::panic::AssertUnwindSafe;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, mpsc};
 
+/// Tree-column width as a percentage of the pane: its default and the bounds the resize keys
+/// clamp to, so neither column can be squeezed to nothing.
+const SPLIT_DEFAULT: u16 = 40;
+const SPLIT_MIN: u16 = 20;
+const SPLIT_MAX: u16 = 80;
+/// How many percentage points one resize keypress moves the divider.
+const SPLIT_STEP: u16 = 5;
+/// How many columns one horizontal-scroll keypress moves the content pane.
+const HSCROLL_STEP: u16 = 8;
+
 /// Read-only git queries the controller coordinates. Behind a trait so tests stub it and
 /// the run loop injects an implementation bound to the real repository. `Send + Sync` so the
 /// diff query can run on the render worker thread, off the input path (AC-23).
@@ -117,6 +127,22 @@ pub struct Controller {
     /// The pane width the run loop last observed (session state for the narrow-split flag,
     /// AC-21); the Presenter still lays out from the live frame, never this.
     width: u16,
+    /// Vertical scroll offset of the content pane, in lines. Reset to the top whenever a new
+    /// render is dispatched (a new file / mode / baseline).
+    content_scroll: u16,
+    /// Horizontal scroll offset of the content pane, in columns (only used when not wrapping).
+    /// Reset to the left edge on a new render.
+    content_hscroll: u16,
+    /// The content viewport `(width, height)` the Presenter last drew into. Used to clamp
+    /// `content_scroll` so the user cannot scroll past the last screenful.
+    content_width: u16,
+    content_height: u16,
+    /// The tree column's share of the width, as a percentage (the rest is the content pane).
+    /// Adjustable from the keyboard since the viewer owns both columns (ADR-0002).
+    split_pct: u16,
+    /// User override forcing content wrap on regardless of view mode (the `w` toggle), so long
+    /// lines in code/diffs can be wrapped on demand. `false` ⇒ the per-mode default applies.
+    wrap_override: bool,
     tree: TreeModel,
     /// Changed-set vs the active baseline, cached; recomputed on a baseline toggle (AC-16).
     changed: BTreeMap<PathBuf, Status>,
@@ -190,6 +216,12 @@ impl Controller {
             changed_only: false,
             focus: Focus::Tree,
             width: 0,
+            content_scroll: 0,
+            content_hscroll: 0,
+            content_width: 0,
+            content_height: 0,
+            split_pct: SPLIT_DEFAULT,
+            wrap_override: false,
             changed: BTreeMap::new(),
             overrides: HashMap::new(),
             content: Text::raw(""),
@@ -253,6 +285,18 @@ impl Controller {
         self.width = width;
     }
 
+    /// Record the content viewport `(width, height)` the Presenter last drew into, so content
+    /// scrolling can be clamped to it. Called by the run loop after each draw.
+    pub fn set_content_viewport(&mut self, width: u16, height: u16) {
+        self.content_width = width;
+        self.content_height = height;
+    }
+
+    /// The content scroll offset (lines). Exposed for the Presenter wiring and tests.
+    pub fn content_scroll(&self) -> u16 {
+        self.content_scroll
+    }
+
     /// Assemble the [`ViewState`] the Presenter draws from: the visible tree rows + cursor,
     /// the current content and notices, focus, and the observed width (the narrow-split
     /// input, AC-21).
@@ -264,7 +308,20 @@ impl Controller {
             notices: self.notices(),
             focus: self.focus,
             width: self.width,
+            content_scroll: self.content_scroll,
+            content_hscroll: self.content_hscroll,
+            wrap: self.effective_wrap(),
+            split_pct: self.split_pct,
         }
+    }
+
+    /// Whether the content pane should wrap long lines: yes for prose (rendered markdown and
+    /// plain text), no for diffs and code, whose column alignment must be preserved.
+    fn wrap_content(&self) -> bool {
+        matches!(
+            self.selected_view_mode(),
+            Some(ViewMode::RenderedMarkdown | ViewMode::RawContent)
+        )
     }
 
     // ---- intent handling ---------------------------------------------------------------
@@ -285,17 +342,82 @@ impl Controller {
             Intent::CycleView => self.cycle_view(),
             Intent::OpenInEditor => self.open_in_editor(),
             Intent::ToggleFocus => self.toggle_focus(),
+            Intent::ShrinkTree => self.resize_split(-(SPLIT_STEP as i16)),
+            Intent::GrowTree => self.resize_split(SPLIT_STEP as i16),
+            Intent::ToggleWrap => self.toggle_wrap(),
             Intent::Close => Effects { quit: true, ..Default::default() },
         }
     }
 
+    /// Up/down navigation is focus-aware: it moves the tree cursor when the tree is focused
+    /// (selecting a file, which re-renders the content), and scrolls the content pane when the
+    /// content is focused (`Tab` switches focus). This reads each pane's natural keys without
+    /// adding a separate scroll intent.
     fn navigate(&mut self, delta: isize) -> Effects {
-        self.tree.move_cursor(delta);
-        self.dispatch_render();
+        match self.focus {
+            Focus::Content => {
+                self.scroll_content(delta);
+                Effects::redraw()
+            }
+            Focus::Tree => {
+                self.tree.move_cursor(delta);
+                self.dispatch_render(); // new selection → re-render (and reset the scroll)
+                Effects::redraw()
+            }
+        }
+    }
+
+    /// Scroll the content pane by `delta` lines, clamped to `[0, max]` so it can never run
+    /// above the first line or past the last screenful.
+    fn scroll_content(&mut self, delta: isize) {
+        let max = self.max_content_scroll() as isize;
+        let next = (self.content_scroll as isize + delta).clamp(0, max);
+        self.content_scroll = next as u16;
+    }
+
+    /// The largest valid scroll offset: total rendered lines minus the viewport height.
+    fn max_content_scroll(&self) -> u16 {
+        self.rendered_line_count().saturating_sub(self.content_height)
+    }
+
+    /// How many lines the content occupies once laid out. Without wrapping each source line
+    /// is one row; with wrapping a line spans `ceil(width / viewport_width)` rows — estimated
+    /// from each line's display width (matches ratatui's per-wrapped-line scrolling).
+    fn rendered_line_count(&self) -> u16 {
+        let lines = &self.content.lines;
+        let count = if self.effective_wrap() {
+            let w = self.content_width.max(1) as usize;
+            lines.iter().map(|l| l.width().max(1).div_ceil(w)).sum::<usize>()
+        } else {
+            lines.len()
+        };
+        count.min(u16::MAX as usize) as u16
+    }
+
+    /// Scroll the content pane horizontally by `delta` columns, clamped to `[0, max]`.
+    fn scroll_content_h(&mut self, delta: i32) -> Effects {
+        let max = self.max_content_hscroll() as i32;
+        let next = (self.content_hscroll as i32 + delta).clamp(0, max);
+        self.content_hscroll = next as u16;
         Effects::redraw()
     }
 
+    /// The largest valid horizontal offset: the widest content line minus the viewport width.
+    /// Zero while wrapping (no line overflows the pane, so there is nothing to scroll past).
+    fn max_content_hscroll(&self) -> u16 {
+        if self.effective_wrap() {
+            return 0;
+        }
+        let widest = self.content.lines.iter().map(|l| l.width()).max().unwrap_or(0);
+        (widest.min(u16::MAX as usize) as u16).saturating_sub(self.content_width)
+    }
+
+    /// Right (→/l): expand the selected directory when the tree is focused, or scroll the
+    /// content pane right when it is focused (so long unwrapped lines can be read).
     fn expand(&mut self) -> Effects {
+        if self.focus == Focus::Content {
+            return self.scroll_content_h(HSCROLL_STEP as i32);
+        }
         if let Some(node) = self.tree.selected()
             && node.kind == NodeKind::Dir
         {
@@ -305,7 +427,12 @@ impl Controller {
         Effects::noop()
     }
 
+    /// Left (←/h): collapse the selected directory when the tree is focused, or scroll the
+    /// content pane left when it is focused.
     fn collapse(&mut self) -> Effects {
+        if self.focus == Focus::Content {
+            return self.scroll_content_h(-(HSCROLL_STEP as i32));
+        }
         if let Some(node) = self.tree.selected()
             && node.kind == NodeKind::Dir
         {
@@ -397,6 +524,31 @@ impl Controller {
         Effects::redraw()
     }
 
+    /// Move the tree/content divider by `delta` percentage points, clamped so neither column
+    /// can collapse. Pure layout state — no re-render is needed (the content is unchanged).
+    fn resize_split(&mut self, delta: i16) -> Effects {
+        let next = (self.split_pct as i16 + delta).clamp(SPLIT_MIN as i16, SPLIT_MAX as i16);
+        self.split_pct = next as u16;
+        Effects::redraw()
+    }
+
+    /// Flip the content-wrap override. Pure layout state — the content text is unchanged, only
+    /// how the Presenter lays it out; the scroll clamp recomputes from the new wrap.
+    fn toggle_wrap(&mut self) -> Effects {
+        self.wrap_override = !self.wrap_override;
+        // Wrapping changes the content's layout, so re-clamp both offsets: vertical to the new
+        // line count, and horizontal to zero while wrapped (no line overflows the pane).
+        self.content_scroll = self.content_scroll.min(self.max_content_scroll());
+        self.content_hscroll = self.content_hscroll.min(self.max_content_hscroll());
+        Effects::redraw()
+    }
+
+    /// Whether the content pane wraps right now: the per-mode default (prose wraps, code/diffs
+    /// don't), unless the user has forced wrap on with the `w` toggle.
+    fn effective_wrap(&self) -> bool {
+        self.wrap_override || self.wrap_content()
+    }
+
     /// Re-query git for the working-tree status (tree markers, AC-7) and the changed-set
     /// against the active baseline (AC-16), updating the tree caches. Used at launch and
     /// after an editor hand-off returns (the file may have changed). No-op without a repo
@@ -423,6 +575,10 @@ impl Controller {
     fn dispatch_render(&mut self) {
         self.latest_seq += 1;
         let seq = self.latest_seq;
+        // A fresh render means new content — start it at the top-left, never inheriting the
+        // previous file's scroll offsets.
+        self.content_scroll = 0;
+        self.content_hscroll = 0;
 
         let Some(node) = self.tree.selected() else { return self.clear_content() };
         if node.kind != NodeKind::File {

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -399,20 +399,27 @@ impl Controller {
         self.rendered_line_count().saturating_sub(self.content_height)
     }
 
-    /// How many lines the content occupies once laid out. Without wrapping each source line is
-    /// one row; with wrapping a line spans roughly `width / viewport_width` rows. ratatui wraps
-    /// at word boundaries, which can leave a partial row that `ceil` undercounts — making the
-    /// bottom of wrapped prose unreachable — so we use `floor(width / w) + 1` per line, a tight
-    /// upper bound (exact for lines that fit; at most one row generous), so the last line is
-    /// always reachable. Over-shooting only risks a little blank space, which ratatui renders
-    /// harmlessly; undershooting would hide content.
+    /// How many rows the content occupies once laid out, so the vertical scroll clamps to the
+    /// real last row. Without wrapping each source line is one (truncated) row. With wrapping a
+    /// line spans multiple rows: ratatui's exact `line_count` is private, and an arithmetic
+    /// `ceil`/`floor` undercounts word wrapping (words don't pack to the column), which would
+    /// leave the bottom of wrapped prose unreachable — so [`wrapped_rows`] simulates the word
+    /// packing, floored by the all-columns char-wrap count so leading/interior spaces can't
+    /// make it undershoot. Off the per-frame path: only scroll / resize / wrap-toggle keypaths
+    /// reach it (`set_content_viewport` early-returns on an unchanged size).
     fn rendered_line_count(&self) -> u16 {
-        let lines = &self.content.lines;
         let count = if self.effective_wrap() {
             let w = self.content_width.max(1) as usize;
-            lines.iter().map(|l| l.width() / w + 1).sum::<usize>()
+            self.content
+                .lines
+                .iter()
+                .map(|l| {
+                    let text: String = l.spans.iter().map(|s| s.content.as_ref()).collect();
+                    wrapped_rows(&text, w).max(l.width().max(1).div_ceil(w))
+                })
+                .sum::<usize>()
         } else {
-            lines.len()
+            self.content.lines.len()
         };
         count.min(u16::MAX as usize) as u16
     }
@@ -678,4 +685,56 @@ fn is_markdown(path: &Path) -> bool {
         .and_then(|e| e.to_str())
         .map(|e| e.eq_ignore_ascii_case("md") || e.eq_ignore_ascii_case("markdown"))
         .unwrap_or(false)
+}
+
+/// How many rows one rendered line occupies under ratatui's word wrapper (`Wrap{trim:false}`)
+/// at `width` columns: greedy word packing — fill the row with space-separated words until the
+/// next one doesn't fit, then wrap; a word wider than the row is broken across rows. A plain
+/// `ceil(width/col)` undercounts this (words rarely pack flush to the column), which is what
+/// would make the bottom of wrapped prose unreachable via the scroll clamp. Char counts stand
+/// in for display width — close enough for the clamp, and the caller floors with the
+/// all-columns char-wrap so it never undershoots.
+fn wrapped_rows(text: &str, width: usize) -> usize {
+    if width == 0 {
+        return 1;
+    }
+    let mut rows = 1usize;
+    let mut col = 0usize;
+    for (i, word) in text.split(' ').enumerate() {
+        let wl = word.chars().count();
+        let sep = usize::from(i > 0);
+        if col != 0 && col + sep + wl > width {
+            rows += 1; // doesn't fit → start a new row
+            col = 0;
+        }
+        if col == 0 {
+            // word starts a fresh row; a word wider than the row breaks across full rows
+            let extra = wl.saturating_sub(1) / width;
+            rows += extra;
+            col = wl - extra * width;
+        } else {
+            col += sep + wl;
+        }
+    }
+    rows
+}
+
+#[cfg(test)]
+mod tests {
+    use super::wrapped_rows;
+
+    #[test]
+    fn wrapped_rows_counts_word_wrapping_not_just_char_wrapping() {
+        // Four width-6 words in a 10-col pane pack one per row → 4 rows, even though the
+        // 27-column line char-wraps to only 3. The scroll clamp must use the larger count.
+        assert_eq!(wrapped_rows("aaaaaa aaaaaa aaaaaa aaaaaa", 10), 4);
+        // A single over-long word is broken like char wrapping.
+        assert_eq!(wrapped_rows(&"x".repeat(100), 25), 4);
+        // Words that pack flush share rows.
+        assert_eq!(wrapped_rows("ab cd ef", 8), 1); // "ab cd ef" = 8 cols, fits exactly
+        // Short / empty / zero-width are one row.
+        assert_eq!(wrapped_rows("hello", 80), 1);
+        assert_eq!(wrapped_rows("", 80), 1);
+        assert_eq!(wrapped_rows("anything", 0), 1);
+    }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -10,10 +10,11 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 /// Decode a key event into an [`Intent`], or `None` if the key is unbound.
 ///
-/// Char bindings require an empty modifier set so reserved chords (e.g. Ctrl+C) stay clear
-/// of the viewer's actions; the dedicated keys (arrows, Tab, Esc) likewise fire unmodified.
+/// Control-style chords (Ctrl/Alt/Super/…) never fire an intent so reserved combos (e.g.
+/// Ctrl+C) stay clear; Shift is allowed, because shifted characters (`<` / `>`) are ordinary
+/// typing — not a chord — and some terminals report them with the Shift bit set.
 pub fn map_key(key: KeyEvent) -> Option<Intent> {
-    if key.modifiers != KeyModifiers::NONE {
+    if key.modifiers.difference(KeyModifiers::SHIFT) != KeyModifiers::NONE {
         return None;
     }
     match key.code {
@@ -27,6 +28,9 @@ pub fn map_key(key: KeyEvent) -> Option<Intent> {
         KeyCode::Char('v') => Some(Intent::CycleView),
         KeyCode::Char('e') => Some(Intent::OpenInEditor),
         KeyCode::Tab => Some(Intent::ToggleFocus),
+        KeyCode::Char('<') => Some(Intent::ShrinkTree),
+        KeyCode::Char('>') => Some(Intent::GrowTree),
+        KeyCode::Char('w') => Some(Intent::ToggleWrap),
         KeyCode::Char('q') | KeyCode::Esc => Some(Intent::Close),
         _ => None,
     }
@@ -57,6 +61,9 @@ mod tests {
         (KeyCode::Char('v'), Intent::CycleView),
         (KeyCode::Char('e'), Intent::OpenInEditor),
         (KeyCode::Tab, Intent::ToggleFocus),
+        (KeyCode::Char('<'), Intent::ShrinkTree),
+        (KeyCode::Char('>'), Intent::GrowTree),
+        (KeyCode::Char('w'), Intent::ToggleWrap),
         (KeyCode::Char('q'), Intent::Close),
         (KeyCode::Esc, Intent::Close),
     ];
@@ -93,5 +100,20 @@ mod tests {
         assert_eq!(map_key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL)), None);
         assert_eq!(map_key(KeyEvent::new(KeyCode::Char('e'), KeyModifiers::ALT)), None);
         assert_eq!(map_key(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::CONTROL)), None);
+    }
+
+    #[test]
+    fn shift_is_allowed_for_shifted_characters() {
+        // '<' / '>' are typed with Shift; the resize keys must fire whether or not the
+        // terminal reports the Shift bit — but a Ctrl chord on the same key must not.
+        assert_eq!(
+            map_key(KeyEvent::new(KeyCode::Char('<'), KeyModifiers::SHIFT)),
+            Some(Intent::ShrinkTree)
+        );
+        assert_eq!(
+            map_key(KeyEvent::new(KeyCode::Char('>'), KeyModifiers::NONE)),
+            Some(Intent::GrowTree)
+        );
+        assert_eq!(map_key(KeyEvent::new(KeyCode::Char('<'), KeyModifiers::CONTROL)), None);
     }
 }

--- a/src/intent.rs
+++ b/src/intent.rs
@@ -28,6 +28,13 @@ pub enum Intent {
     OpenInEditor,
     /// Move focus between the tree and content columns (AC-21).
     ToggleFocus,
+    /// Narrow the tree column (move the tree/content divider left).
+    ShrinkTree,
+    /// Widen the tree column (move the tree/content divider right).
+    GrowTree,
+    /// Force content-line wrapping on/off, overriding the per-mode default (so long lines in
+    /// code and diffs can be wrapped on demand instead of truncated).
+    ToggleWrap,
     /// Close the viewer and return control to the prior pane (AC-20).
     Close,
 }
@@ -35,7 +42,7 @@ pub enum Intent {
 impl Intent {
     /// Every intent variant — lets the dispatcher and tests enumerate the closed set so
     /// keyboard-completeness (AC-18) and the no-edit invariant (AC-N3) stay checkable.
-    pub const ALL: [Intent; 11] = [
+    pub const ALL: [Intent; 14] = [
         Intent::NavUp,
         Intent::NavDown,
         Intent::Expand,
@@ -46,6 +53,9 @@ impl Intent {
         Intent::CycleView,
         Intent::OpenInEditor,
         Intent::ToggleFocus,
+        Intent::ShrinkTree,
+        Intent::GrowTree,
+        Intent::ToggleWrap,
         Intent::Close,
     ];
 }
@@ -73,6 +83,9 @@ mod tests {
                 | Intent::CycleView
                 | Intent::OpenInEditor
                 | Intent::ToggleFocus
+                | Intent::ShrinkTree
+                | Intent::GrowTree
+                | Intent::ToggleWrap
                 | Intent::Close => false,
             };
             assert!(!mutates_file, "{intent:?} must not mutate file contents (AC-N3)");

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -13,7 +13,7 @@ use ratatui::Frame;
 use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span, Text};
-use ratatui::widgets::{Block, Paragraph};
+use ratatui::widgets::{Block, Paragraph, Wrap};
 
 /// Which column currently has keyboard focus.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -41,6 +41,18 @@ pub struct ViewState {
     /// narrow-split flag). The Presenter lays out from the live frame width, not this, so
     /// the two can never disagree; it is carried for the controller's own use.
     pub width: u16,
+    /// Vertical scroll offset of the content pane, in lines (wrapped lines when `wrap`,
+    /// raw lines otherwise — matching ratatui's `Paragraph::scroll` semantics).
+    pub content_scroll: u16,
+    /// Horizontal scroll offset of the content pane, in columns. Only meaningful when not
+    /// wrapping (ratatui ignores it under wrap); lets long code/diff lines be read sideways.
+    pub content_hscroll: u16,
+    /// Wrap long content lines (prose: markdown / plain text) instead of truncating them.
+    /// Off for diffs and code, whose column alignment must be preserved.
+    pub wrap: bool,
+    /// The tree column's share of the width, as a percentage (the content pane takes the
+    /// rest). Adjustable from the keyboard; used only in the wide two-column layout.
+    pub split_pct: u16,
 }
 
 /// The single-character git-status marker shown beside a tree row (AC-7).
@@ -71,8 +83,23 @@ fn node_name(node: &Node) -> String {
         .unwrap_or_else(|| node.path.to_string_lossy().into_owned())
 }
 
+/// The status color for a tree row: changes (modified / deleted) are light red, new files
+/// (added / untracked) light green, and a directory containing any change is light red.
+/// Clean rows take the default foreground.
+fn row_color(node: &Node) -> Option<Color> {
+    match node.kind {
+        NodeKind::Dir => node.dir_dirty.then_some(Color::LightRed),
+        NodeKind::File => match node.status {
+            Some(Status::Modified | Status::Deleted) => Some(Color::LightRed),
+            Some(Status::Added | Status::Untracked) => Some(Color::LightGreen),
+            None => None,
+        },
+    }
+}
+
 /// Render one tree row: `<marker> <indent><glyph><name>`. Indentation grows with depth so
-/// the recursion is visible (AC-3); a directory carries an expand/collapse glyph.
+/// the recursion is visible (AC-3); a directory carries an expand/collapse glyph; the row is
+/// tinted by git status (AC-7).
 fn tree_row(node: &Node, selected: bool) -> Line<'static> {
     let glyph = match node.kind {
         NodeKind::Dir if node.expanded => "▾ ",
@@ -86,11 +113,13 @@ fn tree_row(node: &Node, selected: bool) -> Line<'static> {
         glyph,
         sanitize_label(&node_name(node)),
     );
-    let style = if selected {
-        Style::new().add_modifier(Modifier::REVERSED)
-    } else {
-        Style::new()
-    };
+    let mut style = Style::new();
+    if let Some(color) = row_color(node) {
+        style = style.fg(color);
+    }
+    if selected {
+        style = style.add_modifier(Modifier::REVERSED);
+    }
     Line::from(Span::styled(text, style))
 }
 
@@ -120,8 +149,9 @@ fn draw_tree(frame: &mut Frame, area: Rect, state: &ViewState) {
     frame.render_widget(Paragraph::new(rows), inner);
 }
 
-/// Draw the right column: a notices strip (if any) above the content pane.
-fn draw_content(frame: &mut Frame, area: Rect, state: &ViewState) {
+/// Draw the right column: a notices strip (if any) above the content pane. Returns the
+/// content viewport `(width, height)` so the controller can clamp scrolling to it.
+fn draw_content(frame: &mut Frame, area: Rect, state: &ViewState) -> (u16, u16) {
     let title = state
         .nodes
         .get(state.selected)
@@ -146,31 +176,47 @@ fn draw_content(frame: &mut Frame, area: Rect, state: &ViewState) {
             .collect();
         frame.render_widget(Paragraph::new(notice_lines), parts[0]);
     }
-    frame.render_widget(Paragraph::new(state.content.clone()), parts[1]);
+    // Scroll the content vertically (AC: read a file beyond the first screenful). Wrap prose
+    // so long lines aren't clipped; keep diffs/code unwrapped to preserve their alignment.
+    let mut content =
+        Paragraph::new(state.content.clone()).scroll((state.content_scroll, state.content_hscroll));
+    if state.wrap {
+        content = content.wrap(Wrap { trim: false });
+    }
+    frame.render_widget(content, parts[1]);
+    (parts[1].width, parts[1].height)
 }
 
 /// Below this pane width the viewer drops to a single, focused column (AC-21).
 const NARROW_SPLIT: u16 = 80;
 
-/// Draw the viewer for the given state.
+/// Draw the viewer for the given state, returning the content viewport `(width, height)`
+/// the content pane was drawn into — `(0, 0)` when the content pane is not visible (narrow
+/// layout with the tree focused). The controller uses it to clamp content scrolling.
 ///
 /// At ≥ 80 columns both columns are shown side by side. Narrower than that, only the
 /// focused column is drawn — full width — so the active content stays readable (AC-21).
 /// The decision is taken from the **live frame width**, so the split can never disagree
 /// with the geometry it is drawn into (a stale `state.width` cannot desync the layout).
-pub fn draw(frame: &mut Frame, state: &ViewState) {
+pub fn draw(frame: &mut Frame, state: &ViewState) -> (u16, u16) {
     let area = frame.area();
     if area.width < NARROW_SPLIT {
-        match state.focus {
-            Focus::Tree => draw_tree(frame, area, state),
+        return match state.focus {
+            Focus::Tree => {
+                draw_tree(frame, area, state);
+                (0, 0)
+            }
             Focus::Content => draw_content(frame, area, state),
-        }
-        return;
+        };
     }
-    let cols =
-        Layout::horizontal([Constraint::Percentage(40), Constraint::Percentage(60)]).split(area);
+    let tree_pct = state.split_pct.clamp(10, 90);
+    let cols = Layout::horizontal([
+        Constraint::Percentage(tree_pct),
+        Constraint::Percentage(100 - tree_pct),
+    ])
+    .split(area);
     draw_tree(frame, cols[0], state);
-    draw_content(frame, cols[1], state);
+    draw_content(frame, cols[1], state)
 }
 
 #[cfg(test)]

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -24,6 +24,9 @@ pub struct Node {
     pub depth: usize,
     pub expanded: bool,
     pub status: Option<Status>,
+    /// For a directory: whether any file under it has a git status (so the Presenter can
+    /// color a folder that contains changes). Always `false` for files.
+    pub dir_dirty: bool,
 }
 
 /// Order tree entries: directories first, then files; alphabetical within each group.
@@ -106,12 +109,14 @@ impl TreeModel {
     fn collect(&self, dir: &Path, depth: usize, out: &mut Vec<Node>) {
         for (path, kind) in self.entries(dir) {
             let expanded = kind == NodeKind::Dir && self.expanded.contains(&path);
+            let dir_dirty = kind == NodeKind::Dir && self.dir_contains_change(&path);
             out.push(Node {
                 path: path.clone(),
                 kind,
                 depth,
                 expanded,
                 status: self.status_for(&path),
+                dir_dirty,
             });
             if expanded {
                 self.collect(&path, depth + 1, out);
@@ -161,6 +166,7 @@ impl TreeModel {
                 depth,
                 expanded: true,
                 status: self.status_for(&abs),
+                dir_dirty: self.dir_contains_change(&abs),
             });
             self.emit_synthetic(d, depth + 1, dirs, files, out);
         }
@@ -172,6 +178,7 @@ impl TreeModel {
                 depth,
                 expanded: false,
                 status: self.status_for(&abs),
+                dir_dirty: false,
             });
         }
     }
@@ -185,6 +192,17 @@ impl TreeModel {
                 .or_else(|| self.changed_filter.get(rel))
                 .copied()
         })
+    }
+
+    /// Whether any tracked change lives under directory `path` — used to color a folder that
+    /// contains changes (AC-7). Component-wise prefix match, so `src` is not matched by
+    /// `src2/…`; excludes the directory's own path.
+    fn dir_contains_change(&self, path: &Path) -> bool {
+        let Ok(rel) = path.strip_prefix(&self.root) else { return false };
+        self.markers
+            .keys()
+            .chain(self.changed_filter.keys())
+            .any(|k| k != rel && k.starts_with(rel))
     }
 
     /// Immediate children of `dir`: gitignore-filtered (unless `show_ignored`), `.git`

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -457,6 +457,54 @@ fn left_right_scroll_the_content_horizontally_when_focused_and_unwrapped() {
 }
 
 #[test]
+fn wrapped_content_scrolls_vertically_to_the_bottom_and_not_horizontally() {
+    // With wrap on (a markdown file), the vertical clamp must count WRAPPED rows so the bottom
+    // of long prose is reachable (regression: a ceil estimate undercounted word-wrap), and
+    // horizontal scrolling is inert (nothing overflows the pane when wrapped).
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.md"), "# x\n").unwrap(); // markdown → wraps by default
+    let components = Components {
+        git: Arc::new(StubGit::default()),
+        content: Box::new(WideContent), // 5 lines × 100 columns
+        editor: Box::new(StubEditor { fail: false, opened: Arc::new(Mutex::new(Vec::new())) }),
+    };
+    let mut ctrl = Controller::new(dir.path().to_path_buf(), false, Baseline::Head, components);
+    await_marker(&mut ctrl, "WIDE");
+    ctrl.set_content_viewport(25, 10); // 5 lines × (100/25 + 1)=5 rows = 25 wrapped rows; max ≥ 15
+    assert!(ctrl.view_state().wrap, "a .md file wraps");
+
+    ctrl.handle(Intent::ToggleFocus); // focus content
+    for _ in 0..500 {
+        ctrl.handle(Intent::NavDown);
+    }
+    let vmax = ctrl.view_state().content_scroll;
+    assert!(vmax >= 15, "wrapped rows are counted so the bottom is reachable (got {vmax})");
+
+    let h_before = ctrl.view_state().content_hscroll;
+    ctrl.handle(Intent::Expand); // → : would scroll right, but wrap leaves nothing to scroll past
+    assert_eq!(ctrl.view_state().content_hscroll, h_before, "no horizontal scroll while wrapping");
+}
+
+#[test]
+fn shrinking_the_viewport_reclamps_an_existing_scroll_offset() {
+    // Resizing the pane smaller lowers the max scroll; an existing offset must be re-clamped
+    // so it never points past the end (which would leave blank space below the content).
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.txt"), "x\n").unwrap();
+    let mut ctrl = controller_with_lines(dir.path(), 50);
+    await_marker(&mut ctrl, "L0");
+    ctrl.set_content_viewport(40, 10); // 50 lines, 10 tall → max 40
+    ctrl.handle(Intent::ToggleFocus);
+    for _ in 0..200 {
+        ctrl.handle(Intent::NavDown);
+    }
+    assert_eq!(ctrl.view_state().content_scroll, 40, "scrolled to the bottom");
+
+    ctrl.set_content_viewport(40, 30); // taller viewport → max 20; the offset must re-clamp
+    assert_eq!(ctrl.view_state().content_scroll, 20, "offset re-clamped to the new, smaller max");
+}
+
+#[test]
 fn resize_intents_move_the_tree_content_divider_and_clamp() {
     // The tree/content split is adjustable from the keyboard (the viewer owns both columns,
     // so herdr's pane-resize can't move this internal divider).

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -470,15 +470,17 @@ fn wrapped_content_scrolls_vertically_to_the_bottom_and_not_horizontally() {
     };
     let mut ctrl = Controller::new(dir.path().to_path_buf(), false, Baseline::Head, components);
     await_marker(&mut ctrl, "WIDE");
-    ctrl.set_content_viewport(25, 10); // 5 lines × (100/25 + 1)=5 rows = 25 wrapped rows; max ≥ 15
+    ctrl.set_content_viewport(25, 10); // 5 lines × ceil(100/25)=4 = 20 wrapped rows; max = 10
     assert!(ctrl.view_state().wrap, "a .md file wraps");
 
     ctrl.handle(Intent::ToggleFocus); // focus content
     for _ in 0..500 {
         ctrl.handle(Intent::NavDown);
     }
+    // Wrapped rows (20) are counted, not raw lines (5, which would clamp to 0): the bottom is
+    // reachable. Exact count via ratatui means no over-scroll into blank past row 20.
     let vmax = ctrl.view_state().content_scroll;
-    assert!(vmax >= 15, "wrapped rows are counted so the bottom is reachable (got {vmax})");
+    assert_eq!(vmax, 10, "scrolls to exactly the last wrapped row (20 rows − 10 tall)");
 
     let h_before = ctrl.view_state().content_hscroll;
     ctrl.handle(Intent::Expand); // → : would scroll right, but wrap leaves nothing to scroll past

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -19,6 +19,7 @@ use std::collections::BTreeMap;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 /// A shared, mutable recorder the stubs append to and tests read back. `Arc<Mutex<_>>`
 /// (not `Rc<RefCell<_>>`) so the Git stub is `Send + Sync` — the controller's render worker
@@ -263,6 +264,230 @@ fn no_handled_intent_mutates_the_filesystem() {
     }
 
     assert_eq!(snapshot(dir.path()), before, "no intent mutated any file (AC-N1, AC-N3)");
+}
+
+// ---- content scrolling + wrap (focus-aware navigation) --------------------------------
+
+/// A Content Renderer stub returning a fixed number of single-token lines (`L0`..`L{n-1}`),
+/// so a test can scroll a known amount of content.
+struct LinesContent {
+    n: usize,
+}
+impl ContentProvider for LinesContent {
+    fn render(&self, _path: &Path, _mode: ViewMode, _raw_diff: Option<&str>) -> RenderResult {
+        let body = (0..self.n).map(|i| format!("L{i}")).collect::<Vec<_>>().join("\n");
+        RenderResult { content: Text::raw(body), notices: Vec::new() }
+    }
+}
+
+/// A Content Renderer stub returning five 100-column-wide lines (marker `WIDE` at the start
+/// of each), for horizontal-scroll tests.
+struct WideContent;
+impl ContentProvider for WideContent {
+    fn render(&self, _path: &Path, _mode: ViewMode, _raw_diff: Option<&str>) -> RenderResult {
+        let line = format!("WIDE{}", "x".repeat(96)); // 100 columns
+        let body = std::iter::repeat_n(line, 5).collect::<Vec<_>>().join("\n");
+        RenderResult { content: Text::raw(body), notices: Vec::new() }
+    }
+}
+
+/// Flatten the content pane to a string for assertions.
+fn flatten(t: &Text) -> String {
+    t.lines
+        .iter()
+        .map(|l| l.spans.iter().map(|s| s.content.as_ref()).collect::<String>())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Spin `poll()` until the worker's render for the current selection lands (or time out).
+fn await_marker(ctrl: &mut Controller, marker: &str) {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while !flatten(ctrl.content()).contains(marker) {
+        ctrl.poll();
+        assert!(Instant::now() < deadline, "content '{marker}' never rendered");
+        std::thread::sleep(Duration::from_millis(5));
+    }
+}
+
+/// Build a controller over `root` whose Content Renderer returns `n` lines.
+fn controller_with_lines(root: &Path, n: usize) -> Controller {
+    let components = Components {
+        git: Arc::new(StubGit::default()),
+        content: Box::new(LinesContent { n }),
+        editor: Box::new(StubEditor { fail: false, opened: Arc::new(Mutex::new(Vec::new())) }),
+    };
+    Controller::new(root.to_path_buf(), false, Baseline::Head, components)
+}
+
+#[test]
+fn nav_does_not_scroll_content_while_the_tree_is_focused() {
+    // Default focus is the tree: j/k move the tree cursor and never scroll the content pane.
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.txt"), "x\n").unwrap();
+    let mut ctrl = controller_with_lines(dir.path(), 50);
+    await_marker(&mut ctrl, "L0");
+    ctrl.set_content_viewport(40, 10);
+
+    assert_eq!(ctrl.focus(), Focus::Tree);
+    ctrl.handle(Intent::NavDown);
+    ctrl.handle(Intent::NavDown);
+    assert_eq!(ctrl.view_state().content_scroll, 0, "tree focus: content never scrolls");
+}
+
+#[test]
+fn nav_scrolls_the_content_pane_when_focused_and_clamps_both_ends() {
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.txt"), "x\n").unwrap();
+    let mut ctrl = controller_with_lines(dir.path(), 50);
+    await_marker(&mut ctrl, "L0");
+    ctrl.set_content_viewport(40, 10); // 50 lines, 10 visible → max scroll = 40
+
+    ctrl.handle(Intent::ToggleFocus);
+    assert_eq!(ctrl.focus(), Focus::Content);
+    assert_eq!(ctrl.view_state().content_scroll, 0, "starts at the top");
+
+    ctrl.handle(Intent::NavDown);
+    ctrl.handle(Intent::NavDown);
+    assert_eq!(ctrl.view_state().content_scroll, 2, "NavDown scrolls the content down");
+    ctrl.handle(Intent::NavUp);
+    assert_eq!(ctrl.view_state().content_scroll, 1, "NavUp scrolls the content up");
+
+    for _ in 0..10 {
+        ctrl.handle(Intent::NavUp);
+    }
+    assert_eq!(ctrl.view_state().content_scroll, 0, "cannot scroll above the first line");
+
+    for _ in 0..200 {
+        ctrl.handle(Intent::NavDown);
+    }
+    assert_eq!(ctrl.view_state().content_scroll, 40, "cannot scroll past the last screenful");
+}
+
+#[test]
+fn selecting_a_different_file_resets_the_scroll_to_the_top() {
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.txt"), "x\n").unwrap();
+    std::fs::write(dir.path().join("b.txt"), "y\n").unwrap();
+    let mut ctrl = controller_with_lines(dir.path(), 50);
+    await_marker(&mut ctrl, "L0");
+    ctrl.set_content_viewport(40, 10);
+
+    ctrl.handle(Intent::ToggleFocus); // focus content
+    for _ in 0..5 {
+        ctrl.handle(Intent::NavDown);
+    }
+    assert_eq!(ctrl.view_state().content_scroll, 5, "scrolled down");
+
+    ctrl.handle(Intent::ToggleFocus); // back to the tree
+    ctrl.handle(Intent::NavDown); // select the next file
+    assert_eq!(ctrl.view_state().content_scroll, 0, "a new selection resets the scroll");
+}
+
+#[test]
+fn wrap_is_on_for_markdown_and_off_for_code() {
+    // The content pane wraps prose (markdown / plain) but not code/diffs, whose column
+    // alignment must be preserved.
+    let md = TempDir::new();
+    std::fs::write(md.path().join("a.md"), "# hi\n").unwrap();
+    let (ctrl_md, _, _) = controller(md.path(), false, StubGit::default(), false);
+    assert_eq!(ctrl_md.selected_view_mode(), Some(ViewMode::RenderedMarkdown));
+    assert!(ctrl_md.view_state().wrap, "markdown content wraps");
+
+    let rs = TempDir::new();
+    std::fs::write(rs.path().join("a.rs"), "fn main() {}\n").unwrap();
+    let (ctrl_rs, _, _) = controller(rs.path(), false, StubGit::default(), false);
+    assert_eq!(ctrl_rs.selected_view_mode(), Some(ViewMode::SyntaxContent));
+    assert!(!ctrl_rs.view_state().wrap, "code content does not wrap");
+}
+
+#[test]
+fn wrap_toggle_forces_wrapping_on_for_code_then_back_to_the_mode_default() {
+    // The mode default leaves code/diffs unwrapped (aligned); `w` forces wrap on so long
+    // lines can be read, and toggles back to the default.
+    let rs = TempDir::new();
+    std::fs::write(rs.path().join("a.rs"), "fn main() {}\n").unwrap();
+    let (mut ctrl, _, _) = controller(rs.path(), false, StubGit::default(), false);
+
+    assert!(!ctrl.view_state().wrap, "code does not wrap by default");
+    let fx = ctrl.handle(Intent::ToggleWrap);
+    assert!(fx.redraw);
+    assert!(ctrl.view_state().wrap, "`w` forces wrap on for code");
+    ctrl.handle(Intent::ToggleWrap);
+    assert!(!ctrl.view_state().wrap, "toggling again returns to the mode default");
+}
+
+#[test]
+fn left_right_scroll_the_content_horizontally_when_focused_and_unwrapped() {
+    // A .rs file renders unwrapped (SyntaxContent), so its long lines can overflow the pane;
+    // with the content focused, ←/→ scroll it sideways to read them. (When the tree is
+    // focused those keys still collapse/expand — covered by the navigation tests.)
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.rs"), "code\n").unwrap();
+    let components = Components {
+        git: Arc::new(StubGit::default()),
+        content: Box::new(WideContent),
+        editor: Box::new(StubEditor { fail: false, opened: Arc::new(Mutex::new(Vec::new())) }),
+    };
+    let mut ctrl = Controller::new(dir.path().to_path_buf(), false, Baseline::Head, components);
+    await_marker(&mut ctrl, "WIDE");
+    ctrl.set_content_viewport(20, 10); // widest line 100, viewport 20 → max hscroll = 80
+    assert!(!ctrl.view_state().wrap, "a .rs file does not wrap, so horizontal scroll applies");
+
+    ctrl.handle(Intent::ToggleFocus); // focus the content pane
+    assert_eq!(ctrl.view_state().content_hscroll, 0, "starts at the left edge");
+
+    let fx = ctrl.handle(Intent::Expand); // → scrolls right
+    assert!(fx.redraw);
+    let after_one = ctrl.view_state().content_hscroll;
+    assert!(after_one > 0, "→ scrolls the content right when focused");
+    ctrl.handle(Intent::Expand);
+    assert!(ctrl.view_state().content_hscroll > after_one, "→ again scrolls further right");
+    ctrl.handle(Intent::Collapse); // ← scrolls left
+    assert_eq!(ctrl.view_state().content_hscroll, after_one, "← scrolls back left");
+
+    for _ in 0..50 {
+        ctrl.handle(Intent::Collapse);
+    }
+    assert_eq!(ctrl.view_state().content_hscroll, 0, "cannot scroll left of the start");
+    for _ in 0..500 {
+        ctrl.handle(Intent::Expand);
+    }
+    assert_eq!(ctrl.view_state().content_hscroll, 80, "clamps at the widest line minus the viewport");
+}
+
+#[test]
+fn resize_intents_move_the_tree_content_divider_and_clamp() {
+    // The tree/content split is adjustable from the keyboard (the viewer owns both columns,
+    // so herdr's pane-resize can't move this internal divider).
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.txt"), "x\n").unwrap();
+    let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
+
+    let start = ctrl.view_state().split_pct;
+    let fx = ctrl.handle(Intent::GrowTree);
+    assert!(fx.redraw);
+    assert!(ctrl.view_state().split_pct > start, "GrowTree widens the tree column");
+    ctrl.handle(Intent::ShrinkTree);
+    assert_eq!(ctrl.view_state().split_pct, start, "ShrinkTree narrows it back");
+
+    // Clamp at the wide end.
+    for _ in 0..50 {
+        ctrl.handle(Intent::GrowTree);
+    }
+    let max = ctrl.view_state().split_pct;
+    assert!((20..=80).contains(&max), "split stays within bounds ({max})");
+    ctrl.handle(Intent::GrowTree);
+    assert_eq!(ctrl.view_state().split_pct, max, "cannot grow past the maximum");
+
+    // Clamp at the narrow end.
+    for _ in 0..50 {
+        ctrl.handle(Intent::ShrinkTree);
+    }
+    let min = ctrl.view_state().split_pct;
+    assert!((20..=80).contains(&min) && min < max, "split clamps to a minimum ({min})");
+    ctrl.handle(Intent::ShrinkTree);
+    assert_eq!(ctrl.view_state().split_pct, min, "cannot shrink past the minimum");
 }
 
 /// A sorted (path, bytes) snapshot of every file under `root`, for an exact read-only check.

--- a/tests/presenter.rs
+++ b/tests/presenter.rs
@@ -10,7 +10,7 @@ use ratatui::backend::TestBackend;
 use std::path::PathBuf;
 
 fn node(path: &str, kind: NodeKind, depth: usize, expanded: bool, status: Option<Status>) -> Node {
-    Node { path: PathBuf::from(path), kind, depth, expanded, status }
+    Node { path: PathBuf::from(path), kind, depth, expanded, status, dir_dirty: false }
 }
 
 /// A known tree+content+notices state, wide enough for the two-column layout.
@@ -34,12 +34,20 @@ fn sample_state() -> ViewState {
         ],
         focus: Focus::Tree,
         width: 100,
+        content_scroll: 0,
+        content_hscroll: 0,
+        wrap: false,
+        split_pct: 40,
     }
 }
 
 fn render(state: &ViewState, w: u16, h: u16) -> String {
     let mut terminal = Terminal::new(TestBackend::new(w, h)).unwrap();
-    terminal.draw(|f| draw(f, state)).unwrap();
+    terminal
+        .draw(|f| {
+            draw(f, state);
+        })
+        .unwrap();
     format!("{}", terminal.backend())
 }
 
@@ -100,7 +108,11 @@ fn hostile_file_name_emits_no_control_bytes_to_the_buffer() {
     state.selected = 0;
 
     let mut terminal = Terminal::new(TestBackend::new(100, 12)).unwrap();
-    terminal.draw(|f| draw(f, &state)).unwrap();
+    terminal
+        .draw(|f| {
+            draw(f, &state);
+        })
+        .unwrap();
     let buf = terminal.backend().buffer().clone();
 
     let mut cells = String::new();
@@ -114,6 +126,131 @@ fn hostile_file_name_emits_no_control_bytes_to_the_buffer() {
     assert!(!cells.chars().any(|c| c.is_control()), "no control byte may reach a cell");
     assert!(!cells.contains('\u{1b}'), "no ESC byte in the buffer");
     assert!(cells.contains("pwned"), "the printable remainder is still shown");
+}
+
+#[test]
+fn content_pane_applies_the_vertical_scroll_offset() {
+    // With content_scroll = N (and no wrap), the first visible content row is line N: the
+    // lines above it are scrolled off the top.
+    let mut state = sample_state();
+    state.notices = vec![]; // no notice strip, so content starts at the inner top row
+    state.content = to_text("c0\nc1\nc2\nc3\nc4\nc5\nc6\nc7\n");
+    state.wrap = false;
+    state.content_scroll = 3;
+    let out = render(&state, 100, 12);
+    assert!(out.contains("c3"), "the scrolled-to line is visible\n{out}");
+    assert!(out.contains("c7"), "lines below it are visible\n{out}");
+    assert!(!out.contains("c0"), "lines scrolled past the top are hidden\n{out}");
+}
+
+#[test]
+fn wrapping_shows_more_of_a_long_line_than_truncating() {
+    // A line far wider than the content pane: wrapped, it spills onto further rows; not
+    // wrapped, it is truncated to a single row. So the wrapped render shows strictly more of
+    // it. (The sample tree/title carry no 'W', so every 'W' counted comes from the content.)
+    let long = "W ".repeat(80); // ~160 cols, far wider than the ~58-col content pane
+    let mut state = sample_state();
+    state.notices = vec![];
+    state.content = to_text(&long);
+
+    state.wrap = true;
+    let wrapped = render(&state, 100, 12);
+    state.wrap = false;
+    let truncated = render(&state, 100, 12);
+
+    let ws = |s: &str| s.matches('W').count();
+    assert!(
+        ws(&wrapped) > ws(&truncated),
+        "wrapped shows more of the long line (wrapped W={}, truncated W={})\n{wrapped}",
+        ws(&wrapped),
+        ws(&truncated)
+    );
+}
+
+/// Render to a buffer (for cell-style assertions).
+fn render_buffer(state: &ViewState, w: u16, h: u16) -> ratatui::buffer::Buffer {
+    let mut terminal = Terminal::new(TestBackend::new(w, h)).unwrap();
+    terminal
+        .draw(|f| {
+            draw(f, state);
+        })
+        .unwrap();
+    terminal.backend().buffer().clone()
+}
+
+/// The foreground color of the first cell where `needle` begins in the buffer.
+fn row_fg(buf: &ratatui::buffer::Buffer, needle: &str) -> ratatui::style::Color {
+    let (w, h) = (buf.area().width, buf.area().height);
+    for y in 0..h {
+        for x in 0..w {
+            let matches = needle.chars().enumerate().all(|(i, ch)| {
+                let cx = x + i as u16;
+                cx < w && buf.cell((cx, y)).is_some_and(|c| c.symbol() == ch.to_string())
+            });
+            if matches {
+                return buf.cell((x, y)).unwrap().fg;
+            }
+        }
+    }
+    panic!("{needle:?} not found in buffer");
+}
+
+#[test]
+fn tree_rows_are_colored_by_git_status() {
+    use ratatui::style::Color;
+    let mut state = sample_state();
+    state.notices = vec![];
+    state.nodes = vec![
+        // A directory that contains changes (dir_dirty), a modified file, a new file, a clean
+        // file. The clean file is selected so the colored rows aren't reversed (which would
+        // swap fg/bg).
+        Node {
+            path: PathBuf::from("/r/src"),
+            kind: NodeKind::Dir,
+            depth: 0,
+            expanded: true,
+            status: None,
+            dir_dirty: true,
+        },
+        node("/r/src/mod.rs", NodeKind::File, 1, false, Some(Status::Modified)),
+        node("/r/src/new.rs", NodeKind::File, 1, false, Some(Status::Added)),
+        node("/r/clean.txt", NodeKind::File, 0, false, None),
+    ];
+    state.selected = 3; // the clean file
+    let buf = render_buffer(&state, 100, 12);
+
+    assert_eq!(row_fg(&buf, "mod.rs"), Color::LightRed, "a modified file is light red");
+    assert_eq!(row_fg(&buf, "new.rs"), Color::LightGreen, "a new file is light green");
+    assert_eq!(row_fg(&buf, "src"), Color::LightRed, "a directory with changes is light red");
+    assert_ne!(row_fg(&buf, "clean.txt"), Color::LightRed, "a clean file is not colored red");
+    assert_ne!(row_fg(&buf, "clean.txt"), Color::LightGreen, "a clean file is not colored green");
+}
+
+#[test]
+fn content_pane_applies_the_horizontal_scroll_offset() {
+    // With content_hscroll = N (and no wrap), the leftmost N columns are scrolled off, so a
+    // long line shows from column N onward.
+    let mut state = sample_state();
+    state.notices = vec![];
+    state.content = to_text("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789");
+    state.wrap = false;
+    state.content_hscroll = 5;
+    let out = render(&state, 100, 12);
+    assert!(out.contains("FGHIJ"), "columns from the offset are visible\n{out}");
+    assert!(!out.contains("ABCDE"), "columns scrolled past the left edge are hidden\n{out}");
+}
+
+#[test]
+fn split_ratio_controls_the_tree_column_width() {
+    // A larger split_pct gives the tree column more width, so its block's top-right corner
+    // (the first `┐`) sits further along the top border row.
+    let corner = |pct: u16| -> usize {
+        let mut s = sample_state();
+        s.split_pct = pct;
+        let out = render(&s, 100, 24);
+        out.lines().next().unwrap().find('┐').expect("tree block corner")
+    };
+    assert!(corner(60) > corner(20), "a wider split_pct widens the tree column");
 }
 
 #[test]

--- a/tests/presenter_narrow.rs
+++ b/tests/presenter_narrow.rs
@@ -11,7 +11,7 @@ use ratatui::backend::TestBackend;
 use std::path::PathBuf;
 
 fn node(path: &str, kind: NodeKind, depth: usize, status: Option<Status>) -> Node {
-    Node { path: PathBuf::from(path), kind, depth, expanded: true, status }
+    Node { path: PathBuf::from(path), kind, depth, expanded: true, status, dir_dirty: false }
 }
 
 fn state(width: u16, focus: Focus) -> ViewState {
@@ -26,12 +26,20 @@ fn state(width: u16, focus: Focus) -> ViewState {
         notices: vec!["delta not found — showing plain diff".to_string()],
         focus,
         width,
+        content_scroll: 0,
+        content_hscroll: 0,
+        wrap: false,
+        split_pct: 40,
     }
 }
 
 fn render(state: &ViewState, w: u16, h: u16) -> String {
     let mut terminal = Terminal::new(TestBackend::new(w, h)).unwrap();
-    terminal.draw(|f| draw(f, state)).unwrap();
+    terminal
+        .draw(|f| {
+            draw(f, state);
+        })
+        .unwrap();
     format!("{}", terminal.backend())
 }
 

--- a/tests/tree.rs
+++ b/tests/tree.rs
@@ -4,8 +4,34 @@
 mod common;
 
 use common::TempDir;
+use herdr_file_viewer::git::Status;
 use herdr_file_viewer::tree::TreeModel;
+use std::collections::BTreeMap;
 use std::fs;
+use std::path::PathBuf;
+
+#[test]
+fn a_directory_with_a_changed_descendant_is_flagged_dirty() {
+    // Folder coloring needs an aggregate: a directory is "dirty" when any file under it has a
+    // git status (so the Presenter can color it), while a clean directory is not.
+    let dir = TempDir::new();
+    fs::create_dir_all(dir.path().join("changed")).unwrap();
+    fs::create_dir_all(dir.path().join("clean")).unwrap();
+    fs::write(dir.path().join("changed/a.rs"), "a").unwrap();
+    fs::write(dir.path().join("clean/b.rs"), "b").unwrap();
+
+    let mut model = TreeModel::new(dir.path());
+    let mut status = BTreeMap::new();
+    status.insert(PathBuf::from("changed/a.rs"), Status::Modified);
+    model.set_status(&status);
+
+    let nodes = model.visible_nodes();
+    let find = |name: &str| {
+        nodes.iter().find(|n| n.path.file_name().unwrap() == name).expect("node present")
+    };
+    assert!(find("changed").dir_dirty, "a directory with a modified descendant is dirty");
+    assert!(!find("clean").dir_dirty, "a directory with no changes is not dirty");
+}
 
 fn names(model: &TreeModel) -> Vec<String> {
     model


### PR DESCRIPTION
## Summary

Post-merge **live install + testing** of the plugin in herdr 0.7.0 surfaced real bugs and several UX gaps. This PR fixes them and adds the content-navigation features that emerged from that session. All work is test-first.

> **Scope note:** content scrolling, wrapping, the resizable split, the wrap toggle, tree colors, and line numbers are **enhancements beyond the original v1 acceptance criteria**, added at the user's request during live testing. The spec chain (`specs/`) was not re-run for these; if we want them folded into the contract, that's a separate CodeRight pass.

## What's in it

**Install / manifest (real herdr 0.7.0 surface)**
- `herdr-plugin.toml` needed a top-level `id`, and herdr rejects an action without a `command` (the spec's `pane = "..."` field doesn't parse). Added `id` + a launcher script (`scripts/open-file-viewer.sh`) that opens the pane via `herdr plugin pane open` — the canonical pattern from herdr's plugin examples.

**Renderer fixes** (the viewer pipes renderer stdout, so the renderers' TTY auto-detection misfires)
- `glow`: `-s dark` (its `auto` style degrades to plain "notty" output when piped) **and** `-w 0` (it padded every line to 80 cols, which in a narrow pane wrapped to a blank row after every line — the "massive gaps").
- `bat`: `--style=numbers` → line numbers for code.

**Content navigation** (focus-aware — `Tab` to focus the content pane)
- Vertical **and** horizontal scrolling (arrows / `hjkl`), clamped to the content.
- Mode-aware line **wrapping** (prose wraps; code/diffs stay aligned) with a **`w` toggle** to force-wrap long code/diff lines on demand.
- **Resizable** tree/content split (`<` / `>`) — the divider was hardcoded 40/60.
- The run loop now **redraws on `Event::Resize`** (it was `Key`-only, so a pane resize left a stale layout until the next keypress).

**Tree status colors (AC-7)**
- Changed files/folders **light red**, new files **light green**; folders aggregate descendant changes (`Node.dir_dirty`).

**Input dispatcher** now permits `Shift` (for `<`/`>`) while still rejecting `Ctrl`/`Alt`.

**Docs** — README + manual-verification updated for the real install flow and the new keys/behaviors.

## Verification
- **139 tests pass** (was 123 at build-complete); clippy-clean on changed files; release builds.
- Every behavior was also **verified live** by driving the running viewer pane (`herdr pane send-keys` / `read` / `resize`): split launch, colored markers (M=red, ?=green, dirty folders red), line numbers, glow rendering + the gap fix in a narrow pane, scroll (both axes), wrap toggle, split resize, and resize-reflow.

🤖 Generated with [Claude Code](https://claude.ai/code)
