### PR TITLE
Add zoom toggle (z): hide the tree for a full-screen content pane

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ hand-off to an *external* editor — the viewer itself only reads.
   anything else is shown as syntax-highlighted content with line numbers. Cycle the view to
   override.
 - **Navigable content** — scroll the content pane in all four directions, toggle line
-  wrapping, and resize the tree/content split; the layout reflows when the pane is resized.
+  wrapping, resize the tree/content split, or zoom (`z`) to hide the tree and read a file
+  full-screen; the layout reflows when the pane is resized.
 - **Keyboard-first** — every function has a key; no mouse required.
 
 ## Install
@@ -142,6 +143,7 @@ the same locally and remotely; it's only *which* keymap fires them across `--rem
 | `Tab` | Move focus between the tree and content columns |
 | `<` / `>` | Narrow / widen the tree column (move the divider) |
 | `w` | Toggle line wrapping for the content pane |
+| `z` | Zoom — hide the tree so the content pane fills the frame; press again to restore the two-column layout |
 | `r` | Refresh git state — pick up changes made outside the viewer (a merge / pull / commit elsewhere) |
 | `q` / `Esc` | Close the viewer and return to the prior pane |
 

--- a/docs/manual-verification.md
+++ b/docs/manual-verification.md
@@ -60,6 +60,8 @@ This procedure verifies the remaining **live-host** behavior.
      select a changed file to see its diff.
    - Press `Tab` to focus the content pane, then scroll with the arrows (`←`/`→` horizontally,
      `↑`/`↓` vertically), `w` to toggle wrapping, and `<`/`>` to resize the split.
