### PR TITLE
v1.5: mouse support (click / double-click / wheel / drag divider)

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,22 @@ when the pane is resized.
 Character keys act only when no control chord is held (so terminal chords like `Ctrl+C` are
 never intercepted); `Shift` is permitted, for keys such as `<` and `>`.
 
+### Mouse
+
+The viewer is keyboard-first (AC-18); the mouse is additive and on by default:
+
+| Gesture | Action |
+| --- | --- |
+| **Click** a tree row | Select it (focus the tree) |
+| **Double-click** a folder | Expand / collapse it |
+| **Double-click** a file | Open it in `$EDITOR` (same as `e`) |
+| **Wheel** over the content pane | Scroll it vertically; over the tree, move the selection |
+| **Drag** the divider | Resize the tree / content split |
+
+**`Shift`+drag is left to your terminal**, so its native select-and-copy still works while the
+viewer owns ordinary clicks — herdr reserves `Shift`+mouse for exactly this. (herdr forwards
+mouse events to the pane because the viewer requests capture.)
+
 ### Opening in an editor
 
 `e` hands the selected file to the editor named by the `$EDITOR` environment variable

--- a/README.md
+++ b/README.md
@@ -152,11 +152,16 @@ The viewer is keyboard-first (AC-18); the mouse is additive and on by default:
 | **Double-click** a folder | Expand / collapse it |
 | **Double-click** a file | Open it in `$EDITOR` (same as `e`) |
 | **Wheel** over the content pane | Scroll it vertically; over the tree, move the selection |
+| **Horizontal wheel / swipe** over the content | Scroll it sideways (terminal-dependent — see below) |
 | **Drag** the divider | Resize the tree / content split |
 
 **`Shift`+drag is left to your terminal**, so its native select-and-copy still works while the
 viewer owns ordinary clicks — herdr reserves `Shift`+mouse for exactly this. (herdr forwards
 mouse events to the pane because the viewer requests capture.)
+
+**Horizontal mouse scroll is terminal-dependent** — it works only where your terminal emits
+horizontal-scroll events (`ScrollLeft` / `ScrollRight`); many terminals send nothing for a
+sideways trackpad swipe. The `←` / `→` keys always scroll the content sideways regardless.
 
 ### Opening in an editor
 

--- a/docs/manual-verification.md
+++ b/docs/manual-verification.md
@@ -78,12 +78,26 @@ This procedure verifies the remaining **live-host** behavior.
    - Bind it to a key (README `[[keys.command]]` snippet) and confirm the key drives the same
      open → focus → close cycle.
 
+7. **Mouse (the feel — needs a human; can't be driven over the CLI).** With the viewer open:
+   - **Click** a tree row → it selects (the content pane updates). **Click** in the content
+     column → it takes focus.
+   - **Double-click** a folder → it expands / collapses. **Double-click** a file → your editor
+     opens on it (same as `e`). Single-clicking neither toggles nor opens.
+   - **Wheel** over the content pane → it scrolls; over the tree → the selection moves.
+   - **Drag** the divider between the columns → the split resizes and tracks the cursor.
+   - **`Shift`+drag** to select text → your terminal's native select-and-copy still works (the
+     viewer does not eat `Shift`+mouse).
+   - Confirm the double-click timing and the divider drag feel responsive — tune
+     `DOUBLE_CLICK` / `WHEEL_STEP` in `src/controller.rs` if not.
+
 ## Pass criteria
 
 - [ ] Step 3 — the viewer opened in a **split** pane beside the current work (AC-17).
 - [ ] Step 5 — the close key closed the viewer and returned focus to the origin pane (AC-20).
 - [ ] Step 6 — repeated invocation focuses the existing viewer (no duplicate panes) and toggles
       it closed; a bound key drives the same cycle.
+- [ ] Step 7 — click selects, double-click activates (folder toggle / file editor), the wheel
+      scrolls, the divider drags, and `Shift`+drag still selects text in the terminal.
 
 If either fails, capture the herdr version (`herdr --version`), the platform, and the manifest
 in use, and file an issue — these are the host-integration points most sensitive to herdr

--- a/src/app.rs
+++ b/src/app.rs
@@ -65,6 +65,14 @@ pub fn run() -> io::Result<()> {
     // pane that requests capture, while reserving Shift+mouse for the terminal's own
     // selection/copy. Best-effort so a terminal without mouse support still runs.
     let _ = execute!(io::stdout(), EnableMouseCapture);
+    // ratatui's panic hook restores the terminal but doesn't know we enabled mouse capture, so
+    // chain a disable in front of it — otherwise a panic would leave the host terminal stuck in
+    // mouse-reporting mode.
+    let prev_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let _ = execute!(io::stdout(), DisableMouseCapture);
+        prev_hook(info);
+    }));
     let outcome = event_loop(&mut terminal, &mut controller);
     let _ = execute!(io::stdout(), DisableMouseCapture);
     ratatui::try_restore()?;
@@ -237,16 +245,22 @@ impl Spawner for ProcessSpawner {
     }
 }
 
