### PR TITLE
Refresh git state on focus-gain + the `r` key

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ the same locally and remotely; it's only *which* keymap fires them across `--rem
 | `Tab` | Move focus between the tree and content columns |
 | `<` / `>` | Narrow / widen the tree column (move the divider) |
 | `w` | Toggle line wrapping for the content pane |
+| `r` | Refresh git state — pick up changes made outside the viewer (a merge / pull / commit elsewhere) |
 | `q` / `Esc` | Close the viewer and return to the prior pane |
 
 `Tab` to the content pane, then the arrow keys (or `h`/`j`/`k`/`l`) scroll it in all four
@@ -149,6 +150,11 @@ directions; `Tab` back to the tree to move between files. Long lines wrap in pro
 plain text); diffs and code keep their original lines so columns stay aligned — scroll
 sideways with `←`/`→`, or press `w` to wrap them instead. The layout reflows automatically
 when the pane is resized.
+
+**Git state stays current.** The viewer re-reads git status when the pane **regains focus**, so
+changes you make outside it (a merge, pull, or commit in another pane) show up automatically; `r`
+forces a full refresh on demand. (Focus-refresh updates the tree's status without disturbing your
+content scroll.)
 
 Character keys act only when no control chord is held (so terminal chords like `Ctrl+C` are
 never intercepted); `Shift` is permitted, for keys such as `<` and `>`.

--- a/src/app.rs
+++ b/src/app.rs
@@ -15,7 +15,10 @@ use crate::presenter::{self, ViewState};
 use crate::render::{self, Prepared, Renderers};
 use crate::view_policy::ViewMode;
 use crate::{host, input, root};
-use crossterm::event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyEventKind};
+use crossterm::event::{
+    self, DisableFocusChange, DisableMouseCapture, EnableFocusChange, EnableMouseCapture, Event,
+    KeyEventKind,
+};
 use crossterm::execute;
 use crossterm::terminal::{
     EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
@@ -65,16 +68,21 @@ pub fn run() -> io::Result<()> {
     // pane that requests capture, while reserving Shift+mouse for the terminal's own
     // selection/copy. Best-effort so a terminal without mouse support still runs.
     let _ = execute!(io::stdout(), EnableMouseCapture);
+    // Request focus-change reporting so the viewer can refresh git state when it regains focus
+    // (herdr forwards FocusGained/FocusLost to a pane that opts in). Best-effort.
+    let _ = execute!(io::stdout(), EnableFocusChange);
     // ratatui's panic hook restores the terminal but doesn't know we enabled mouse capture, so
     // chain a disable in front of it — otherwise a panic would leave the host terminal stuck in
     // mouse-reporting mode.
     let prev_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
         let _ = execute!(io::stdout(), DisableMouseCapture);
+        let _ = execute!(io::stdout(), DisableFocusChange);
         prev_hook(info);
     }));
     let outcome = event_loop(&mut terminal, &mut controller);
     let _ = execute!(io::stdout(), DisableMouseCapture);
+    let _ = execute!(io::stdout(), DisableFocusChange);
     ratatui::try_restore()?;
     outcome
 }
@@ -136,6 +144,11 @@ fn event_loop(terminal: &mut DefaultTerminal, controller: &mut Controller) -> io
                     }
                     dirty |= fx.redraw;
                 }
+                // The pane regained focus (herdr forwards focus events to a pane that opts in):
+                // re-read git state so external changes — a merge, pull, or commit in another
+                // pane — show in the tree without a relaunch. FocusLost needs no action.
+                Event::FocusGained => dirty |= controller.handle_focus_gained().redraw,
+                Event::FocusLost => {}
                 // The pane was resized: redraw so the two-column layout and content reflow to
                 // the new geometry. `terminal.draw` autoresizes its buffers before drawing, so
                 // marking the frame dirty is enough.