+   - Press `z` to zoom: the tree disappears and the content pane fills the whole frame (focus
+     moves to it, so `↑`/`↓` scroll the file); press `z` again to restore the two columns.
    - Press `e` on a file (with `$EDITOR` set) and confirm your editor opens on that file, then
      exit the editor and confirm the viewer redraws cleanly.
    - Resize the pane (e.g. `herdr pane resize`) and confirm the layout reflows to the new size.

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -722,6 +722,13 @@ impl Controller {
     }
 
     fn toggle_focus(&mut self) -> Effects {
+        // While zoomed the tree is hidden, so there is nothing to switch focus to: keep focus
+        // pinned to the content pane (entering zoom set it there). Without this guard, Tab would
+        // move focus to the invisible tree and route j/k to its cursor — silently re-rendering a
+        // different file behind the full-screen content (review-gate R1, 4-model finding).
+        if self.zoomed {
+            return Effects::noop();
+        }
         self.focus = match self.focus {
             Focus::Tree => Focus::Content,
             Focus::Content => Focus::Tree,

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -151,6 +151,9 @@ pub struct Controller {
     /// User override forcing content wrap on regardless of view mode (the `w` toggle), so long
     /// lines in code/diffs can be wrapped on demand. `false` ⇒ the per-mode default applies.
     wrap_override: bool,
+    /// Hide the tree so the content pane fills the frame (the `z` zoom toggle). Pure layout
+    /// state — the selection and rendered content are unchanged.
+    zoomed: bool,
     tree: TreeModel,
     /// Changed-set vs the active baseline, cached; recomputed on a baseline toggle (AC-16).
     changed: BTreeMap<PathBuf, Status>,
@@ -238,6 +241,7 @@ impl Controller {
             content_height: 0,
             split_pct: SPLIT_DEFAULT,
             wrap_override: false,
+            zoomed: false,
             changed: BTreeMap::new(),
             overrides: HashMap::new(),
             content: Text::raw(""),
@@ -270,6 +274,9 @@ impl Controller {
     }
     pub fn focus(&self) -> Focus {
         self.focus
+    }
+    pub fn zoomed(&self) -> bool {
+        self.zoomed
     }
     pub fn tree(&self) -> &TreeModel {
         &self.tree
@@ -350,6 +357,7 @@ impl Controller {
             content_hscroll: self.content_hscroll,
             wrap,
             split_pct: self.split_pct,
+            zoomed: self.zoomed,
         }
     }
 
@@ -389,6 +397,7 @@ impl Controller {
             Intent::ShrinkTree => self.resize_split(-(SPLIT_STEP as i16)),
             Intent::GrowTree => self.resize_split(SPLIT_STEP as i16),
             Intent::ToggleWrap => self.toggle_wrap(),
+            Intent::ToggleZoom => self.toggle_zoom(),
             Intent::Refresh => self.refresh(),
             Intent::Close => Effects { quit: true, ..Default::default() },
         }
@@ -717,6 +726,16 @@ impl Controller {
             Focus::Tree => Focus::Content,
             Focus::Content => Focus::Tree,
         };
+        Effects::redraw()
+    }
+
+    /// Toggle zoom: hide the tree so the content pane fills the frame, and back. Entering zoom
+    /// moves focus to the content pane so up/down keys scroll the now-full-screen file; leaving
+    /// it returns focus to the tree (back to picking files). Pure layout state — the selection
+    /// and rendered content are unchanged, so no re-render is dispatched.
+    fn toggle_zoom(&mut self) -> Effects {
+        self.zoomed = !self.zoomed;
+        self.focus = if self.zoomed { Focus::Content } else { Focus::Tree };
         Effects::redraw()
     }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -31,6 +31,7 @@ pub fn map_key(key: KeyEvent) -> Option<Intent> {
         KeyCode::Char('<') => Some(Intent::ShrinkTree),
         KeyCode::Char('>') => Some(Intent::GrowTree),
         KeyCode::Char('w') => Some(Intent::ToggleWrap),
+        KeyCode::Char('z') => Some(Intent::ToggleZoom),
         KeyCode::Char('r') => Some(Intent::Refresh),
         KeyCode::Char('q') | KeyCode::Esc => Some(Intent::Close),
         _ => None,
@@ -65,6 +66,7 @@ mod tests {
         (KeyCode::Char('<'), Intent::ShrinkTree),
         (KeyCode::Char('>'), Intent::GrowTree),
         (KeyCode::Char('w'), Intent::ToggleWrap),
+        (KeyCode::Char('z'), Intent::ToggleZoom),
         (KeyCode::Char('r'), Intent::Refresh),
         (KeyCode::Char('q'), Intent::Close),
         (KeyCode::Esc, Intent::Close),
@@ -89,7 +91,7 @@ mod tests {
 
     #[test]
     fn unmapped_keys_are_a_noop() {
-        assert_eq!(map_key(k(KeyCode::Char('z'))), None);
+        assert_eq!(map_key(k(KeyCode::Char('g'))), None);
         assert_eq!(map_key(k(KeyCode::Char('x'))), None);
         assert_eq!(map_key(k(KeyCode::F(1))), None);
         assert_eq!(map_key(k(KeyCode::Backspace)), None);

--- a/src/intent.rs
+++ b/src/intent.rs
@@ -35,6 +35,9 @@ pub enum Intent {
     /// Force content-line wrapping on/off, overriding the per-mode default (so long lines in
     /// code and diffs can be wrapped on demand instead of truncated).
     ToggleWrap,
+    /// Hide the tree so the content pane fills the frame / restore the two-column layout — a
+    /// pure layout toggle for reading a file full-screen.
+    ToggleZoom,
     /// Re-read git state (working-tree status + changed-set) and re-render, so the viewer picks
     /// up changes made outside it — a merge, pull, or commit in another pane. Read-only.
     Refresh,
@@ -45,7 +48,7 @@ pub enum Intent {
 impl Intent {
     /// Every intent variant — lets the dispatcher and tests enumerate the closed set so
     /// keyboard-completeness (AC-18) and the no-edit invariant (AC-N3) stay checkable.
-    pub const ALL: [Intent; 15] = [
+    pub const ALL: [Intent; 16] = [
         Intent::NavUp,
         Intent::NavDown,
         Intent::Expand,
@@ -59,6 +62,7 @@ impl Intent {
         Intent::ShrinkTree,
         Intent::GrowTree,
         Intent::ToggleWrap,
+        Intent::ToggleZoom,
         Intent::Refresh,
         Intent::Close,
     ];
@@ -90,6 +94,7 @@ mod tests {
                 | Intent::ShrinkTree
                 | Intent::GrowTree
                 | Intent::ToggleWrap
+                | Intent::ToggleZoom
                 | Intent::Refresh
                 | Intent::Close => false,
             };

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -53,6 +53,9 @@ pub struct ViewState {
     /// The tree column's share of the width, as a percentage (the content pane takes the
     /// rest). Adjustable from the keyboard; used only in the wide two-column layout.
     pub split_pct: u16,
+    /// Hide the tree and let the content pane fill the whole frame (the `z` zoom toggle).
+    /// Overrides the split — and the narrow-layout focus rule — to draw content only.
+    pub zoomed: bool,
 }
 
 /// The single-character git-status marker shown beside a tree row (AC-7).
@@ -194,6 +197,11 @@ const NARROW_SPLIT: u16 = 80;
 /// is `None` when not drawn (narrow layout shows only the focused one). Shared by [`draw`] and
 /// [`geometry`] so the drawn layout and the hit-test geometry can never disagree.
 fn columns(area: Rect, state: &ViewState) -> (Option<Rect>, Option<Rect>, Option<u16>) {
+    // Zoom hides the tree entirely: the content pane fills the frame regardless of width or
+    // focus, so there is no tree interior and no divider to hit-test.
+    if state.zoomed {
+        return (None, Some(area), None);
+    }
     if area.width < NARROW_SPLIT {
         return match state.focus {
             Focus::Tree => (Some(area), None, None),

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -248,6 +248,28 @@ fn zoom_toggle_hides_tree_and_pins_content_focus() {
 }
 
 #[test]
+fn tab_is_inert_while_zoomed_so_focus_stays_on_content() {
+    // Regression guard (review-gate R1, 4-model): zoom hides the tree and pins focus to the
+    // content pane. Tab must NOT move focus to the now-hidden tree — otherwise j/k would drive
+    // the invisible cursor and `dispatch_render` would silently swap the full-screen file.
+    let dir = TempDir::new();
+    let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
+
+    ctrl.handle(Intent::ToggleZoom);
+    assert_eq!(ctrl.focus(), Focus::Content, "entering zoom focuses the content pane");
+
+    let fx = ctrl.handle(Intent::ToggleFocus); // Tab while zoomed
+    assert_eq!(ctrl.focus(), Focus::Content, "Tab is inert while zoomed — focus stays on content");
+    assert!(!fx.redraw, "an inert Tab need not redraw");
+
+    // Un-zoom: Tab works normally again (the guard is scoped to the zoom session).
+    ctrl.handle(Intent::ToggleZoom);
+    assert_eq!(ctrl.focus(), Focus::Tree, "leaving zoom returns focus to the tree");
+    ctrl.handle(Intent::ToggleFocus);
+    assert_eq!(ctrl.focus(), Focus::Content, "Tab switches columns again once un-zoomed");
+}
+
+#[test]
 fn close_intent_signals_quit() {
     // AC-20: the close key ends the session.
     let dir = TempDir::new();

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -224,6 +224,30 @@ fn toggle_focus_switches_columns() {
 }
 
 #[test]
+fn zoom_toggle_hides_tree_and_pins_content_focus() {
+    // The `z` zoom toggle collapses the tree so the content pane fills the frame. Entering
+    // zoom moves focus to the content pane (so j/k scroll the now-full-screen file); leaving
+    // zoom returns focus to the tree (back to picking files). It is pure layout state — the
+    // selection and content are unchanged.
+    let dir = TempDir::new();
+    let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
+
+    assert!(!ctrl.zoomed(), "the viewer is not zoomed by default");
+    assert_eq!(ctrl.focus(), Focus::Tree, "the tree holds focus initially");
+
+    let fx = ctrl.handle(Intent::ToggleZoom);
+    assert!(fx.redraw, "toggling zoom redraws");
+    assert!(ctrl.zoomed(), "the viewer is zoomed after the toggle");
+    assert_eq!(ctrl.focus(), Focus::Content, "entering zoom focuses the content pane");
+    assert!(ctrl.view_state().zoomed, "the view state reflects the zoom for the Presenter");
+
+    ctrl.handle(Intent::ToggleZoom);
+    assert!(!ctrl.zoomed(), "the toggle un-zooms");
+    assert_eq!(ctrl.focus(), Focus::Tree, "leaving zoom returns focus to the tree");
+    assert!(!ctrl.view_state().zoomed, "the view state reflects the un-zoom");
+}
+
+#[test]
 fn close_intent_signals_quit() {
     // AC-20: the close key ends the session.
     let dir = TempDir::new();

--- a/tests/presenter.rs
+++ b/tests/presenter.rs
@@ -38,6 +38,7 @@ fn sample_state() -> ViewState {
         content_hscroll: 0,
         wrap: false,
         split_pct: 40,
+        zoomed: false,
     }
 }
 
@@ -271,6 +272,32 @@ fn geometry_matches_the_wide_two_column_layout() {
     assert!(c.x > t.x + t.width, "the content column is to the right of the tree");
     assert!(g.divider_x.is_some(), "a wide layout has a draggable divider");
     assert_eq!((g.area_x, g.area_width), (0, 100));
+}
+
+#[test]
+fn zoomed_layout_hides_the_tree_and_fills_with_content() {
+    // The `z` zoom toggle hides the tree so the content pane fills the whole frame — even at a
+    // wide width that would normally show both columns.
+    let mut state = sample_state();
+    state.zoomed = true;
+    let out = render(&state, 100, 24);
+    assert!(out.contains("fn main()"), "content fills the frame when zoomed\n{out}");
+    // No tree-only rows survive: the directory row and a tree-only file are gone.
+    assert!(!out.contains("scratch.log"), "the tree is hidden when zoomed\n{out}");
+    assert!(!out.contains("added.rs"), "no tree rows are drawn when zoomed\n{out}");
+}
+
+#[test]
+fn geometry_is_content_only_when_zoomed() {
+    use herdr_file_viewer::presenter::geometry;
+    use ratatui::layout::Rect;
+    let mut st = sample_state();
+    st.zoomed = true;
+    // Even at a wide width (which normally shows both columns), zoom draws content only.
+    let g = geometry(Rect { x: 0, y: 0, width: 100, height: 24 }, &st);
+    assert!(g.tree_inner.is_none(), "no tree interior when zoomed");
+    assert!(g.content_inner.is_some(), "the content pane fills the frame when zoomed");
+    assert!(g.divider_x.is_none(), "no divider when the tree is hidden");
 }
 
 #[test]

--- a/tests/presenter_narrow.rs
+++ b/tests/presenter_narrow.rs
@@ -30,6 +30,7 @@ fn state(width: u16, focus: Focus) -> ViewState {
         content_hscroll: 0,
         wrap: false,
         split_pct: 40,
+        zoomed: false,
     }
 }
 

--- a/tests/presenter_narrow.rs
+++ b/tests/presenter_narrow.rs
@@ -61,6 +61,17 @@ fn narrow_content_focus_gives_content_full_width_and_hides_tree() {
 }
 
 #[test]
+fn zoom_overrides_narrow_layout_and_fills_with_content() {
+    // review-gate R1: zoom hides the tree even below the 80-col narrow threshold and with the
+    // tree focused — the content pane fills the frame regardless of width or focus.
+    let mut st = state(60, Focus::Tree);
+    st.zoomed = true;
+    let out = render(&st, 60, 20);
+    assert!(out.contains("fn main()"), "content fills the frame when zoomed, even narrow\n{out}");
+    assert!(!out.contains("scratch.log"), "the tree is hidden when zoomed, even narrow\n{out}");
+}
+
+#[test]
 fn wide_shows_both_columns_regardless_of_focus() {
     let out = render(&state(100, Focus::Tree), 100, 20);
     assert!(out.contains("scratch.log"), "tree column present at >= 80 cols\n{out}");


### PR DESCRIPTION
## What

Adds a **zoom toggle** (`z`) that hides the file tree so the content pane fills the whole frame — for reading a file full-screen without the tree taking space. Press `z` again to restore the two-column layout.

## Why

The split can only be narrowed to a minimum (`>` clamps the tree at ~20%); there was no way to give the content pane the full width. This is the "maximize content" affordance, staying fully within the read-only viewer model (pure layout state — no file/git mutations, no new rendering path).

## How

- **intent / input** — `Intent::ToggleZoom` added to the closed intent set (`ALL` now 16; the exhaustive no-edit match in `intent.rs` is preserved, so AC-N3 still holds) and mapped to the `z` key. Keyboard-completeness (AC-18) is covered by the existing `every_intent_has_at_least_one_key` test.
- **controller** — a `zoomed` flag, pure layout state (no `dispatch_render`). Entering zoom moves focus to the content pane so `↑`/`↓` scroll the now-full-screen file; leaving zoom returns focus to the tree (back to picking files).
- **presenter** — `ViewState.zoomed`; `columns()` returns content-only when zoomed, overriding both the split *and* the narrow-layout focus rule. The shared `geometry()` therefore reports no tree interior and no divider, so mouse hit-testing routes everything to the content pane (no stale tree/divider regions).
- **docs** — README key table + feature intro, and the manual-verification checklist.

## Tests (TDD)

- `controller.rs::zoom_toggle_hides_tree_and_pins_content_focus` — the toggle flips `zoomed`, pins focus to content on entry and restores it to the tree on exit, and surfaces through `view_state()`.
- `presenter.rs::geometry_is_content_only_when_zoomed` — at a wide width, geometry is content-only (no tree interior, no divider).
- `presenter.rs::zoomed_layout_hides_the_tree_and_fills_with_content` — a draw test: the tree rows are gone and the content fills the frame.

Full suite green; no new clippy warnings. (Repo-wide `cargo fmt` drift is pre-existing and untouched — the code is hand-formatted.)

## Scope / not included

- No persistence — zoom is ephemeral session state (consistent with v1).
- `Tab` while zoomed still flips the focus flag (the hidden tree's cursor); benign, noted for manual verification. Left as-is for YAGNI.
