### PR TITLE
v1.5: rich markdown rendering (bundled palette glamour style)

### DIFF
--- a/assets/markdown-style.json
+++ b/assets/markdown-style.json
@@ -1,0 +1,141 @@
+{
+  "document": {
+    "block_prefix": "\n",
+    "block_suffix": "\n",
+    "margin": 0
+  },
+  "block_quote": {
+    "color": "8",
+    "indent": 1,
+    "indent_token": "│ "
+  },
+  "paragraph": {},
+  "list": {
+    "level_indent": 2
+  },
+  "heading": {
+    "block_suffix": "\n",
+    "bold": true
+  },
+  "h1": {
+    "prefix": "",
+    "suffix": "",
+    "color": "5",
+    "bold": true
+  },
+  "h2": {
+    "prefix": "",
+    "color": "4",
+    "bold": true
+  },
+  "h3": {
+    "prefix": "",
+    "color": "6",
+    "bold": true
+  },
+  "h4": {
+    "prefix": "",
+    "color": "2",
+    "bold": true
+  },
+  "h5": {
+    "prefix": "",
+    "color": "3",
+    "bold": true
+  },
+  "h6": {
+    "prefix": "",
+    "color": "8",
+    "bold": true
+  },
+  "text": {},
+  "strikethrough": {
+    "crossed_out": true
+  },
+  "emph": {
+    "italic": true
+  },
+  "strong": {
+    "bold": true
+  },
+  "hr": {
+    "color": "8",
+    "format": "\n--------\n"
+  },
+  "item": {
+    "block_prefix": "• "
+  },
+  "enumeration": {
+    "block_prefix": ". "
+  },
+  "task": {
+    "ticked": "[✓] ",
+    "unticked": "[ ] "
+  },
+  "link": {
+    "color": "6",
+    "underline": true
+  },
+  "link_text": {
+    "color": "4",
+    "bold": true
+  },
+  "image": {
+    "color": "5",
+    "underline": true
+  },
+  "image_text": {
+    "color": "8",
+    "format": "Image: {{.text}} →"
+  },
+  "code": {
+    "prefix": " ",
+    "suffix": " ",
+    "color": "1"
+  },
+  "code_block": {
+    "color": "8",
+    "margin": 0,
+    "chroma": {
+      "text": { "color": "#C4C4C4" },
+      "error": { "color": "#F1F1F1", "background_color": "#F05B5B" },
+      "comment": { "color": "#676767" },
+      "comment_preproc": { "color": "#FF875F" },
+      "keyword": { "color": "#00AAFF" },
+      "keyword_reserved": { "color": "#FF5FD2" },
+      "keyword_namespace": { "color": "#FF5F87" },
+      "keyword_type": { "color": "#6E6ED8" },
+      "operator": { "color": "#EF8080" },
+      "punctuation": { "color": "#E8E8A8" },
+      "name": { "color": "#C4C4C4" },
+      "name_builtin": { "color": "#FF8EC7" },
+      "name_tag": { "color": "#B083EA" },
+      "name_attribute": { "color": "#7A7AE6" },
+      "name_class": { "color": "#F1F1F1", "underline": true, "bold": true },
+      "name_constant": {},
+      "name_decorator": { "color": "#FFFF87" },
+      "name_exception": {},
+      "name_function": { "color": "#00D787" },
+      "name_other": {},
+      "literal": {},
+      "literal_number": { "color": "#6EEFC0" },
+      "literal_date": {},
+      "literal_string": { "color": "#C69669" },
+      "literal_string_escape": { "color": "#AFFFD7" },
+      "generic_deleted": { "color": "#FD5B5B" },
+      "generic_emph": { "italic": true },
+      "generic_inserted": { "color": "#00D787" },
+      "generic_strong": { "bold": true },
+      "generic_subheading": { "color": "#777777" },
+      "background": { "background_color": "#373737" }
+    }
+  },
+  "table": {},
+  "definition_list": {},
+  "definition_term": {},
+  "definition_description": {
+    "block_prefix": "\n🠶 "
+  },
+  "html_block": {},
+  "html_span": {}
+}

