### PR TITLE
docs: note the herdr --remote keybinding limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,13 +120,7 @@ viewer via the same idempotent launcher. (Alternatively, `command` may invoke
 default, and herdr has no way to fire a plugin action into the *attached* (remote) session from
 a local key: a `type = "shell"` command runs against your **local** herdr (wrong session), and a
 `type = "pane"` command runs in a throwaway pane that closes the instant it exits (so the viewer
-doesn't persist). To drive the viewer on the remote, either:
-
-- attach with **`herdr --remote <host> --remote-keybindings server`** — the binding then lives in
-  the *server's* `config.toml` and behaves fully (open / focus / close-toggle); or
-- bind a `type = "shell"` command that SSHes in:
-  `command = "ssh <host> 'herdr plugin action invoke open-file-viewer --plugin herdr-file-viewer'"`
-  (needs passwordless SSH; the host is baked into the binding).
+doesn't persist).
 
 This is a herdr keybinding/remote limitation, not the plugin's — the action and launcher work
 the same locally and remotely; it's only *which* keymap fires them across `--remote` that differs.

--- a/README.md
+++ b/README.md
@@ -116,6 +116,21 @@ Reload with `herdr server reload-config`. Pressing the key then opens / focuses 
 viewer via the same idempotent launcher. (Alternatively, `command` may invoke
 `scripts/open-file-viewer.sh` directly using the absolute install path from `herdr plugin list`.)
 
+**Limitation over `herdr --remote`.** `--remote` attaches with **local** keybindings by
+default, and herdr has no way to fire a plugin action into the *attached* (remote) session from
+a local key: a `type = "shell"` command runs against your **local** herdr (wrong session), and a
+`type = "pane"` command runs in a throwaway pane that closes the instant it exits (so the viewer
+doesn't persist). To drive the viewer on the remote, either:
+
+- attach with **`herdr --remote <host> --remote-keybindings server`** — the binding then lives in
+  the *server's* `config.toml` and behaves fully (open / focus / close-toggle); or
+- bind a `type = "shell"` command that SSHes in:
+  `command = "ssh <host> 'herdr plugin action invoke open-file-viewer --plugin herdr-file-viewer'"`
+  (needs passwordless SSH; the host is baked into the binding).
+
+This is a herdr keybinding/remote limitation, not the plugin's — the action and launcher work
+the same locally and remotely; it's only *which* keymap fires them across `--remote` that differs.
+
 ## Keys
 
 | Key | Action |

--- a/README.md
+++ b/README.md
@@ -120,7 +120,9 @@ viewer via the same idempotent launcher. (Alternatively, `command` may invoke
 default, and herdr has no way to fire a plugin action into the *attached* (remote) session from
 a local key: a `type = "shell"` command runs against your **local** herdr (wrong session), and a
 `type = "pane"` command runs in a throwaway pane that closes the instant it exits (so the viewer
-doesn't persist).
+doesn't persist). To drive the viewer on the remote, attach with
+**`herdr --remote <host> --remote-keybindings server`** — the binding then lives in the
+*server's* `config.toml` and behaves fully (open / focus / close-toggle).
 
 This is a herdr keybinding/remote limitation, not the plugin's — the action and launcher work
 the same locally and remotely; it's only *which* keymap fires them across `--remote` that differs.


### PR DESCRIPTION
One-paragraph docs-only addition to the README's *Summoning the viewer* section.

Documents that a herdr keybinding can't open the viewer in the **attached remote session** under `herdr --remote`'s default (local) keymap — `type="shell"` hits the local herdr, `type="pane"` runs in a throwaway pane that closes immediately. Records the two workarounds (`--remote-keybindings server`, or an `ssh`-shell command). This is a herdr limitation, not the plugin's.

Docs-only — no code change. Happy to fast-merge or run a light review; your call.