@@ -250,6 +263,7 @@ impl Spawner for ProcessSpawner {
 /// raw mouse escape sequences instead of normal input.
 fn suspend_tui() -> io::Result<()> {
     let _ = execute!(io::stdout(), DisableMouseCapture);
+    let _ = execute!(io::stdout(), DisableFocusChange);
     disable_raw_mode()?;
     execute!(io::stdout(), LeaveAlternateScreen)
 }
@@ -260,6 +274,7 @@ fn resume_tui() -> io::Result<()> {
     enable_raw_mode()?;
     execute!(io::stdout(), EnterAlternateScreen)?;
     let _ = execute!(io::stdout(), EnableMouseCapture);
+    let _ = execute!(io::stdout(), EnableFocusChange);
     Ok(())
 }
 

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -756,11 +756,20 @@ impl Controller {
     }
 
     /// The pane regained focus (the run loop forwards herdr's focus events): re-read git state
-    /// so external changes show in the tree, but do NOT re-render the content — re-rendering on
-    /// every focus change would reset the scroll. The fresh status repaints on the next draw;
-    /// the content re-renders on the next selection (or an explicit `r`). No-op without a repo.
+    /// so external changes show in the tree. No-op without a repo (AC-26) — so an external
+    /// change to a non-git directory costs nothing. In **changed-only** mode the refresh
+    /// re-filters the visible list, which can move the cursor to a different file; if the
+    /// selection actually changed, re-render so the content pane matches the highlighted row —
+    /// otherwise the content (and its scroll) is left untouched, the common case.
     pub fn handle_focus_gained(&mut self) -> Effects {
+        if !self.is_git_repo {
+            return Effects::noop();
+        }
+        let before = self.tree.selected().map(|n| n.path);
         self.refresh_git_state();
+        if self.tree.selected().map(|n| n.path) != before {
+            self.dispatch_render();
+        }
         Effects::redraw()
     }
 

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -389,6 +389,7 @@ impl Controller {
             Intent::ShrinkTree => self.resize_split(-(SPLIT_STEP as i16)),
             Intent::GrowTree => self.resize_split(SPLIT_STEP as i16),
             Intent::ToggleWrap => self.toggle_wrap(),
+            Intent::Refresh => self.refresh(),
             Intent::Close => Effects { quit: true, ..Default::default() },
         }
     }
@@ -745,12 +746,29 @@ impl Controller {
         self.wrap_for(self.tree.selected().as_ref())
     }
 
+    /// `r` — explicitly re-read git state and re-render the current selection, so the viewer
+    /// picks up changes made outside it (a merge, pull, or commit in another pane). A full
+    /// refresh: it re-renders the content (resetting its scroll), since the user asked for it.
+    fn refresh(&mut self) -> Effects {
+        self.refresh_git_state();
+        self.dispatch_render();
+        Effects::redraw()
+    }
+
+    /// The pane regained focus (the run loop forwards herdr's focus events): re-read git state
+    /// so external changes show in the tree, but do NOT re-render the content — re-rendering on
+    /// every focus change would reset the scroll. The fresh status repaints on the next draw;
+    /// the content re-renders on the next selection (or an explicit `r`). No-op without a repo.
+    pub fn handle_focus_gained(&mut self) -> Effects {
+        self.refresh_git_state();
+        Effects::redraw()
+    }
+
     /// Re-query git for the working-tree status (tree markers, AC-7) and the changed-set