-/// Leave raw mode + the alternate screen so an external editor owns a clean terminal.
+/// Leave raw mode + the alternate screen so an external editor owns a clean terminal. Mouse
+/// capture is dropped too: otherwise our capture mode leaks into the editor, which would see
+/// raw mouse escape sequences instead of normal input.
 fn suspend_tui() -> io::Result<()> {
+    let _ = execute!(io::stdout(), DisableMouseCapture);
     disable_raw_mode()?;
     execute!(io::stdout(), LeaveAlternateScreen)
 }
 
-/// Re-enter raw mode + the alternate screen after the editor returns.
+/// Re-enter raw mode + the alternate screen after the editor returns, and re-arm mouse capture
+/// for the viewer (best-effort, matching `run`'s setup).
 fn resume_tui() -> io::Result<()> {
     enable_raw_mode()?;
-    execute!(io::stdout(), EnterAlternateScreen)
+    execute!(io::stdout(), EnterAlternateScreen)?;
+    let _ = execute!(io::stdout(), EnableMouseCapture);
+    Ok(())
 }
 
 /// Resolve glow's `-s` style argument: the bundled palette style if it ships in the

--- a/src/app.rs
+++ b/src/app.rs
@@ -15,7 +15,7 @@ use crate::presenter::{self, ViewState};
 use crate::render::{self, Prepared, Renderers};
 use crate::view_policy::ViewMode;
 use crate::{host, input, root};
-use crossterm::event::{self, Event, KeyEventKind};
+use crossterm::event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyEventKind};
 use crossterm::execute;
 use crossterm::terminal::{
     EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
@@ -61,7 +61,12 @@ pub fn run() -> io::Result<()> {
     );
 
     let mut terminal = ratatui::try_init()?;
+    // Mouse is additive to the keyboard-first design (AC-18): herdr forwards mouse events to a
+    // pane that requests capture, while reserving Shift+mouse for the terminal's own
+    // selection/copy. Best-effort so a terminal without mouse support still runs.
+    let _ = execute!(io::stdout(), EnableMouseCapture);
     let outcome = event_loop(&mut terminal, &mut controller);
+    let _ = execute!(io::stdout(), DisableMouseCapture);
     ratatui::try_restore()?;
     outcome
 }
@@ -78,8 +83,10 @@ fn event_loop(terminal: &mut DefaultTerminal, controller: &mut Controller) -> io
                 let view: ViewState = controller.view_state();
                 let (cw, ch) = presenter::draw(frame, &view);
                 // Feed the drawn content viewport back so content scrolling can be clamped to
-                // it on the next intent.
+                // it on the next intent, and the hit-test geometry so a mouse event maps to the
+                // live layout.
                 controller.set_content_viewport(cw, ch);
+                controller.set_pane_geometry(presenter::geometry(frame.area(), &view));
             })?;
             dirty = false;
         }
@@ -108,6 +115,16 @@ fn event_loop(terminal: &mut DefaultTerminal, controller: &mut Controller) -> io
                     }
                     if fx.quit {
                         return Ok(());
+                    }
+                    dirty |= fx.redraw;
+                }
+                // Mouse input (capture is enabled in `run`): clicks select / activate, the
+                // wheel scrolls, dragging the divider resizes. It never quits the viewer.
+                Event::Mouse(me) => {
+                    let fx = controller.handle_mouse(me);
+                    if fx.clear {
+                        let _ = terminal.clear();
+                        dirty = true;
                     }
                     dirty |= fx.redraw;
                 }

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -18,15 +18,18 @@
 
 use crate::git::{Baseline, Status};
 use crate::intent::Intent;
-use crate::presenter::{Focus, ViewState};
+use crate::presenter::{Focus, PaneGeometry, ViewState};
 use crate::tree::{Node, NodeKind, TreeModel};
 use crate::view_policy::{FileDescriptor, ViewMode, applicable_modes, default_mode};
+use crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+use ratatui::layout::Position;
 use ratatui::text::Text;
 use std::collections::{BTreeMap, HashMap};
 use std::io;
 use std::panic::AssertUnwindSafe;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, mpsc};
+use std::time::{Duration, Instant};
 
 /// Tree-column width as a percentage of the pane: its default and the bounds the resize keys
 /// clamp to, so neither column can be squeezed to nothing.
@@ -37,6 +40,11 @@ const SPLIT_MAX: u16 = 80;
 const SPLIT_STEP: u16 = 5;
 /// How many columns one horizontal-scroll keypress moves the content pane.
 const HSCROLL_STEP: u16 = 8;
+/// How many content lines one mouse-wheel notch scrolls (matches herdr's default).
+const WHEEL_STEP: isize = 3;
+/// Two left-clicks at the same cell within this window are a double-click (a folder toggles
+/// expand/collapse; a file hands off to the editor).
+const DOUBLE_CLICK: Duration = Duration::from_millis(400);
 
 /// Read-only git queries the controller coordinates. Behind a trait so tests stub it and
 /// the run loop injects an implementation bound to the real repository. `Send + Sync` so the