--- a/src/app.rs
+++ b/src/app.rs
@@ -49,7 +49,7 @@ pub fn run() -> io::Result<()> {
         base_hint: resolved.base_branch.clone(),
     });
     let content: Box<dyn ContentProvider> =
-        Box::new(LiveContent { root: resolved.root.clone(), renderers: default_renderers(&asset_root()) });
+        Box::new(LiveContent { root: resolved.root.clone(), renderers: default_renderers() });
     let editor: Box<dyn EditorHandoff> =
         Box::new(LiveEditor { editor: std::env::var_os("EDITOR") });
 
@@ -232,39 +232,37 @@ fn resume_tui() -> io::Result<()> {
     execute!(io::stdout(), EnterAlternateScreen)
 }
 
-/// Resolve glow's `-s` style argument: the bundled palette style if it ships at
-/// `<asset_root>/assets/markdown-style.json` (prose in the host ANSI palette, stripped `##`
-/// markers, syntax-highlighted code blocks), else glow's built-in `dark` so markdown still
-/// renders rather than failing on a missing `-s` file.
-fn markdown_style(asset_root: &Path) -> String {
-    let bundled = asset_root.join("assets/markdown-style.json");
-    if bundled.is_file() {
-        bundled.to_string_lossy().into_owned()
-    } else {
-        "dark".to_string()
-    }
+/// Resolve glow's `-s` style argument: the bundled palette style if it ships in the
+/// executable's own install tree (prose in the host ANSI palette, stripped `##` markers,
+/// syntax-highlighted code blocks), else glow's built-in `dark` so markdown still renders
+/// rather than failing on a missing `-s` file.
+///
+/// The style is a glow *argument* — trusted, operator-configured — so it is located ONLY
+/// relative to the executable, **never the cwd**: the viewed repo is untrusted and could
+/// otherwise plant an `assets/markdown-style.json` for the cwd fallback to pick up, turning
+/// repo content into the (trusted) renderer's config.
+fn markdown_style() -> String {
+    bundled_style_path(std::env::current_exe().ok().as_deref())
+        .unwrap_or_else(|| "dark".to_string())
 }
 
-/// Locate the plugin root holding the bundled `assets/`. The binary runs from
-/// `<root>/target/<profile>/herdr-file-viewer`, so walk up from the executable to the first
-/// ancestor that actually contains the style (works under both `herdr plugin link` and
-/// `plugin install`, which both build into `target/`). Falls back to the current directory.
-fn asset_root() -> PathBuf {
-    if let Ok(exe) = std::env::current_exe() {
-        for anc in exe.ancestors() {
-            if anc.join("assets/markdown-style.json").is_file() {
-                return anc.to_path_buf();
-            }
-        }
-    }
-    std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
+/// Find `assets/markdown-style.json` among the ancestors of the executable — the trusted
+/// install dir (the binary runs from `<root>/target/<profile>/herdr-file-viewer`, with the
+/// asset at `<root>/assets/…`, under both `herdr plugin link` and `plugin install`). Pure
+/// over its input, so it is unit-testable and provably never consults the cwd. `None` (→
+/// caller uses `dark`) when `exe` is absent or no ancestor bundles the asset.
+fn bundled_style_path(exe: Option<&Path>) -> Option<String> {
+    exe?.ancestors()
+        .map(|anc| anc.join("assets/markdown-style.json"))
+        .find(|candidate| candidate.is_file())
+        .map(|candidate| candidate.to_string_lossy().into_owned())
 }
 
 /// The default external renderers (the documented runtime deps). Each reads the untrusted
 /// content on **stdin** (never as an argument); a missing one degrades to plain text +
 /// notice (AC-24/25). `{name}` is substituted with the sanitized file name for language
 /// detection.
-fn default_renderers(asset_root: &Path) -> Renderers {
+fn default_renderers() -> Renderers {
     Renderers {
         // glow's default `auto` style downgrades to the plain "notty" renderer when stdout is a
         // pipe (the viewer always captures it), leaving `#`, `**`, etc. literal — so a concrete
@@ -276,7 +274,7 @@ fn default_renderers(asset_root: &Path) -> Renderers {
         markdown: vec![
             "glow".into(),
             "-s".into(),
-            markdown_style(asset_root),
+            markdown_style(),
             "-w".into(),
             "0".into(),
             "-".into(),
@@ -310,59 +308,62 @@ mod tests {
     }
 
     #[test]
-    fn markdown_style_uses_the_bundled_style_when_present() {
-        // When the plugin ships `assets/markdown-style.json`, glow is pointed at it (not the
-        // built-in `dark`) so prose inherits the host palette and code blocks highlight.
-        let root = tmp("style-present");
+    fn bundled_style_is_found_in_the_executables_install_tree() {
+        // A binary at <root>/target/release/<bin> resolves <root>/assets/markdown-style.json,
+        // so glow is pointed at the bundled palette style (not the built-in `dark`).
+        let root = tmp("bundled-present");
         std::fs::create_dir_all(root.join("assets")).unwrap();
         std::fs::write(root.join("assets/markdown-style.json"), "{}").unwrap();
-        let s = markdown_style(&root);
+        let exe = root.join("target/release/herdr-file-viewer");
+        let s = bundled_style_path(Some(&exe)).expect("style found in the install tree");
         assert!(s.ends_with("markdown-style.json"), "points at the bundled style: {s}");
         assert!(Path::new(&s).is_file(), "the referenced style file exists: {s}");
         let _ = std::fs::remove_dir_all(&root);
     }
 
     #[test]
-    fn markdown_style_falls_back_to_dark_when_absent() {
-        // No bundled style (e.g. a stripped install) → glow's built-in `dark`, so markdown
-        // still renders rather than erroring on a missing `-s` file.
-        let root = tmp("style-absent");
-        assert_eq!(markdown_style(&root), "dark");
+    fn no_bundled_style_yields_none_and_never_consults_the_cwd() {
+        // Security regression: the style is a trusted glow argument, located ONLY via the
+        // executable's tree — never the cwd, which may be an untrusted viewed repo. Here the
+        // exe's tree ships no asset, so we get None EVEN THOUGH the real cwd (this repo) ships
+        // one. `markdown_style()` then falls back to glow's built-in `dark`.
+        let root = tmp("bundled-absent"); // deliberately no assets/ created
+        let exe = root.join("target/release/herdr-file-viewer");
+        assert_eq!(bundled_style_path(Some(&exe)), None, "no asset in the install tree → None");
         let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn missing_executable_path_yields_none() {
+        assert_eq!(bundled_style_path(None), None);
     }
 
     #[test]
     fn markdown_renderer_forces_a_concrete_glow_style() {
         // Regression: glow's default `auto` style degrades to the plain "notty" renderer when
         // stdout is a pipe (as the viewer always captures it), leaving literal `#`/`**`. A
-        // concrete style must be forced or markdown renders as near-raw text.
-        let root = tmp("renderers-style");
-        std::fs::create_dir_all(root.join("assets")).unwrap();
-        std::fs::write(root.join("assets/markdown-style.json"), "{}").unwrap();
-        let r = default_renderers(&root);
-        assert!(r.markdown.iter().any(|a| a == "-s"), "glow style flag present: {:?}", r.markdown);
+        // concrete `-s` style (the bundled file or `dark`) must be passed, and `-w 0` must
+        // follow `-w` to disable glow's line-padding (else blank-row gaps in a narrow pane).
+        let r = default_renderers();
+        let s = r.markdown.iter().position(|a| a == "-s");
         assert!(
-            r.markdown.iter().any(|a| a.ends_with("markdown-style.json")),
-            "the bundled style is used: {:?}",
+            s.is_some_and(|i| r.markdown.get(i + 1).is_some_and(|v| !v.is_empty())),
+            "a concrete -s style is passed: {:?}",
             r.markdown
         );
-        // `-w 0` must follow `-w`: it disables glow's line-padding that otherwise wraps to
-        // blank-row gaps in a narrow pane.
         let w = r.markdown.iter().position(|a| a == "-w");
         assert!(
             w.is_some_and(|i| r.markdown.get(i + 1).is_some_and(|v| v == "0")),
             "glow width disabled with `-w 0`: {:?}",
             r.markdown
         );
-        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[test]
     fn syntax_renderer_forces_color_and_line_numbers() {
         // bat, like glow, must be told to colorize since its output is piped, not a TTY; and
-        // `--style=numbers` shows the line-number gutter the viewer wants for code. (The
-        // syntax/diff commands don't depend on the asset root.)
-        let r = default_renderers(Path::new("/nonexistent"));
+        // `--style=numbers` shows the line-number gutter the viewer wants for code.
+        let r = default_renderers();
         assert!(r.syntax.iter().any(|a| a == "--color=always"), "bat color forced: {:?}", r.syntax);
         assert!(r.syntax.iter().any(|a| a == "--style=numbers"), "bat line numbers: {:?}", r.syntax);
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -49,7 +49,7 @@ pub fn run() -> io::Result<()> {
         base_hint: resolved.base_branch.clone(),
     });
     let content: Box<dyn ContentProvider> =
-        Box::new(LiveContent { root: resolved.root.clone(), renderers: default_renderers() });
+        Box::new(LiveContent { root: resolved.root.clone(), renderers: default_renderers(&asset_root()) });
     let editor: Box<dyn EditorHandoff> =
         Box::new(LiveEditor { editor: std::env::var_os("EDITOR") });
 
@@ -232,19 +232,55 @@ fn resume_tui() -> io::Result<()> {
     execute!(io::stdout(), EnterAlternateScreen)
 }
 
+/// Resolve glow's `-s` style argument: the bundled palette style if it ships at
+/// `<asset_root>/assets/markdown-style.json` (prose in the host ANSI palette, stripped `##`
+/// markers, syntax-highlighted code blocks), else glow's built-in `dark` so markdown still
+/// renders rather than failing on a missing `-s` file.
+fn markdown_style(asset_root: &Path) -> String {
+    let bundled = asset_root.join("assets/markdown-style.json");
+    if bundled.is_file() {
+        bundled.to_string_lossy().into_owned()
+    } else {
+        "dark".to_string()
+    }
+}
+
+/// Locate the plugin root holding the bundled `assets/`. The binary runs from
+/// `<root>/target/<profile>/herdr-file-viewer`, so walk up from the executable to the first
+/// ancestor that actually contains the style (works under both `herdr plugin link` and
+/// `plugin install`, which both build into `target/`). Falls back to the current directory.
+fn asset_root() -> PathBuf {
+    if let Ok(exe) = std::env::current_exe() {
+        for anc in exe.ancestors() {
+            if anc.join("assets/markdown-style.json").is_file() {
+                return anc.to_path_buf();
+            }
+        }
+    }
+    std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
+}
+
 /// The default external renderers (the documented runtime deps). Each reads the untrusted
 /// content on **stdin** (never as an argument); a missing one degrades to plain text +
 /// notice (AC-24/25). `{name}` is substituted with the sanitized file name for language
 /// detection.
-fn default_renderers() -> Renderers {
+fn default_renderers(asset_root: &Path) -> Renderers {
     Renderers {
-        // `-s dark` forces a concrete glamour style (glow's default `auto` downgrades to the
-        // plain "notty" renderer when stdout is a pipe — as the viewer always captures it —
-        // leaving `#`, `**`, etc. as literal text). `-w 0` disables glow's own wrapping/line-
-        // padding: otherwise it pads every line to 80 cols, and in a narrower pane the trailing
-        // padding wraps to a blank row after each line ("gaps"). With `-w 0` the Presenter's
-        // own wrap reflows the text to the actual pane width.
-        markdown: vec!["glow".into(), "-s".into(), "dark".into(), "-w".into(), "0".into(), "-".into()],
+        // glow's default `auto` style downgrades to the plain "notty" renderer when stdout is a
+        // pipe (the viewer always captures it), leaving `#`, `**`, etc. literal — so a concrete
+        // style is forced (the bundled palette style, else `dark`) and color is forced on the
+        // subprocess (see `render::renderer_command`). `-w 0` disables glow's own wrapping/
+        // line-padding: otherwise it pads every line to 80 cols, and in a narrower pane that
+        // trailing padding wraps to a blank row after each line ("gaps"); the Presenter's own
+        // wrap reflows to the actual pane width instead.
+        markdown: vec![
+            "glow".into(),
+            "-s".into(),
+            markdown_style(asset_root),
+            "-w".into(),
+            "0".into(),
+            "-".into(),
+        ],
         // delta already colorizes piped output (its default), and has no `--color=always` flag.
         diff: vec!["delta".into()],
         syntax: vec![
@@ -264,14 +300,52 @@ fn default_renderers() -> Renderers {
 mod tests {
     use super::*;
 
+    /// A fresh empty temp dir for a test (no tempfile dep — matches the project's hermetic
+    /// test style). Distinct per `tag` so parallel unit tests don't collide.
+    fn tmp(tag: &str) -> PathBuf {
+        let d = std::env::temp_dir().join(format!("hfv-{}-{}", tag, std::process::id()));
+        let _ = std::fs::remove_dir_all(&d);
+        std::fs::create_dir_all(&d).unwrap();
+        d
+    }
+
+    #[test]
+    fn markdown_style_uses_the_bundled_style_when_present() {
+        // When the plugin ships `assets/markdown-style.json`, glow is pointed at it (not the
+        // built-in `dark`) so prose inherits the host palette and code blocks highlight.
+        let root = tmp("style-present");
+        std::fs::create_dir_all(root.join("assets")).unwrap();
+        std::fs::write(root.join("assets/markdown-style.json"), "{}").unwrap();
+        let s = markdown_style(&root);
+        assert!(s.ends_with("markdown-style.json"), "points at the bundled style: {s}");
+        assert!(Path::new(&s).is_file(), "the referenced style file exists: {s}");
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn markdown_style_falls_back_to_dark_when_absent() {
+        // No bundled style (e.g. a stripped install) → glow's built-in `dark`, so markdown
+        // still renders rather than erroring on a missing `-s` file.
+        let root = tmp("style-absent");
+        assert_eq!(markdown_style(&root), "dark");
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
     #[test]
     fn markdown_renderer_forces_a_concrete_glow_style() {
         // Regression: glow's default `auto` style degrades to the plain "notty" renderer when
         // stdout is a pipe (as the viewer always captures it), leaving literal `#`/`**`. A
         // concrete style must be forced or markdown renders as near-raw text.
-        let r = default_renderers();
+        let root = tmp("renderers-style");
+        std::fs::create_dir_all(root.join("assets")).unwrap();
+        std::fs::write(root.join("assets/markdown-style.json"), "{}").unwrap();
+        let r = default_renderers(&root);
         assert!(r.markdown.iter().any(|a| a == "-s"), "glow style flag present: {:?}", r.markdown);
-        assert!(r.markdown.iter().any(|a| a == "dark"), "a concrete style is named: {:?}", r.markdown);
+        assert!(
+            r.markdown.iter().any(|a| a.ends_with("markdown-style.json")),
+            "the bundled style is used: {:?}",
+            r.markdown
+        );
         // `-w 0` must follow `-w`: it disables glow's line-padding that otherwise wraps to
         // blank-row gaps in a narrow pane.
         let w = r.markdown.iter().position(|a| a == "-w");
@@ -280,13 +354,15 @@ mod tests {
             "glow width disabled with `-w 0`: {:?}",
             r.markdown
         );
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[test]
     fn syntax_renderer_forces_color_and_line_numbers() {
         // bat, like glow, must be told to colorize since its output is piped, not a TTY; and
-        // `--style=numbers` shows the line-number gutter the viewer wants for code.
-        let r = default_renderers();
+        // `--style=numbers` shows the line-number gutter the viewer wants for code. (The
+        // syntax/diff commands don't depend on the asset root.)
+        let r = default_renderers(Path::new("/nonexistent"));
         assert!(r.syntax.iter().any(|a| a == "--color=always"), "bat color forced: {:?}", r.syntax);
         assert!(r.syntax.iter().any(|a| a == "--style=numbers"), "bat line numbers: {:?}", r.syntax);
     }

--- a/src/render.rs
+++ b/src/render.rs
@@ -251,13 +251,25 @@ fn capability(mode: ViewMode) -> &'static str {
 /// and reported as failed so the plain-text fallback kicks in. `Err` on a missing program,
 /// non-zero exit, or timeout. The command is trusted (operator-configured); only the stdin
 /// content is untrusted, so there is no argument injection.
-fn run_renderer(command: &[String], input: &str, timeout: Duration) -> Result<String, String> {
+/// Build the (trusted, operator-configured) renderer subprocess: program + args, color forced
+/// for the pipe, stdin/stdout piped, stderr discarded. `CLICOLOR_FORCE=1` stops termenv-based
+/// tools (glow/glamour) from dropping to a no-color profile when stdout is not a TTY — as it
+/// always is here — which would strip all markdown color (headings, inline code, code-block
+/// highlighting). Harmless to delta/bat, which force color via their own flags.
+fn renderer_command(command: &[String]) -> Result<Command, String> {
     let (prog, args) = command.split_first().ok_or("empty renderer command")?;
-    let mut child = Command::new(prog)
-        .args(args)
+    let mut cmd = Command::new(prog);
+    cmd.args(args)
+        .env("CLICOLOR_FORCE", "1")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::null())
+        .stderr(Stdio::null());
+    Ok(cmd)
+}
+
+fn run_renderer(command: &[String], input: &str, timeout: Duration) -> Result<String, String> {
+    let prog = command.first().cloned().ok_or("empty renderer command")?;
+    let mut child = renderer_command(command)?
         .spawn()
         .map_err(|e| format!("{prog}: {e}"))?;
 
@@ -507,5 +519,30 @@ mod tests {
         fs::create_dir_all(&sub).unwrap();
         assert_eq!(classify(&root, &sub), Prepared::Binary);
         fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn renderer_command_forces_color_so_piped_renderers_keep_styling() {
+        // glow/glamour drops to a no-color profile when stdout is a pipe (always, here), so
+        // every renderer subprocess is spawned with CLICOLOR_FORCE=1 — without it markdown
+        // loses all color (headings, inline code, code-block highlighting). Harmless to
+        // delta/bat, which force color via flags already.
+        use std::ffi::OsStr;
+        let cmd = renderer_command(&["glow".into(), "-".into()]).unwrap();
+        let forced = cmd
+            .get_envs()
+            .any(|(k, v)| k == OsStr::new("CLICOLOR_FORCE") && v == Some(OsStr::new("1")));
+        assert!(forced, "CLICOLOR_FORCE=1 must be set on the renderer subprocess");
+    }
+
+    #[test]
+    fn named_ansi_color_survives_to_text_as_a_named_color() {
+        // The markdown palette feature relies on glow's named ANSI colors (e.g. `\e[34m`)
+        // surviving `to_text` as ratatui *named* colors, so the terminal/herdr theme re-themes
+        // them — rather than being flattened to fixed RGB.
+        use ratatui::style::Color;
+        let t = to_text("\u{1b}[34mhi\u{1b}[0m");
+        let fg = t.lines.iter().flat_map(|l| l.spans.iter()).find_map(|s| s.style.fg);
+        assert_eq!(fg, Some(Color::Blue), "SGR 34 must map to the named Blue, not RGB");
     }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -246,11 +246,6 @@ fn capability(mode: ViewMode) -> &'static str {
     }
 }
 
-/// Spawn a renderer, feed `input` on stdin (writer thread, avoids a pipe deadlock), read
-/// stdout (reader thread), and bound the wait by `timeout` — a wedged renderer is killed
-/// and reported as failed so the plain-text fallback kicks in. `Err` on a missing program,
-/// non-zero exit, or timeout. The command is trusted (operator-configured); only the stdin
-/// content is untrusted, so there is no argument injection.
 /// Build the (trusted, operator-configured) renderer subprocess: program + args, color forced
 /// for the pipe, stdin/stdout piped, stderr discarded. `CLICOLOR_FORCE=1` stops termenv-based
 /// tools (glow/glamour) from dropping to a no-color profile when stdout is not a TTY — as it
@@ -267,6 +262,11 @@ fn renderer_command(command: &[String]) -> Result<Command, String> {
     Ok(cmd)
 }
 
+/// Spawn a renderer, feed `input` on stdin (writer thread, avoids a pipe deadlock), read
+/// stdout (reader thread), and bound the wait by `timeout` — a wedged renderer is killed
+/// and reported as failed so the plain-text fallback kicks in. `Err` on a missing program,
+/// non-zero exit, or timeout. The command is trusted (operator-configured); only the stdin
+/// content is untrusted, so there is no argument injection.
 fn run_renderer(command: &[String], input: &str, timeout: Duration) -> Result<String, String> {
     let prog = command.first().cloned().ok_or("empty renderer command")?;
     let mut child = renderer_command(command)?


### PR DESCRIPTION
## What & why

Markdown rendered near-raw in the viewer (undifferentiated bold headings, unstyled inline code, no code-block highlighting). Root cause was **our invocation, not glow**: the viewer pipes glow's stdout (never a TTY), so glamour dropped to a no-color profile, and the stock `dark` style carries no code-block theme.

Fix stays **delegated to glow** (ADR-0001 unchanged):

- **Force color** on every renderer subprocess (`CLICOLOR_FORCE=1`) so glamour keeps its color profile despite the pipe. Harmless to delta/bat (they force color via flags).
- **Bundle a complete palette-based glamour style** (`assets/markdown-style.json`): prose colors in **ANSI 0–15** so headings / inline code / emphasis **inherit the terminal & herdr theme**; `prefix:""` strips the literal `#`/`##`/`###`; a Chroma `code_block.theme` gives real per-token syntax highlighting (fixed-color by design — consistent with bat/delta).
- **Resolve the style relative to the executable** so it works under both `herdr plugin link` and `plugin install`; **fall back to glow's `dark`** when the asset is absent (graceful, never errors on a missing `-s` file).

Content still flows `glow → ansi-to-tui`, so **AC-27 escape-neutralization is unchanged** (an advantage over an in-process renderer, which would have to re-earn it).

## Verification

- TDD (red→green). New tests: bundled-style-used vs `dark`-fallback resolution; `CLICOLOR_FORCE` set on the subprocess; a `to_text` round-trip proving glow's named ANSI colors survive as ratatui **named** colors (so the theme re-themes them, not flattened to RGB).
- All tests green; clippy-clean on changed files (pre-existing `git.rs` lints untouched — out of scope).
- **Verified live in a herdr pane** (production binary, real asset resolution): H1 `38;5;5` magenta, H2 `38;5;4` blue, inline code `38;5;1` red — all in the themeable 0–15 palette; markers stripped; code blocks highlighted.

## Not in this PR

- `ROADMAP.md` (intentionally uncommitted).
- The other v1.5 items (**mouse**, **herdr keybinding**) — separate PRs; mouse needs a feasibility spike first (does herdr forward mouse events to the focused pane?).