-    /// against the active baseline (AC-16), updating the tree caches. Used at launch and
-    /// after an editor hand-off returns (the file may have changed). No-op without a repo
-    /// (AC-26). This runs on the calling thread, but only on deliberate, infrequent actions
-    /// (launch, editor return, baseline toggle) — never the hot navigation path, where the
-    /// diff is fetched off-thread (AC-23).
+    /// against the active baseline (AC-16), updating the tree caches. No-op without a repo
+    /// (AC-26). Runs on the calling thread, but only on deliberate, infrequent actions —
+    /// launch, editor return, baseline toggle, the `r` refresh key, and focus-gain — never the
+    /// hot navigation path, where the diff is fetched off-thread (AC-23).
     fn refresh_git_state(&mut self) {
         if !self.is_git_repo {
             return;

--- a/src/input.rs
+++ b/src/input.rs
@@ -31,6 +31,7 @@ pub fn map_key(key: KeyEvent) -> Option<Intent> {
         KeyCode::Char('<') => Some(Intent::ShrinkTree),
         KeyCode::Char('>') => Some(Intent::GrowTree),
         KeyCode::Char('w') => Some(Intent::ToggleWrap),
+        KeyCode::Char('r') => Some(Intent::Refresh),
         KeyCode::Char('q') | KeyCode::Esc => Some(Intent::Close),
         _ => None,
     }
@@ -64,6 +65,7 @@ mod tests {
         (KeyCode::Char('<'), Intent::ShrinkTree),
         (KeyCode::Char('>'), Intent::GrowTree),
         (KeyCode::Char('w'), Intent::ToggleWrap),
+        (KeyCode::Char('r'), Intent::Refresh),
         (KeyCode::Char('q'), Intent::Close),
         (KeyCode::Esc, Intent::Close),
     ];

--- a/src/intent.rs
+++ b/src/intent.rs
@@ -35,6 +35,9 @@ pub enum Intent {
     /// Force content-line wrapping on/off, overriding the per-mode default (so long lines in
     /// code and diffs can be wrapped on demand instead of truncated).
     ToggleWrap,
+    /// Re-read git state (working-tree status + changed-set) and re-render, so the viewer picks
+    /// up changes made outside it — a merge, pull, or commit in another pane. Read-only.
+    Refresh,
     /// Close the viewer and return control to the prior pane (AC-20).
     Close,
 }
@@ -42,7 +45,7 @@ pub enum Intent {
 impl Intent {
     /// Every intent variant — lets the dispatcher and tests enumerate the closed set so
     /// keyboard-completeness (AC-18) and the no-edit invariant (AC-N3) stay checkable.
-    pub const ALL: [Intent; 14] = [
+    pub const ALL: [Intent; 15] = [
         Intent::NavUp,
         Intent::NavDown,
         Intent::Expand,
@@ -56,6 +59,7 @@ impl Intent {
         Intent::ShrinkTree,
         Intent::GrowTree,
         Intent::ToggleWrap,
+        Intent::Refresh,
         Intent::Close,
     ];
 }
@@ -86,6 +90,7 @@ mod tests {
                 | Intent::ShrinkTree
                 | Intent::GrowTree
                 | Intent::ToggleWrap
+                | Intent::Refresh
                 | Intent::Close => false,
             };
             assert!(!mutates_file, "{intent:?} must not mutate file contents (AC-N3)");

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -757,3 +757,49 @@ fn horizontal_wheel_scrolls_the_content_sideways() {
     ctrl.handle_mouse(mouse(MouseEventKind::ScrollRight, 5, 5));
     assert_eq!(ctrl.view_state().content_hscroll, 0, "horizontal wheel over the tree does nothing");
 }
+
+// ---- refresh: pick up external git changes (the `r` key + focus-gain) ------------------
+
+#[test]
+fn refresh_re_queries_git_state_and_redraws() {
+    // `r` re-reads git so a change made outside the viewer (merge/pull/commit elsewhere) shows.
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.txt"), "x").unwrap();
+    let (mut ctrl, changed_calls, _) = controller(dir.path(), true, StubGit::default(), false);
+    let before = changed_calls.lock().unwrap().len();
+
+    let fx = ctrl.handle(Intent::Refresh);
+    assert!(fx.redraw, "Refresh redraws");
+    assert!(
+        changed_calls.lock().unwrap().len() > before,
+        "Refresh re-queries git for the changed-set"
+    );
+}
+
+#[test]
+fn focus_gained_re_queries_git_but_preserves_content_scroll() {
+    // Regaining focus refreshes the tree's git state (external changes show) WITHOUT re-rendering
+    // the content — so the user's scroll position is not reset on every focus change.
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.txt"), "x\n").unwrap();
+    let git = StubGit::default();
+    let changed_calls = git.changed_calls.clone();
+    let components = Components {
+        git: Arc::new(git),
+        content: Box::new(LinesContent { n: 50 }),
+        editor: Box::new(StubEditor { fail: false, opened: Arc::new(Mutex::new(Vec::new())) }),
+    };
+    let mut ctrl = Controller::new(dir.path().to_path_buf(), true, Baseline::Head, components);
+    await_marker(&mut ctrl, "L0");
+    ctrl.set_content_viewport(40, 10);
+    ctrl.handle(Intent::ToggleFocus); // focus the content pane
+    ctrl.handle(Intent::NavDown);
+    ctrl.handle(Intent::NavDown);
+    assert_eq!(ctrl.view_state().content_scroll, 2, "scrolled down two lines");
+    let before = changed_calls.lock().unwrap().len();
+
+    let fx = ctrl.handle_focus_gained();
+    assert!(fx.redraw, "focus-gain redraws (fresh tree colours)");
+    assert!(changed_calls.lock().unwrap().len() > before, "focus-gain re-queries git");
+    assert_eq!(ctrl.view_state().content_scroll, 2, "focus-gain does NOT reset the content scroll");
+}

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -803,3 +803,79 @@ fn focus_gained_re_queries_git_but_preserves_content_scroll() {
     assert!(changed_calls.lock().unwrap().len() > before, "focus-gain re-queries git");
     assert_eq!(ctrl.view_state().content_scroll, 2, "focus-gain does NOT reset the content scroll");
 }
+
+#[test]
+fn focus_gained_without_a_repo_is_inert() {
+    // No repo → nothing to refresh (AC-26); focus-gain must not force a redraw or a git query.
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.txt"), "x").unwrap();
+    let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
+    let fx = ctrl.handle_focus_gained();
+    assert!(!fx.redraw && !fx.quit, "no repo → focus-gain is a no-op");
+}
+
+/// A Git stub whose changed-set flips from `first` to `rest` after the first query — so a
+/// changed-only re-filter on focus-gain moves the selection. `status` is fixed.
+struct EvolvingGit {
+    status: BTreeMap<PathBuf, Status>,
+    first: BTreeMap<PathBuf, Status>,
+    rest: BTreeMap<PathBuf, Status>,
+    calls: Arc<Mutex<usize>>,
+}
+impl GitService for EvolvingGit {
+    fn status(&self) -> BTreeMap<PathBuf, Status> {
+        self.status.clone()
+    }
+    fn changed_set(&self, _baseline: Baseline) -> BTreeMap<PathBuf, Status> {
+        let mut n = self.calls.lock().unwrap();
+        *n += 1;
+        if *n <= 1 { self.first.clone() } else { self.rest.clone() }
+    }
+    fn diff(&self, _p: &Path, _b: Baseline) -> String {
+        String::new()
+    }
+}
+
+/// A Content Renderer that renders the file's path, so a test can see which file the content
+/// pane is showing (and thus catch a tree/content desync).
+struct PathContent;
+impl ContentProvider for PathContent {
+    fn render(&self, path: &Path, _m: ViewMode, _d: Option<&str>) -> RenderResult {
+        RenderResult { content: Text::raw(format!("showing {}", path.display())), notices: Vec::new() }
+    }
+}
+
+#[test]
+fn focus_gained_keeps_tree_and_content_in_sync_after_a_changed_only_refilter() {
+    // Regression (the gate's medium): in changed-only mode, an external change that drops the
+    // selected file from the changed-set re-filters the tree on focus-gain and moves the cursor.
+    // The content pane must FOLLOW the new selection (pre-fix it stayed on the old file → desync).
+    // A single changed file at each step makes the selection deterministic.
+    let dir = TempDir::new();
+    for f in ["a.rs", "b.rs"] {
+        std::fs::write(dir.path().join(f), "x").unwrap();
+    }
+    let (a, b) = (PathBuf::from("a.rs"), PathBuf::from("b.rs"));
+    let git = EvolvingGit {
+        status: BTreeMap::from([(a.clone(), Status::Modified), (b.clone(), Status::Modified)]),
+        first: BTreeMap::from([(a.clone(), Status::Modified)]), // only a.rs changed → it's selected
+        rest: BTreeMap::from([(b.clone(), Status::Modified)]),  // now only b.rs is changed
+        calls: Arc::new(Mutex::new(0)),
+    };
+    let components = Components {
+        git: Arc::new(git),
+        content: Box::new(PathContent),
+        editor: Box::new(StubEditor { fail: false, opened: Arc::new(Mutex::new(Vec::new())) }),
+    };
+    let mut ctrl = Controller::new(dir.path().to_path_buf(), true, Baseline::Head, components);
+    ctrl.handle(Intent::ToggleChangedOnly); // changed-only: only a.rs visible → it's selected
+    await_marker(&mut ctrl, "a.rs");
+    assert_eq!(ctrl.tree().selected().unwrap().path.file_name().unwrap(), "a.rs");
+
+    // Focus-gain: the changed-set is now {b.rs}, so a.rs filters out and the cursor moves to
+    // b.rs. The render is async — await it; pre-fix the content stayed on a.rs and this times out.
+    ctrl.handle_focus_gained();
+    await_marker(&mut ctrl, "b.rs");
+    assert_eq!(ctrl.tree().selected().unwrap().path.file_name().unwrap(), "b.rs", "cursor moved to b.rs");
+    assert!(flatten(ctrl.content()).contains("b.rs"), "content pane shows the selected file — in sync");
+}


### PR DESCRIPTION
## What & why

A long-running viewer reads git status at launch and only re-reads on its *own* actions (baseline toggle, editor return), so a **merge / pull / commit made in another pane left it stale** — exactly what surfaced after PR #9 merged (stale tree colours + clicking a now-unchanged file rendered an empty live diff). This makes git state stay current.

- **`r`** (new `Intent::Refresh`): re-read git status + the changed-set and re-render the selection — a full, on-demand refresh.
- **Auto-refresh on focus:** herdr forwards `FocusGained`/`FocusLost` to a pane that opts in (`EnableFocusChange` — **verified via a CLI-driven spike**: the viewer received the events as I drove focus). On regaining focus the viewer re-reads git status **without re-rendering**, so the tree's colours update **without disturbing your content scroll**.

## Lifecycle

Focus reporting is enabled in `run()`, **re-armed across the editor hand-off** (`suspend_tui`/`resume_tui`), and **disabled on the panic hook + normal exit** — paired with mouse capture, so the host terminal is never left in focus-reporting mode.

## Verification

- Spike confirmed herdr forwards focus events to the pane.
- Tests: `Refresh` re-queries git; `focus_gained` re-queries git **and preserves the content scroll** (it must not reset scroll on every focus change). Full suite green, clippy-clean.

## Notes

- Focus-refresh updates the tree's git status only; the open file re-renders on the next selection (or `r`) — deliberate, to avoid resetting scroll on every focus change.
- `ROADMAP.md` stays uncommitted.