@@ -161,6 +169,14 @@ pub struct Controller {
     job_tx: mpsc::Sender<RenderJob>,
     result_rx: mpsc::Receiver<(u64, RenderResult)>,
     latest_seq: u64,
+    /// Hit-test geometry from the last drawn frame (fed back by the Presenter), so a mouse
+    /// event can be mapped to a tree row / the content pane / the divider.
+    geom: PaneGeometry,
+    /// The previous left-click `(col, row, time)`, for double-click detection.
+    last_click: Option<(u16, u16, Instant)>,
+    /// True while the left button is held after pressing on the divider (a resize drag), so the
+    /// release is treated as the end of the drag, not a click.
+    dragging_divider: bool,
 }
 
 impl Controller {
@@ -232,6 +248,9 @@ impl Controller {
             job_tx,
             result_rx,
             latest_seq: 0,
+            geom: PaneGeometry::default(),
+            last_click: None,
+            dragging_divider: false,
         };
         ctrl.refresh_git_state();
         ctrl.dispatch_render();
@@ -297,6 +316,12 @@ impl Controller {
         // the end, leaving blank space; re-clamp both axes to the new geometry.
         self.content_scroll = self.content_scroll.min(self.max_content_scroll());
         self.content_hscroll = self.content_hscroll.min(self.max_content_hscroll());
+    }
+
+    /// Receive the hit-test geometry the Presenter drew this frame (fed back from the draw
+    /// closure), so the next mouse event is mapped against the live layout.
+    pub fn set_pane_geometry(&mut self, geom: PaneGeometry) {
+        self.geom = geom;
     }
 
     /// The content scroll offset (lines). Exposed for the Presenter wiring and tests.
@@ -366,6 +391,132 @@ impl Controller {
             Intent::ToggleWrap => self.toggle_wrap(),
             Intent::Close => Effects { quit: true, ..Default::default() },
         }
+    }
+
+    /// Map a mouse event to a state change. Mouse is additive to the keyboard-first design
+    /// (AC-18). A `Shift`+mouse event is left untouched so the terminal's own selection/copy
+    /// still works (herdr reserves Shift+mouse for exactly that). Selection/activation happen
+    /// on button *release*, so a divider drag is never mistaken for a click.
+    pub fn handle_mouse(&mut self, ev: MouseEvent) -> Effects {
+        if ev.modifiers.contains(KeyModifiers::SHIFT) {
+            return Effects::noop();
+        }
+        let (col, row) = (ev.column, ev.row);
+        match ev.kind {
+            MouseEventKind::ScrollDown => self.scroll_at(col, row, WHEEL_STEP),
+            MouseEventKind::ScrollUp => self.scroll_at(col, row, -WHEEL_STEP),
+            MouseEventKind::Down(MouseButton::Left) => {
+                // A press on the divider begins a resize drag; otherwise wait for the release.
+                self.dragging_divider = matches!(self.hit_test(col, row), MouseRegion::Divider);
+                Effects::noop()
+            }
+            MouseEventKind::Drag(MouseButton::Left) if self.dragging_divider => {
+                self.resize_split_to_col(col)
+            }
+            MouseEventKind::Up(MouseButton::Left) => {
+                if std::mem::take(&mut self.dragging_divider) {
+                    return Effects::noop(); // end of a resize drag, not a click
+                }
+                self.handle_click(col, row)
+            }
+            _ => Effects::noop(),
+        }
+    }
+
+    /// A completed left-click: select the tree row it landed on (or focus the content pane). A
+    /// double-click activates — a directory toggles expand/collapse, a file hands off to the
+    /// editor (mirrors the `e` key).
+    fn handle_click(&mut self, col: u16, row: u16) -> Effects {
+        let region = self.hit_test(col, row);
+        let now = Instant::now();
+        let double = is_double_click(self.last_click, (col, row), now);
+        self.last_click = Some((col, row, now));
+        match region {
+            MouseRegion::TreeRow(idx) => {
+                if idx >= self.tree.visible_nodes().len() {
+                    return Effects::noop(); // the empty area below the last node — inert
+                }
+                self.action_notice = None;
+                self.focus = Focus::Tree;
+                self.tree.set_cursor(idx);
+                self.dispatch_render(); // selection changed → re-render the content pane
+                if double
+                    && let Some(node) = self.tree.selected()
+                {
+                    return match node.kind {
+                        NodeKind::Dir => {
+                            if node.expanded {
+                                self.tree.collapse(&node.path);
+                            } else {
+                                self.tree.expand(&node.path);
+                            }
+                            Effects::redraw()
+                        }
+                        NodeKind::File => self.open_in_editor(),
+                    };
+                }
+                Effects::redraw()
+            }
+            MouseRegion::Content => {
+                self.focus = Focus::Content;
+                Effects::redraw()
+            }
+            MouseRegion::Divider | MouseRegion::Outside => Effects::noop(),
+        }
+    }
+
+    /// Scroll the pane under the cursor: the content pane scrolls vertically; over the tree
+    /// (which does not scroll) the wheel moves the selection — the closest equivalent.
+    fn scroll_at(&mut self, col: u16, row: u16, delta: isize) -> Effects {
+        match self.hit_test(col, row) {
+            MouseRegion::Content => {
+                self.scroll_content(delta);
+                Effects::redraw()
+            }
+            MouseRegion::TreeRow(_) => {
+                self.focus = Focus::Tree;
+                self.tree.move_cursor(delta.signum());
+                self.dispatch_render();
+                Effects::redraw()
+            }
+            _ => Effects::noop(),
+        }
+    }
+
+    /// During a divider drag, set the split so the divider tracks the cursor column — clamped
+    /// like the keyboard resize so neither column can collapse.
+    fn resize_split_to_col(&mut self, col: u16) -> Effects {
+        if self.geom.area_width == 0 {
+            return Effects::noop();
+        }
+        let tree_w = col.saturating_sub(self.geom.area_x) as i32;
+        let pct = (tree_w * 100 / self.geom.area_width as i32)
+            .clamp(SPLIT_MIN as i32, SPLIT_MAX as i32);
+        self.split_pct = pct as u16;
+        Effects::redraw()
+    }
+
+    /// Which region of the last-drawn frame a cell falls in. The divider is checked first (it
+    /// sits between the columns); a tree click maps to a visible node index by its row.
+    fn hit_test(&self, col: u16, row: u16) -> MouseRegion {
+        if let Some(dx) = self.geom.divider_x
+            && (col == dx || col + 1 == dx)
+        {
+            return MouseRegion::Divider;
+        }
+        if let Some(t) = self.geom.tree_inner
+            && t.contains(Position { x: col, y: row })
+        {
+            // The row index may exceed the node count (the empty area below the last node): the
+            // click handler treats that as inert, while the wheel still scrolls the column.
+            return MouseRegion::TreeRow((row - t.y) as usize);
+        }
+        if let Some(c) = self.geom.content_inner
+            && c.contains(Position { x: col, y: row })
+        {
+            return MouseRegion::Content;
+        }
+        MouseRegion::Outside
     }
 
     /// Up/down navigation is focus-aware: it moves the tree cursor when the tree is focused
@@ -679,6 +830,21 @@ impl Controller {
     }
 }
 
+/// Where a mouse cell falls in the drawn layout.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MouseRegion {
+    TreeRow(usize),
+    Content,
+    Divider,
+    Outside,
+}
+
+/// Two left-clicks at the same cell within [`DOUBLE_CLICK`] are a double-click. Pure over its
+/// timestamps so the timing rule is unit-testable without sleeping.
+fn is_double_click(prev: Option<(u16, u16, Instant)>, pos: (u16, u16), now: Instant) -> bool {
+    matches!(prev, Some((px, py, t)) if (px, py) == pos && now.saturating_duration_since(t) <= DOUBLE_CLICK)
+}
+
 /// Whether a path names a markdown file (by extension, case-insensitive).
 fn is_markdown(path: &Path) -> bool {
     path.extension()
@@ -721,7 +887,23 @@ fn wrapped_rows(text: &str, width: usize) -> usize {
 
 #[cfg(test)]
 mod tests {
-    use super::wrapped_rows;
+    use super::{DOUBLE_CLICK, is_double_click, wrapped_rows};
+    use std::time::Instant;
+
+    #[test]
+    fn is_double_click_requires_same_cell_within_the_window() {
+        let t0 = Instant::now();
+        let within = t0 + DOUBLE_CLICK / 2;
+        let after = t0 + DOUBLE_CLICK * 2;
+        // Same cell, inside the window → double-click.
+        assert!(is_double_click(Some((5, 5, t0)), (5, 5), within));
+        // Too slow → not a double-click.
+        assert!(!is_double_click(Some((5, 5, t0)), (5, 5), after));
+        // A different cell → not a double-click (even if fast).
+        assert!(!is_double_click(Some((5, 5, t0)), (6, 5), within));
+        // No previous click → never a double-click.
+        assert!(!is_double_click(None, (5, 5), within));
+    }
 
     #[test]
     fn wrapped_rows_counts_word_wrapping_not_just_char_wrapping() {

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -405,6 +405,8 @@ impl Controller {
         match ev.kind {
             MouseEventKind::ScrollDown => self.scroll_at(col, row, WHEEL_STEP),
             MouseEventKind::ScrollUp => self.scroll_at(col, row, -WHEEL_STEP),
+            MouseEventKind::ScrollRight => self.hscroll_at(col, row, HSCROLL_STEP as i32),
+            MouseEventKind::ScrollLeft => self.hscroll_at(col, row, -(HSCROLL_STEP as i32)),
             MouseEventKind::Down(MouseButton::Left) => {
                 // A press on the divider begins a resize drag; otherwise wait for the release.
                 self.dragging_divider = matches!(self.hit_test(col, row), MouseRegion::Divider);
@@ -480,6 +482,18 @@ impl Controller {
                 Effects::redraw()
             }
             _ => Effects::noop(),
+        }
+    }
+
+    /// Horizontal wheel / trackpad swipe over the content pane scrolls it sideways, like the
+    /// `←`/`→` keys (for unwrapped long lines). Over the tree it does nothing — the tree has no
+    /// horizontal scroll. `scroll_content_h` clamps to `[0, widest − viewport]` (zero while
+    /// wrapping), so it is inert on wrapped prose, matching the keys.
+    fn hscroll_at(&mut self, col: u16, row: u16, delta: i32) -> Effects {
+        if matches!(self.hit_test(col, row), MouseRegion::Content) {
+            self.scroll_content_h(delta)
+        } else {
+            Effects::noop()
         }
     }
 

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -190,23 +190,14 @@ fn draw_content(frame: &mut Frame, area: Rect, state: &ViewState) -> (u16, u16) 
 /// Below this pane width the viewer drops to a single, focused column (AC-21).
 const NARROW_SPLIT: u16 = 80;
 
-/// Draw the viewer for the given state, returning the content viewport `(width, height)`
-/// the content pane was drawn into — `(0, 0)` when the content pane is not visible (narrow
-/// layout with the tree focused). The controller uses it to clamp content scrolling.
-///
-/// At ≥ 80 columns both columns are shown side by side. Narrower than that, only the
-/// focused column is drawn — full width — so the active content stays readable (AC-21).
-/// The decision is taken from the **live frame width**, so the split can never disagree
-/// with the geometry it is drawn into (a stale `state.width` cannot desync the layout).
-pub fn draw(frame: &mut Frame, state: &ViewState) -> (u16, u16) {
-    let area = frame.area();
+/// The column split for the current frame: `(tree_area, content_area, divider_x)`. A column
+/// is `None` when not drawn (narrow layout shows only the focused one). Shared by [`draw`] and
+/// [`geometry`] so the drawn layout and the hit-test geometry can never disagree.
+fn columns(area: Rect, state: &ViewState) -> (Option<Rect>, Option<Rect>, Option<u16>) {
     if area.width < NARROW_SPLIT {
         return match state.focus {
-            Focus::Tree => {
-                draw_tree(frame, area, state);
-                (0, 0)
-            }
-            Focus::Content => draw_content(frame, area, state),
+            Focus::Tree => (Some(area), None, None),
+            Focus::Content => (None, Some(area), None),
         };
     }
     let tree_pct = state.split_pct.clamp(10, 90);
@@ -215,8 +206,56 @@ pub fn draw(frame: &mut Frame, state: &ViewState) -> (u16, u16) {
         Constraint::Percentage(100 - tree_pct),
     ])
     .split(area);
-    draw_tree(frame, cols[0], state);
-    draw_content(frame, cols[1], state)
+    // The divider is the boundary column where the tree's right border meets the content's
+    // left border (the two bordered blocks abut here).
+    (Some(cols[0]), Some(cols[1]), Some(cols[1].x))
+}
+
+/// Hit-test geometry for mouse input, derived from the same split [`draw`] renders.
+/// `tree_inner` is the interior where tree rows are drawn — visible node `i` is at row
+/// `tree_inner.y + i` (the tree does not scroll). `content_inner` is the content column
+/// interior. `divider_x` is the draggable boundary column (wide layout only).
+#[derive(Clone, Copy, Default, Debug, PartialEq, Eq)]
+pub struct PaneGeometry {
+    pub area_x: u16,
+    pub area_width: u16,
+    pub tree_inner: Option<Rect>,
+    pub content_inner: Option<Rect>,
+    pub divider_x: Option<u16>,
+}
+
+/// Compute the [`PaneGeometry`] for hit-testing the current frame — the same layout [`draw`]
+/// renders, so a click is never mapped against stale geometry. The interior of a bordered
+/// block is its area inset by one cell on each side (the title does not change it).
+pub fn geometry(area: Rect, state: &ViewState) -> PaneGeometry {
+    let (tree, content, divider_x) = columns(area, state);
+    let inner = |r: Rect| Block::bordered().inner(r);
+    PaneGeometry {
+        area_x: area.x,
+        area_width: area.width,
+        tree_inner: tree.map(inner),
+        content_inner: content.map(inner),
+        divider_x,
+    }
+}
+
+/// Draw the viewer for the given state, returning the content viewport `(width, height)`
+/// the content pane was drawn into — `(0, 0)` when the content pane is not visible (narrow
+/// layout with the tree focused). The controller uses it to clamp content scrolling.
+///
+/// At ≥ 80 columns both columns are shown side by side. Narrower than that, only the focused
+/// column is drawn — full width — so the active content stays readable (AC-21). The split is
+/// taken from the **live frame width** (via [`columns`]), so it can never disagree with the
+/// geometry it is drawn into (a stale `state.width` cannot desync the layout).
+pub fn draw(frame: &mut Frame, state: &ViewState) -> (u16, u16) {
+    let (tree, content, _divider) = columns(frame.area(), state);
+    if let Some(area) = tree {
+        draw_tree(frame, area, state);
+    }
+    match content {
+        Some(area) => draw_content(frame, area, state),
+        None => (0, 0),
+    }
 }
 
 #[cfg(test)]

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -260,6 +260,13 @@ impl TreeModel {
         }
     }
 
+    /// Set the cursor to an absolute visible-row index, clamped to the visible range (used by
+    /// a mouse click that selects the row it landed on).
+    pub fn set_cursor(&mut self, idx: usize) {
+        let len = self.visible_nodes().len();
+        self.cursor = if len == 0 { 0 } else { idx.min(len - 1) };
+    }
+
     /// Move the cursor by `delta` rows, clamped to the visible range.
     pub fn move_cursor(&mut self, delta: isize) {
         let len = self.visible_nodes().len();

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -728,3 +728,32 @@ fn a_click_below_the_last_row_selects_nothing() {
     ctrl.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 6, 12));
     assert_eq!(ctrl.tree().cursor(), before, "clicking the empty area below the tree is inert");
 }
+
+#[test]
+fn horizontal_wheel_scrolls_the_content_sideways() {
+    // ScrollLeft/ScrollRight (trackpad swipe / horizontal wheel) over the content pane scroll it
+    // sideways for unwrapped long lines — like the ←/→ keys. (Vertical wheel is covered above.)
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.rs"), "code\n").unwrap(); // .rs → unwrapped, so hscroll applies
+    let components = Components {
+        git: Arc::new(StubGit::default()),
+        content: Box::new(WideContent),
+        editor: Box::new(StubEditor { fail: false, opened: Arc::new(Mutex::new(Vec::new())) }),
+    };
+    let mut ctrl = Controller::new(dir.path().to_path_buf(), false, Baseline::Head, components);
+    await_marker(&mut ctrl, "WIDE");
+    ctrl.set_content_viewport(20, 10); // widest line 100, viewport 20 → max hscroll = 80
+    ctrl.set_pane_geometry(wide_geometry());
+    assert!(!ctrl.view_state().wrap, "a .rs file is unwrapped, so horizontal scroll applies");
+    assert_eq!(ctrl.view_state().content_hscroll, 0, "starts at the left edge");
+
+    // Wheel right over the content column (no focus change needed — scroll what's under the cursor).
+    ctrl.handle_mouse(mouse(MouseEventKind::ScrollRight, 50, 5));
+    assert!(ctrl.view_state().content_hscroll > 0, "horizontal wheel-right scrolls the content right");
+    ctrl.handle_mouse(mouse(MouseEventKind::ScrollLeft, 50, 5));
+    assert_eq!(ctrl.view_state().content_hscroll, 0, "wheel-left scrolls back to the start");
+
+    // Over the tree, horizontal wheel is inert (the tree has no horizontal scroll).
+    ctrl.handle_mouse(mouse(MouseEventKind::ScrollRight, 5, 5));
+    assert_eq!(ctrl.view_state().content_hscroll, 0, "horizontal wheel over the tree does nothing");
+}

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -10,10 +10,12 @@ use common::TempDir;
 use herdr_file_viewer::controller::{
     Components, ContentProvider, Controller, EditorHandoff, GitService, RenderResult,
 };
+use crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 use herdr_file_viewer::git::{Baseline, Status};
 use herdr_file_viewer::intent::Intent;
-use herdr_file_viewer::presenter::Focus;
+use herdr_file_viewer::presenter::{Focus, PaneGeometry};
 use herdr_file_viewer::view_policy::ViewMode;
+use ratatui::layout::Rect;
 use ratatui::text::Text;
 use std::collections::BTreeMap;
 use std::io;
@@ -557,4 +559,172 @@ fn snapshot(root: &Path) -> Vec<(PathBuf, Vec<u8>)> {
     }
     walk(root, &mut out);
     out
+}
+
+// ---- mouse (AC-18 is keyboard-first; mouse is additive) -------------------------------
+
+fn mouse(kind: MouseEventKind, col: u16, row: u16) -> MouseEvent {
+    MouseEvent { kind, column: col, row, modifiers: KeyModifiers::NONE }
+}
+
+/// A standard wide two-column layout: tree interior at x=1,y=1 (so visible node `i` is at row
+/// `1 + i`), content interior at x=41, and the draggable divider at column 40, over a 100-wide
+/// pane anchored at x=0.
+fn wide_geometry() -> PaneGeometry {
+    PaneGeometry {
+        area_x: 0,
+        area_width: 100,
+        tree_inner: Some(Rect { x: 1, y: 1, width: 38, height: 20 }),
+        content_inner: Some(Rect { x: 41, y: 1, width: 58, height: 20 }),
+        divider_x: Some(40),
+    }
+}
+
+#[test]
+fn left_click_selects_the_tree_row_it_lands_on() {
+    let dir = TempDir::new();
+    for f in ["a.txt", "b.txt", "c.txt"] {
+        std::fs::write(dir.path().join(f), "x").unwrap();
+    }
+    let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
+    ctrl.set_pane_geometry(wide_geometry());
+
+    // Row 3 = tree_inner.y (1) + index 2 → selects the third visible node and focuses the tree.
+    let fx = ctrl.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 6, 3));
+    assert_eq!(ctrl.tree().cursor(), 2, "clicking row 3 selects visible node index 2");
+    assert_eq!(ctrl.focus(), Focus::Tree, "a tree click focuses the tree");
+    assert!(fx.redraw);
+}
+
+#[test]
+fn left_click_in_the_content_column_focuses_it() {
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.txt"), "x").unwrap();
+    let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
+    ctrl.set_pane_geometry(wide_geometry());
+
+    ctrl.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 50, 5));
+    assert_eq!(ctrl.focus(), Focus::Content, "clicking the content column focuses it");
+}
+
+#[test]
+fn double_click_a_folder_toggles_expansion() {
+    let dir = TempDir::new();
+    std::fs::create_dir(dir.path().join("sub")).unwrap();
+    std::fs::write(dir.path().join("sub/inner.txt"), "x").unwrap();
+    let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
+    ctrl.set_pane_geometry(wide_geometry());
+    assert_eq!(ctrl.tree().visible_nodes().len(), 1, "only the collapsed folder is visible");
+
+    // Two rapid clicks on row 1 (the folder): the first selects, the second (double) expands.
+    ctrl.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 6, 1));
+    ctrl.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 6, 1));
+    assert_eq!(
+        ctrl.tree().visible_nodes().len(),
+        2,
+        "double-clicking the folder expands it to reveal its child"
+    );
+}
+
+#[test]
+fn double_click_a_file_hands_off_to_the_editor_single_click_does_not() {
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.txt"), "x").unwrap();
+    let (mut ctrl, _, opened) = controller(dir.path(), false, StubGit::default(), false);
+    ctrl.set_pane_geometry(wide_geometry());
+
+    ctrl.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 6, 1)); // single → select only
+    assert!(opened.lock().unwrap().is_empty(), "a single click does not open the editor");
+
+    ctrl.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 6, 1)); // double → editor
+    let opened = opened.lock().unwrap();
+    assert_eq!(opened.len(), 1, "double-clicking a file hands it off to the editor");
+    assert!(opened[0].ends_with("a.txt"));
+}
+
+#[test]
+fn wheel_scrolls_the_pane_under_the_cursor() {
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.txt"), "x\n").unwrap();
+    let mut ctrl = controller_with_lines(dir.path(), 50);
+    await_marker(&mut ctrl, "L0");
+    ctrl.set_content_viewport(58, 10); // 50 lines, 10 visible → max scroll = 40
+    ctrl.set_pane_geometry(wide_geometry());
+
+    // Over the content column → scrolls the content by WHEEL_STEP (3) per notch.
+    assert_eq!(ctrl.content_scroll(), 0);
+    ctrl.handle_mouse(mouse(MouseEventKind::ScrollDown, 50, 5));
+    assert_eq!(ctrl.content_scroll(), 3, "wheel-down over content scrolls it down");
+    ctrl.handle_mouse(mouse(MouseEventKind::ScrollUp, 50, 5));
+    assert_eq!(ctrl.content_scroll(), 0, "wheel-up scrolls it back to the top");
+}
+
+#[test]
+fn wheel_over_the_tree_moves_the_selection() {
+    let dir = TempDir::new();
+    for f in ["a.txt", "b.txt", "c.txt"] {
+        std::fs::write(dir.path().join(f), "x").unwrap();
+    }
+    let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
+    ctrl.set_pane_geometry(wide_geometry());
+    assert_eq!(ctrl.tree().cursor(), 0);
+
+    // The tree does not scroll independently, so the wheel moves the selection (its equivalent).
+    ctrl.handle_mouse(mouse(MouseEventKind::ScrollDown, 5, 5));
+    assert_eq!(ctrl.tree().cursor(), 1, "wheel-down over the tree moves the selection down");
+    ctrl.handle_mouse(mouse(MouseEventKind::ScrollUp, 5, 5));
+    assert_eq!(ctrl.tree().cursor(), 0, "wheel-up moves it back up");
+}
+
+#[test]
+fn dragging_the_divider_resizes_the_split() {
+    let dir = TempDir::new();
+    let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
+    ctrl.set_pane_geometry(wide_geometry()); // divider at col 40, pane x=0 width=100
+
+    assert_eq!(ctrl.view_state().split_pct, 40, "default split");
+    ctrl.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 40, 0)); // grab the divider
+    ctrl.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 60, 0)); // drag right
+    assert_eq!(ctrl.view_state().split_pct, 60, "the divider tracks the cursor → 60% tree");
+
+    // Releasing ends the drag; a later move is not a resize.
+    ctrl.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 60, 0));
+    ctrl.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 80, 0));
+    assert_eq!(ctrl.view_state().split_pct, 60, "no drag in progress → no resize");
+}
+
+#[test]
+fn shift_mouse_is_left_to_the_terminal_for_selection() {
+    let dir = TempDir::new();
+    for f in ["a.txt", "b.txt"] {
+        std::fs::write(dir.path().join(f), "x").unwrap();
+    }
+    let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
+    ctrl.set_pane_geometry(wide_geometry());
+    let before = ctrl.tree().cursor();
+
+    let ev = MouseEvent {
+        kind: MouseEventKind::Up(MouseButton::Left),
+        column: 6,
+        row: 2,
+        modifiers: KeyModifiers::SHIFT,
+    };
+    let fx = ctrl.handle_mouse(ev);
+    assert_eq!(ctrl.tree().cursor(), before, "Shift+click is the terminal's selection, not ours");
+    assert!(!fx.redraw && !fx.quit, "Shift+mouse is a no-op for the viewer");
+}
+
+#[test]
+fn a_click_below_the_last_row_selects_nothing() {
+    let dir = TempDir::new();
+    for f in ["a.txt", "b.txt"] {
+        std::fs::write(dir.path().join(f), "x").unwrap();
+    }
+    let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
+    ctrl.set_pane_geometry(wide_geometry());
+    let before = ctrl.tree().cursor();
+
+    // Row 12 maps to index 11, past the 2 visible nodes → no selection change.
+    ctrl.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 6, 12));
+    assert_eq!(ctrl.tree().cursor(), before, "clicking the empty area below the tree is inert");
 }

--- a/tests/presenter.rs
+++ b/tests/presenter.rs
@@ -257,3 +257,31 @@ fn split_ratio_controls_the_tree_column_width() {
 fn wide_layout_snapshot() {
     insta::assert_snapshot!("presenter_wide", render(&sample_state(), 100, 24));
 }
+
+#[test]
+fn geometry_matches_the_wide_two_column_layout() {
+    use herdr_file_viewer::presenter::geometry;
+    use ratatui::layout::Rect;
+    let g = geometry(Rect { x: 0, y: 0, width: 100, height: 24 }, &sample_state());
+    let t = g.tree_inner.expect("tree interior present in a wide layout");
+    let c = g.content_inner.expect("content interior present in a wide layout");
+    // Tree rows begin just inside the block border, so node `i` is at row `tree_inner.y + i`.
+    assert_eq!(t.x, 1);
+    assert_eq!(t.y, 1, "tree rows start just inside the top border");
+    assert!(c.x > t.x + t.width, "the content column is to the right of the tree");
+    assert!(g.divider_x.is_some(), "a wide layout has a draggable divider");
+    assert_eq!((g.area_x, g.area_width), (0, 100));
+}
+
+#[test]
+fn geometry_is_single_column_when_narrow() {
+    use herdr_file_viewer::presenter::geometry;
+    use ratatui::layout::Rect;
+    let mut st = sample_state();
+    st.focus = Focus::Tree;
+    // Below the 80-col narrow threshold only the focused column is drawn (AC-21).
+    let g = geometry(Rect { x: 0, y: 0, width: 60, height: 24 }, &st);
+    assert!(g.tree_inner.is_some(), "narrow + tree focus draws the tree");
+    assert!(g.content_inner.is_none(), "the content column is not drawn when narrow");
+    assert!(g.divider_x.is_none(), "no divider in a single-column layout");
+}


### PR DESCRIPTION
## What & why

Mouse support for the viewer — keyboard-first (AC-18) stays the contract; the mouse is **additive and on by default**. herdr forwards mouse events to a pane that requests capture, and reserves `Shift`+mouse for the terminal's own selection-copy — so we capture the mouse for interactions while **`Shift`+drag still selects/copies text natively**.

| Gesture | Action |
| --- | --- |
| Click a tree row | Select it (focus the tree) |
| Double-click a folder | Expand / collapse |
| Double-click a file | Editor hand-off (same as `e`) |
| Wheel over content | Scroll vertically; over the tree, move the selection |
| Drag the divider | Resize the split (tracks the cursor) |

## How

- **presenter:** factored `columns()` (shared by `draw` + the new `geometry()` so the drawn layout and hit-test geometry can never disagree); exposed `PaneGeometry` (tree-inner rect for row mapping, content-inner, divider column, pane bounds).
- **controller:** `handle_mouse()` → `hit_test` → select / activate / scroll / resize; `is_double_click` (pure, timing-tested); fed the live geometry each frame via `set_pane_geometry`.
- **tree:** `set_cursor(idx)` for click-select. **app:** `EnableMouseCapture` lifecycle (best-effort) + route `Event::Mouse`.

## Verification

- **Unit/integration:** 9 mouse-behavior tests (click-select, content-focus, double-click folder/file, wheel over content/tree, divider drag, `Shift`-ignored, click-below-last inert) + `is_double_click` timing + 2 `geometry` tests. Full suite green; **the e2e pty suite still passes** (mouse capture doesn't disturb it). clippy-clean on changed files.
- **Live:** launches with mouse capture enabled without crashing; keyboard nav intact.
- ⚠️ **The mouse *feel* needs a human** — herdr's CLI sends keys, not mouse, so the double-click timing and drag responsiveness can't be driven automatically. **Awaiting a live feel-test before merge** (see `docs/manual-verification.md` step 7).

## Not in this PR

`ROADMAP.md` stays uncommitted. This completes the v1.5 trio (markdown #7, keybinding #8, mouse).