### PR TITLE
Add full-file inline-diff view (FullDiff); remove RawContent from the cycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ hand-off to an *external* editor — the viewer itself only reads.
   changed-files-only filter; and a baseline you can switch between the merge-base of your
   branch and `HEAD`.
 - **The right view per file** — a changed file shows its **diff**; a markdown file renders;
-  anything else is shown as syntax-highlighted content with line numbers. Cycle the view to
-  override.
+  anything else is shown as syntax-highlighted content with line numbers. Cycle the view
+  (`v`) to override — a changed file can also show a **full-file diff**: the whole file with
+  line numbers and the diff shown inline.
 - **Navigable content** — scroll the content pane in all four directions, toggle line
   wrapping, resize the tree/content split, or zoom (`z`) to hide the tree and read a file
   full-screen; the layout reflows when the pane is resized.

--- a/docs/manual-verification.md
+++ b/docs/manual-verification.md
@@ -57,7 +57,9 @@ This procedure verifies the remaining **live-host** behavior.
    - Navigate with `j`/`k`; the content pane updates to the selected file.
    - If this is a git worktree: confirm colored status markers (`M`/`A`/`D`/`?` — changed
      red, new green, folders-with-changes red), press `c` to filter to changed files, and
-     select a changed file to see its diff.
+     select a changed file to see its diff. Press `v` to cycle the view: the compact diff →
+     the **full-file diff** (the whole file with a line-number gutter and the changes shown
+     inline) → syntax-highlighted content, then back.
    - Press `Tab` to focus the content pane, then scroll with the arrows (`←`/`→` horizontally,
      `↑`/`↓` vertically), `w` to toggle wrapping, and `<`/`>` to resize the split.
    - Press `z` to zoom: the tree disappears and the content pane fills the whole frame (focus

--- a/specs/file-viewer/acceptance-criteria.md
+++ b/specs/file-viewer/acceptance-criteria.md
@@ -51,8 +51,9 @@ handles; do not renumber.
   syntax-highlighted content in the content pane by default.
   *(test-backed: integration)*
 - **AC-11** — A dedicated key cycles the content pane among the view modes applicable
-  to the selected file (raw content / rendered / diff), overriding the auto-selected
-  default.
+  to the selected file — rendered markdown, the compact diff, syntax-highlighted content,
+  and (for a changed file) a full-context diff that shows the whole file with line numbers
+  and the diff inline — overriding the auto-selected default.
   *(test-backed: integration)*
 - **AC-12** — Selecting a binary file shows a placeholder identifying it as binary and
   does not emit its raw bytes into the pane.

--- a/specs/file-viewer/brief.md
+++ b/specs/file-viewer/brief.md
@@ -31,7 +31,8 @@ as a bolt-on preview mode.
   - rendered markdown for markdown files,
   - diff for a changed file,
   - syntax-highlighted content otherwise.
-- A key cycles modes, so the user can always force raw content or the diff.
+- A key cycles modes, so the user can always force a different view — the rendered,
+  syntax-highlighted, compact-diff, or full-context (whole-file, line-numbered) diff view.
 
 **Git / diff**
 - "The diff" and the meaning of "changed" compare against a context-smart baseline:

--- a/specs/file-viewer/design.md
+++ b/specs/file-viewer/design.md
@@ -59,10 +59,11 @@ Each component has one responsibility (one reason to change) and an explicit con
 - **Responsibility:** choose the default content view mode for a file.
 - **Kind:** pure decision function.
 - **Inputs:** `{ path, isMarkdown, isChanged }` + optional user override.
-- **Outputs:** chosen mode ∈ `{ rendered-markdown, diff, syntax-content, raw-content }`
+- **Outputs:** chosen default mode ∈ `{ rendered-markdown, diff, syntax-content }`
   by precedence — changed → diff (incl. markdown, AC-9); else markdown → rendered
-  (AC-8); else → syntax-content (AC-10) — plus the applicable set for cycling (AC-11).
-- **Errors:** unknown type → `syntax-content`/`raw-content`. No I/O.
+  (AC-8); else → syntax-content (AC-10) — plus the applicable set for cycling (AC-11),
+  which for a changed file also offers `full-diff` (a whole-file, line-numbered diff).
+- **Errors:** unknown type → `syntax-content`. No I/O.
 
 ### Content Renderer
 - **Responsibility:** produce the content-pane text for `(file, mode)` via delegated

--- a/specs/file-viewer/plan.md
+++ b/specs/file-viewer/plan.md
@@ -37,8 +37,8 @@ adds its `pub mod` to `src/lib.rs` as it lands.
 ### T-2 — View Policy: default mode + applicable set
 - **Files:** `src/view_policy.rs`
 - **Test first:** inline unit tests: unchanged markdown → `RenderedMarkdown`; changed file →
-  `Diff` even when markdown; non-changed non-markdown → `SyntaxContent`; `applicable_modes`
-  includes `RawContent` for override.
+  `Diff` even when markdown; non-changed non-markdown → `SyntaxContent`; a changed file's
+  `applicable_modes` offers `FullDiff` (full-context diff) after the compact `Diff`.
 - **Implements:** `enum ViewMode`, `struct FileDescriptor { path, is_markdown, is_changed }`,
   `fn default_mode(&FileDescriptor) -> ViewMode`, `fn applicable_modes(&FileDescriptor) -> Vec<ViewMode>`.
 - **AC:** AC-8, AC-9, AC-10, AC-11. **Component:** View Policy. **Deps:** T-1.

--- a/src/app.rs
+++ b/src/app.rs
@@ -189,10 +189,11 @@ struct LiveContent {
 
 impl ContentProvider for LiveContent {
     fn render(&self, path: &Path, mode: ViewMode, raw_diff: Option<&str>) -> RenderResult {
-        // Diff mode renders from git's diff text, not the file bytes — so a deleted or binary
-        // file still shows its diff (AC-9); other modes classify first (binary / size guards,
-        // AC-12/13). `Prepared::Binary` is inert for the diff path inside `render`.
-        let prepared = if mode == ViewMode::Diff {
+        // Both diff modes render from git's diff text, not the file bytes — so a deleted or
+        // binary file still shows its diff (AC-9), and there is no point classifying (a wasted
+        // bounded file read). Other modes classify first (binary / size guards, AC-12/13).
+        // `Prepared::Binary` is inert for the diff path inside `render`.
+        let prepared = if matches!(mode, ViewMode::Diff | ViewMode::FullDiff) {
             Prepared::Binary
         } else {
             render::classify(&self.root, path)
@@ -415,5 +416,23 @@ mod tests {
         let r = default_renderers();
         assert!(r.syntax.iter().any(|a| a == "--color=always"), "bat color forced: {:?}", r.syntax);
         assert!(r.syntax.iter().any(|a| a == "--style=numbers"), "bat line numbers: {:?}", r.syntax);
+    }
+
+    #[test]
+    fn full_diff_renderer_adds_delta_line_numbers() {
+        // The full-file diff view (AC-11) is delta WITH a line-number gutter — that gutter is
+        // what makes it "the whole file with line numbers". The compact diff omits it.
+        let r = default_renderers();
+        assert_eq!(r.full_diff.first().map(String::as_str), Some("delta"), "full_diff uses delta: {:?}", r.full_diff);
+        assert!(
+            r.full_diff.iter().any(|a| a == "--line-numbers"),
+            "full_diff shows line numbers: {:?}",
+            r.full_diff
+        );
+        assert!(
+            !r.diff.iter().any(|a| a == "--line-numbers"),
+            "the compact diff does NOT add line numbers: {:?}",
+            r.diff
+        );
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -176,8 +176,8 @@ impl GitService for LiveGit {
     fn changed_set(&self, baseline: Baseline) -> BTreeMap<PathBuf, Status> {
         git::changed_set(&self.repo_root, baseline, self.base_hint.as_deref())
     }
-    fn diff(&self, rel_path: &Path, baseline: Baseline) -> String {
-        git::diff(&self.repo_root, rel_path, baseline, self.base_hint.as_deref())
+    fn diff(&self, rel_path: &Path, baseline: Baseline, full_context: bool) -> String {
+        git::diff(&self.repo_root, rel_path, baseline, self.base_hint.as_deref(), full_context)
     }
 }
 
@@ -327,6 +327,9 @@ fn default_renderers() -> Renderers {
         ],
         // delta already colorizes piped output (its default), and has no `--color=always` flag.
         diff: vec!["delta".into()],
+        // The full-file diff view adds delta's line-number gutter, so the whole file is shown
+        // with its line numbers and the diff inline (the compact `diff` omits the gutter).
+        full_diff: vec!["delta".into(), "--line-numbers".into()],
         syntax: vec![
             "bat".into(),
             "--color=always".into(),

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -55,8 +55,10 @@ pub trait GitService: Send + Sync {
     /// The set of files changed against `baseline` (drives the changed-only filter, AC-6,
     /// and is recomputed when the baseline toggles, AC-16).
     fn changed_set(&self, baseline: Baseline) -> BTreeMap<PathBuf, Status>;
-    /// Raw unified diff text for one repo-root-relative path against `baseline` (AC-9).
-    fn diff(&self, rel_path: &Path, baseline: Baseline) -> String;
+    /// Raw unified diff text for one repo-root-relative path against `baseline` (AC-9). With
+    /// `full_context`, git emits the whole file as context (for the full-file diff view);
+    /// otherwise it returns the compact hunks-only diff.
+    fn diff(&self, rel_path: &Path, baseline: Baseline, full_context: bool) -> String;
 }
 
 /// The rendered content pane for one file: ingested text plus any non-fatal notices
@@ -204,9 +206,12 @@ impl Controller {
                     job = newer;
                 }
                 // The diff is read here, off the input thread, so a large/slow diff never
-                // blocks input (AC-23). Other modes don't need git.
-                let raw_diff = if job.mode == ViewMode::Diff && job.is_git {
-                    job.rel.as_deref().map(|rel| worker_git.diff(rel, job.baseline))
+                // blocks input (AC-23). Other modes don't need git. The full-file diff view
+                // asks git for whole-file context; the compact diff uses git's default.
+                let raw_diff = if matches!(job.mode, ViewMode::Diff | ViewMode::FullDiff) && job.is_git
+                {
+                    let full = job.mode == ViewMode::FullDiff;
+                    job.rel.as_deref().map(|rel| worker_git.diff(rel, job.baseline, full))
                 } else {
                     None
                 };
@@ -370,7 +375,9 @@ impl Controller {
         }
         match node {
             Some(n) if n.kind == NodeKind::File => {
-                matches!(self.effective_mode(&n.path), ViewMode::RenderedMarkdown | ViewMode::RawContent)
+                // Only prose wraps; diffs (compact and full-context) and code keep their lines
+                // so columns and the line-number gutter stay aligned.
+                matches!(self.effective_mode(&n.path), ViewMode::RenderedMarkdown)
             }
             _ => false,
         }

--- a/src/git.rs
+++ b/src/git.rs
@@ -23,6 +23,11 @@ use std::process::Command;
 /// git's well-known empty-tree object — the baseline for an unborn repo's first files.
 const EMPTY_TREE: &str = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
 
+/// Unified-context window for a full-context (whole-file) diff: a value far larger than any
+/// real file, so every unchanged line is emitted as context around the changes. The render
+/// layer caps the result, so an enormous file's diff is still bounded (AC-13).
+const FULL_CONTEXT: &str = "-U1000000";
+
 /// A file's git status against the working tree (AC-7).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Status {
@@ -147,19 +152,30 @@ pub fn changed_set(
 /// Raw unified diff text for one file against `baseline` (AC-9). Empty if unavailable.
 /// An untracked file (or any file in an unborn repo) is diffed against the empty tree so
 /// AC-9 still shows the new file's content rather than an empty pane.
-pub fn diff(repo_root: &Path, path: &Path, baseline: Baseline, base_hint: Option<&str>) -> String {
+pub fn diff(
+    repo_root: &Path,
+    path: &Path,
+    baseline: Baseline,
+    base_hint: Option<&str>,
+    full_context: bool,
+) -> String {
     // Never resolve a path outside the root — no arbitrary file reads, and the viewer
     // does not navigate above its root (AC-N5).
     if !is_within_root(repo_root, path) {
         return String::new();
     }
+    // For the full-context (whole-file) diff, ask git for a very large unified-context window
+    // so every unchanged line is emitted as context around the changes; the default (3 lines)
+    // gives the compact hunks-only diff. The render layer still bounds the result (AC-13).
+    let unified = full_context.then_some(FULL_CONTEXT);
     // The path is appended as a raw OsStr arg (not lossy UTF-8) so non-ASCII / non-UTF-8
     // filenames reach git verbatim and their diffs are not silently empty.
     if is_untracked(repo_root, path) {
-        let mut cmd = git_command(
-            repo_root,
-            &["diff", "--no-ext-diff", "--no-textconv", "--no-index", "--no-color", "--", "/dev/null"],
-        );
+        let mut args = vec!["diff", "--no-ext-diff", "--no-textconv", "--no-index", "--no-color"];
+        args.extend(unified);
+        args.push("--");
+        args.push("/dev/null");
+        let mut cmd = git_command(repo_root, &args);
         cmd.arg(path);
         return capture_stdout(cmd);
     }
@@ -169,10 +185,11 @@ pub fn diff(repo_root: &Path, path: &Path, baseline: Baseline, base_hint: Option
             base_fork_point(repo_root, base_hint).unwrap_or_else(|| head_or_empty_tree(repo_root))
         }
     };
-    let mut cmd = git_command(
-        repo_root,
-        &["diff", "--no-ext-diff", "--no-textconv", "--no-color", &against, "--"],
-    );
+    let mut args = vec!["diff", "--no-ext-diff", "--no-textconv", "--no-color"];
+    args.extend(unified);
+    args.push(&against);
+    args.push("--");
+    let mut cmd = git_command(repo_root, &args);
     cmd.arg(path);
     capture_stdout(cmd)
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -16,17 +16,25 @@
 use crate::root::Resolved;
 use std::collections::BTreeMap;
 use std::ffi::OsStr;
+use std::io::Read;
 use std::os::unix::ffi::OsStrExt;
 use std::path::{Component, Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 /// git's well-known empty-tree object — the baseline for an unborn repo's first files.
 const EMPTY_TREE: &str = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
 
 /// Unified-context window for a full-context (whole-file) diff: a value far larger than any
-/// real file, so every unchanged line is emitted as context around the changes. The render
-/// layer caps the result, so an enormous file's diff is still bounded (AC-13).
+/// real file, so every unchanged line is emitted as context around the changes. The output is
+/// bounded by [`MAX_DIFF_BYTES`] (and the render layer's AC-13 cap), so an enormous file's
+/// diff is never buffered whole.
 const FULL_CONTEXT: &str = "-U1000000";
+
+/// Upper bound on bytes captured from a `git diff`, so a full-context diff of a huge file (or
+/// an untracked whole-file diff) cannot buffer the entire file into memory before the render
+/// layer's display cap (AC-13) runs. Comfortably above that display cap (render's ~1 MB), so
+/// it never reduces what the user sees — only the transient buffer and git's work.
+const MAX_DIFF_BYTES: u64 = 4 * 1024 * 1024; // 4 MB
 
 /// A file's git status against the working tree (AC-7).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -219,12 +227,31 @@ fn git_command(repo_root: &Path, args: &[&str]) -> Command {
     cmd
 }
 
-/// Capture a git command's stdout (lossy) regardless of exit code. `git diff` exits 1
-/// under `--no-index` *because* it found differences, so we cannot gate on success.
+/// Capture a git command's stdout (lossy) regardless of exit code, bounded to
+/// [`MAX_DIFF_BYTES`]. `git diff` exits 1 under `--no-index` *because* it found differences,
+/// so we cannot gate on success.
+///
+/// The read is bounded so a full-context diff (`-U1000000`) of a huge file — or an untracked
+/// whole-file diff — cannot buffer the entire file into memory before the render layer's cap
+/// (AC-13) runs: we read at most `MAX_DIFF_BYTES`, then kill git (which is otherwise blocked
+/// writing to the now-unread pipe). The render layer still truncates the visible diff and
+/// shows its notice; this bound is comfortably above that display cap, so it only limits the
+/// transient buffer (and git's work), never what the user sees.
 fn capture_stdout(mut cmd: Command) -> String {
-    cmd.output()
-        .map(|o| String::from_utf8_lossy(&o.stdout).into_owned())
-        .unwrap_or_default()
+    let mut child = match cmd.stdout(Stdio::piped()).stderr(Stdio::null()).spawn() {
+        Ok(c) => c,
+        Err(_) => return String::new(),
+    };
+    let mut buf = Vec::new();
+    if let Some(out) = child.stdout.take() {
+        let _ = out.take(MAX_DIFF_BYTES).read_to_end(&mut buf);
+    }
+    // We may have stopped reading before git finished (output exceeded the cap); kill it so a
+    // git blocked on the full pipe is released, and reap it to avoid a zombie. The exit status
+    // is irrelevant here (see above), so it is ignored.
+    let _ = child.kill();
+    let _ = child.wait();
+    String::from_utf8_lossy(&buf).into_owned()
 }
 
 /// Run a read-only `git` command, returning raw stdout bytes (for `-z` parsing).

--- a/src/render.rs
+++ b/src/render.rs
@@ -106,6 +106,9 @@ pub fn classify(root: &Path, path: &Path) -> Prepared {
 pub struct Renderers {
     pub markdown: Vec<String>,
     pub diff: Vec<String>,
+    /// Renders a full-context diff (whole file) — same delegate as `diff` but configured to
+    /// show a line-number gutter, so the file's lines are numbered with the diff shown inline.
+    pub full_diff: Vec<String>,
     pub syntax: Vec<String>,
     /// Per-invocation wall-clock bound; a renderer exceeding it is killed and the plain-
     /// text fallback is used, so a wedged delegate can never hang rendering.
@@ -127,10 +130,14 @@ pub fn render(
     let name = sanitize_name(file_name.unwrap_or(""));
     let name = name.as_str();
     // A diff is derived from git, not from the file's bytes, so it renders even for a
-    // deleted or binary file (AC-9) — never short-circuit it to the binary placeholder.
-    if mode == ViewMode::Diff {
+    // deleted or binary file (AC-9) — never short-circuit it to the binary placeholder. Both
+    // the compact diff and the full-context diff render from the git diff text on `raw_diff`;
+    // they differ only in the diff git produced (default vs. whole-file context) and the
+    // delegate used (the full-context one numbers lines).
+    if mode == ViewMode::Diff || mode == ViewMode::FullDiff {
+        let cmd = if mode == ViewMode::FullDiff { &renderers.full_diff } else { &renderers.diff };
         let (diff, notice) = cap_preview(raw_diff.unwrap_or(""));
-        return delegate(&with_name(&renderers.diff, name), &diff, mode, renderers.timeout, notice);
+        return delegate(&with_name(cmd, name), &diff, mode, renderers.timeout, notice);
     }
 
     // Content modes: a binary file shows a placeholder, never raw bytes (AC-12).
@@ -155,8 +162,7 @@ pub fn render(
             renderers.timeout,
             base_notice,
         ),
-        ViewMode::RawContent => (to_text(content), base_notice),
-        ViewMode::Diff => unreachable!("handled above"),
+        ViewMode::Diff | ViewMode::FullDiff => unreachable!("handled above"),
     }
 }
 
@@ -240,9 +246,9 @@ fn delegate(
 fn capability(mode: ViewMode) -> &'static str {
     match mode {
         ViewMode::Diff => "Diff",
+        ViewMode::FullDiff => "Full-file diff",
         ViewMode::RenderedMarkdown => "Markdown",
         ViewMode::SyntaxContent => "Syntax",
-        ViewMode::RawContent => "Plain",
     }
 }
 

--- a/src/view_policy.rs
+++ b/src/view_policy.rs
@@ -2,8 +2,8 @@
 //!
 //! Precedence (design.md): changed → diff (even for markdown, AC-9); else markdown →
 //! rendered (AC-8); else → syntax-highlighted content (AC-10). The applicable set
-//! (AC-11) is what a mode-cycle key steps through, always including raw content so the
-//! user can override the auto-selected default. No I/O.
+//! (AC-11) is what a mode-cycle key steps through; for a changed file it also offers a
+//! full-context diff (the whole file with line numbers and the diff shown inline). No I/O.
 
 use std::path::PathBuf;
 
@@ -12,12 +12,13 @@ use std::path::PathBuf;
 pub enum ViewMode {
     /// Markdown rendered to formatted text.
     RenderedMarkdown,
-    /// Unified diff against the active baseline.
+    /// Unified diff against the active baseline — only the changed hunks.
     Diff,
+    /// Full-context diff against the active baseline: the whole file with a line-number
+    /// gutter, syntax highlighting on unchanged lines, and the diff shown inline.
+    FullDiff,
     /// Syntax-highlighted file content.
     SyntaxContent,
-    /// Plain, unstyled file content (the override floor).
-    RawContent,
 }
 
 /// The facts the policy needs about a file — no path I/O is performed here.
@@ -39,8 +40,9 @@ pub fn default_mode(fd: &FileDescriptor) -> ViewMode {
     }
 }
 
-/// The modes a cycle key steps through for a file, default first, always ending with
-/// a raw-content override (AC-11).
+/// The modes a cycle key steps through for a file, default first (AC-11). A changed file
+/// also offers a full-context diff (whole file + line numbers + inline diff) right after
+/// the compact diff; markdown adds its rendered view; every file ends with syntax content.
 pub fn applicable_modes(fd: &FileDescriptor) -> Vec<ViewMode> {
     let mut modes = vec![default_mode(fd)];
     let add = |modes: &mut Vec<ViewMode>, m: ViewMode| {
@@ -50,12 +52,12 @@ pub fn applicable_modes(fd: &FileDescriptor) -> Vec<ViewMode> {
     };
     if fd.is_changed {
         add(&mut modes, ViewMode::Diff);
+        add(&mut modes, ViewMode::FullDiff);
     }
     if fd.is_markdown {
         add(&mut modes, ViewMode::RenderedMarkdown);
     }
     add(&mut modes, ViewMode::SyntaxContent);
-    add(&mut modes, ViewMode::RawContent);
     modes
 }
 
@@ -84,13 +86,32 @@ mod tests {
     }
 
     #[test]
-    fn applicable_modes_always_include_raw_content_for_override() {
-        for (md, ch) in [(true, false), (true, true), (false, false), (false, true)] {
-            let modes = applicable_modes(&fd("x", md, ch));
-            assert!(
-                modes.contains(&ViewMode::RawContent),
-                "RawContent must be cyclable (md={md}, changed={ch})"
-            );
+    fn changed_file_cycle_offers_a_full_context_diff_right_after_the_compact_diff() {
+        // AC-11: a changed file can cycle from the compact diff to a full-context diff
+        // (whole file + line numbers + inline diff) before the content views.
+        let modes = applicable_modes(&fd("main.rs", false, true));
+        assert_eq!(modes, vec![ViewMode::Diff, ViewMode::FullDiff, ViewMode::SyntaxContent]);
+        // For a changed markdown file the rendered view sits after the two diff views.
+        let md = applicable_modes(&fd("README.md", true, true));
+        assert_eq!(
+            md,
+            vec![
+                ViewMode::Diff,
+                ViewMode::FullDiff,
+                ViewMode::RenderedMarkdown,
+                ViewMode::SyntaxContent
+            ]
+        );
+    }
+
+    #[test]
+    fn unchanged_file_has_no_diff_views_in_its_cycle() {
+        // A full-context (or compact) diff only makes sense for a changed file — there is no
+        // diff for an unchanged one, so neither diff mode is offered.
+        for md in [true, false] {
+            let modes = applicable_modes(&fd("x", md, false));
+            assert!(!modes.contains(&ViewMode::Diff), "no compact diff when unchanged (md={md})");
+            assert!(!modes.contains(&ViewMode::FullDiff), "no full diff when unchanged (md={md})");
         }
     }
 

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -48,7 +48,7 @@ impl GitService for StubGit {
         self.changed_calls.lock().unwrap().push(baseline);
         self.changed.clone()
     }
-    fn diff(&self, _rel_path: &Path, _baseline: Baseline) -> String {
+    fn diff(&self, _rel_path: &Path, _baseline: Baseline, _full_context: bool) -> String {
         String::new()
     }
 }
@@ -134,16 +134,36 @@ fn toggle_changed_only_flips_in_a_repo() {
 fn cycle_view_advances_the_selected_files_mode_through_the_applicable_set() {
     // AC-11: the view-mode override steps through applicable_modes and wraps around.
     let dir = TempDir::new();
-    std::fs::write(dir.path().join("a.rs"), "fn main() {}\n").unwrap();
-    // Non-git → unchanged, non-markdown: applicable modes are [SyntaxContent, RawContent].
+    std::fs::write(dir.path().join("notes.md"), "# Title\n").unwrap();
+    // Non-git → unchanged markdown: applicable modes are [RenderedMarkdown, SyntaxContent].
     let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
 
-    assert_eq!(ctrl.selected_view_mode(), Some(ViewMode::SyntaxContent), "default mode");
+    assert_eq!(ctrl.selected_view_mode(), Some(ViewMode::RenderedMarkdown), "markdown default");
     let fx = ctrl.handle(Intent::CycleView);
-    assert_eq!(ctrl.selected_view_mode(), Some(ViewMode::RawContent), "advances to the override");
+    assert_eq!(ctrl.selected_view_mode(), Some(ViewMode::SyntaxContent), "advances to the override");
     assert!(fx.redraw);
     ctrl.handle(Intent::CycleView);
-    assert_eq!(ctrl.selected_view_mode(), Some(ViewMode::SyntaxContent), "cycle wraps around");
+    assert_eq!(ctrl.selected_view_mode(), Some(ViewMode::RenderedMarkdown), "cycle wraps around");
+}
+
+#[test]
+fn cycle_view_on_a_changed_file_reaches_the_full_context_diff() {
+    // PR2 / AC-11: a changed file cycles Diff → FullDiff (whole file + line numbers + the diff
+    // inline) → SyntaxContent → wraps. The full-context diff sits right after the compact diff.
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("changed.rs"), "fn main() {}\n").unwrap();
+    let mut changed = BTreeMap::new();
+    changed.insert(PathBuf::from("changed.rs"), Status::Modified);
+    let git = StubGit { status: changed.clone(), changed, ..StubGit::default() };
+    let (mut ctrl, _, _) = controller(dir.path(), true, git, false);
+
+    assert_eq!(ctrl.selected_view_mode(), Some(ViewMode::Diff), "a changed file defaults to diff");
+    ctrl.handle(Intent::CycleView);
+    assert_eq!(ctrl.selected_view_mode(), Some(ViewMode::FullDiff), "→ full-context diff");
+    ctrl.handle(Intent::CycleView);
+    assert_eq!(ctrl.selected_view_mode(), Some(ViewMode::SyntaxContent), "→ syntax content");
+    ctrl.handle(Intent::CycleView);
+    assert_eq!(ctrl.selected_view_mode(), Some(ViewMode::Diff), "cycle wraps back to the compact diff");
 }
 
 #[test]
@@ -877,7 +897,7 @@ impl GitService for EvolvingGit {
         *n += 1;
         if *n <= 1 { self.first.clone() } else { self.rest.clone() }
     }
-    fn diff(&self, _p: &Path, _b: Baseline) -> String {
+    fn diff(&self, _p: &Path, _b: Baseline, _full: bool) -> String {
         String::new()
     }
 }

--- a/tests/controller_async.rs
+++ b/tests/controller_async.rs
@@ -16,7 +16,7 @@ use ratatui::text::Text;
 use std::collections::BTreeMap;
 use std::io;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 /// A renderer that sleeps before producing output — the stand-in for a slow external CLI.
@@ -39,7 +39,7 @@ impl GitService for NoGit {
     fn changed_set(&self, _: Baseline) -> BTreeMap<PathBuf, Status> {
         BTreeMap::new()
     }
-    fn diff(&self, _: &Path, _: Baseline) -> String {
+    fn diff(&self, _: &Path, _: Baseline, _full: bool) -> String {
         String::new()
     }
 }
@@ -48,6 +48,26 @@ struct NoEditor;
 impl EditorHandoff for NoEditor {
     fn open(&mut self, _: &Path) -> io::Result<bool> {
         Ok(false)
+    }
+}
+
+/// A Git stub that records the `full_context` flag of every `diff()` call (made on the render
+/// worker thread) and reports one changed file — so a test can prove the FullDiff view asks
+/// git for whole-file context rather than the compact hunks-only diff.
+struct RecordingGit {
+    changed: BTreeMap<PathBuf, Status>,
+    diff_full_calls: Arc<Mutex<Vec<bool>>>,
+}
+impl GitService for RecordingGit {
+    fn status(&self) -> BTreeMap<PathBuf, Status> {
+        self.changed.clone()
+    }
+    fn changed_set(&self, _: Baseline) -> BTreeMap<PathBuf, Status> {
+        self.changed.clone()
+    }
+    fn diff(&self, _: &Path, _: Baseline, full_context: bool) -> String {
+        self.diff_full_calls.lock().unwrap().push(full_context);
+        if full_context { "FULL".into() } else { "COMPACT".into() }
     }
 }
 
@@ -108,6 +128,41 @@ fn a_select_intent_does_not_block_on_a_slow_render_and_content_arrives_later() {
     }
     assert!(redrew, "the arriving content signalled a redraw via poll()");
     assert_eq!(flatten(ctrl.content()), "rendered:b.rs", "the selected file rendered");
+}
+
+#[test]
+fn full_diff_mode_asks_git_for_whole_file_context() {
+    // PR2 (AC-23 path): cycling a changed file to FullDiff dispatches a render whose worker
+    // reads the diff with full_context=true — so the whole file (not just hunks) is diffed.
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("c.rs"), "fn main() {}\n").unwrap();
+    let mut changed = BTreeMap::new();
+    changed.insert(PathBuf::from("c.rs"), Status::Modified);
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let components = Components {
+        git: Arc::new(RecordingGit { changed, diff_full_calls: calls.clone() }),
+        content: Box::new(SlowContent { delay: Duration::from_millis(0) }),
+        editor: Box::new(NoEditor),
+    };
+    let mut ctrl = Controller::new(dir.path().to_path_buf(), true, Baseline::Head, components);
+
+    // The changed file defaults to the compact Diff; one cycle advances to FullDiff, which
+    // dispatches a render whose worker requests a full-context diff.
+    ctrl.handle(Intent::CycleView);
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        ctrl.poll();
+        if calls.lock().unwrap().iter().any(|&full| full) {
+            break;
+        }
+        assert!(Instant::now() < deadline, "the worker never requested a full-context diff");
+        std::thread::sleep(Duration::from_millis(5));
+    }
+    assert!(
+        calls.lock().unwrap().contains(&true),
+        "FullDiff mode must ask git for whole-file context (full_context=true)"
+    );
 }
 
 #[test]

--- a/tests/git_baseline.rs
+++ b/tests/git_baseline.rs
@@ -78,14 +78,47 @@ fn diff_returns_unified_text_and_varies_with_baseline() {
     git(repo.path(), &["add", "."]);
     git(repo.path(), &["commit", "-q", "-m", "extend seed"]);
 
-    let base_diff = diff(repo.path(), Path::new("seed.txt"), Baseline::Base, None);
+    let base_diff = diff(repo.path(), Path::new("seed.txt"), Baseline::Base, None, false);
     assert!(base_diff.contains("@@"), "base diff is a unified diff (AC-9)");
     assert!(base_diff.contains("+2"), "base diff shows the committed addition");
 
     // No uncommitted change → empty HEAD diff; the two baselines differ (AC-16).
-    let head_diff = diff(repo.path(), Path::new("seed.txt"), Baseline::Head, None);
+    let head_diff = diff(repo.path(), Path::new("seed.txt"), Baseline::Head, None, false);
     assert!(!head_diff.contains("@@"), "HEAD diff is empty (no uncommitted change)");
     assert_ne!(base_diff, head_diff);
+}
+
+#[test]
+fn full_context_diff_includes_whole_file_context_the_compact_diff_omits() {
+    // PR2 / AC-9: full_context=true asks git for whole-file context, so lines far from the
+    // change (outside the default 3-line hunk window) are present — the compact diff omits them.
+    let repo = make_repo();
+    let mut lines: Vec<String> = Vec::new();
+    lines.push("TOP_MARKER".into());
+    for n in 1..=20 {
+        lines.push(format!("body{n}"));
+    }
+    lines.push("BOTTOM_MARKER".into());
+    let write = |ls: &[String]| fs::write(repo.path().join("big.txt"), format!("{}\n", ls.join("\n"))).unwrap();
+    write(&lines);
+    git(repo.path(), &["add", "."]);
+    git(repo.path(), &["commit", "-q", "-m", "add big"]);
+    // Change one middle line; the markers are far from it (> 3 lines away).
+    lines[10] = "CHANGED".into();
+    write(&lines);
+
+    let compact = diff(repo.path(), Path::new("big.txt"), Baseline::Head, None, false);
+    let full = diff(repo.path(), Path::new("big.txt"), Baseline::Head, None, true);
+
+    assert!(compact.contains("CHANGED") && full.contains("CHANGED"), "both show the change");
+    assert!(
+        !compact.contains("TOP_MARKER") && !compact.contains("BOTTOM_MARKER"),
+        "the compact (3-line) hunk omits distant context:\n{compact}"
+    );
+    assert!(
+        full.contains("TOP_MARKER") && full.contains("BOTTOM_MARKER"),
+        "the full-context diff carries the whole file as context:\n{full}"
+    );
 }
 
 #[test]
@@ -111,7 +144,7 @@ fn base_branch_hint_drives_base_queries_for_non_main_master_repos() {
     // With the hint, committed feature work is in the base set...
     let hinted = changed_set(repo.path(), Baseline::Base, Some("trunk"));
     assert!(hinted.contains_key(&PathBuf::from("feat.txt")));
-    assert!(diff(repo.path(), Path::new("feat.txt"), Baseline::Base, Some("trunk")).contains("@@"));
+    assert!(diff(repo.path(), Path::new("feat.txt"), Baseline::Base, Some("trunk"), false).contains("@@"));
 
     // ...without it (and with no main/master fallback), the Base query degrades to a
     // HEAD comparison, where the committed file is clean — proving the hint is honored.
@@ -125,7 +158,7 @@ fn untracked_file_diff_shows_added_content() {
     let repo = make_repo();
     fs::write(repo.path().join("brand_new.txt"), "hello\nworld\n").unwrap();
 
-    let d = diff(repo.path(), Path::new("brand_new.txt"), Baseline::Head, None);
+    let d = diff(repo.path(), Path::new("brand_new.txt"), Baseline::Head, None, false);
     assert!(d.contains("+hello"), "untracked file diff shows its content as added");
     assert!(d.contains("+world"));
 }
@@ -197,7 +230,7 @@ fn non_ascii_filename_round_trips_through_status_and_diff() {
         set.get(&PathBuf::from("résumé.txt")),
         Some(&Status::Modified)
     );
-    let d = diff(repo.path(), Path::new("résumé.txt"), Baseline::Head, None);
+    let d = diff(repo.path(), Path::new("résumé.txt"), Baseline::Head, None, false);
     assert!(d.contains("+noël"), "diff of a non-ASCII path is not empty");
 }
 
@@ -211,7 +244,7 @@ fn staged_file_in_unborn_repo_diffs_as_added() {
     fs::write(repo.path().join("first.txt"), "hello\n").unwrap();
     git(repo.path(), &["add", "first.txt"]);
 
-    let d = diff(repo.path(), Path::new("first.txt"), Baseline::Head, None);
+    let d = diff(repo.path(), Path::new("first.txt"), Baseline::Head, None, false);
     assert!(d.contains("+hello"), "unborn-repo staged file shows an added diff (AC-9)");
 }
 
@@ -219,8 +252,8 @@ fn staged_file_in_unborn_repo_diffs_as_added() {
 fn diff_refuses_paths_outside_the_root() {
     // No arbitrary file reads; the viewer never resolves above its root (AC-N5).
     let repo = make_repo();
-    assert!(diff(repo.path(), Path::new("/etc/hostname"), Baseline::Head, None).is_empty());
-    assert!(diff(repo.path(), Path::new("../../etc/hostname"), Baseline::Head, None).is_empty());
+    assert!(diff(repo.path(), Path::new("/etc/hostname"), Baseline::Head, None, false).is_empty());
+    assert!(diff(repo.path(), Path::new("../../etc/hostname"), Baseline::Head, None, false).is_empty());
 }
 
 #[test]
@@ -246,7 +279,7 @@ fn malicious_repo_config_is_not_executed_during_queries() {
 
     let _ = status(repo.path());
     let _ = changed_set(repo.path(), Baseline::Head, None);
-    let _ = diff(repo.path(), Path::new("seed.txt"), Baseline::Head, None);
+    let _ = diff(repo.path(), Path::new("seed.txt"), Baseline::Head, None, false);
 
     assert!(
         !marker.exists(),
@@ -262,7 +295,7 @@ fn diff_refuses_symlink_escaping_the_root() {
     fs::write(outside.path().join("secret.txt"), "TOPSECRET\n").unwrap();
     std::os::unix::fs::symlink(outside.path(), repo.path().join("escape")).unwrap();
 
-    let d = diff(repo.path(), Path::new("escape/secret.txt"), Baseline::Head, None);
+    let d = diff(repo.path(), Path::new("escape/secret.txt"), Baseline::Head, None, false);
     assert!(d.is_empty(), "must not read files via a symlink escaping the root (AC-N5)");
     assert!(!d.contains("TOPSECRET"));
 }
@@ -282,8 +315,8 @@ fn baseline_queries_do_not_mutate_the_repo() {
     let _ = default_baseline(&resolved(repo.path()));
     let _ = changed_set(repo.path(), Baseline::Base, None);
     let _ = changed_set(repo.path(), Baseline::Head, None);
-    let _ = diff(repo.path(), Path::new("seed.txt"), Baseline::Base, None);
-    let _ = diff(repo.path(), Path::new("feat.txt"), Baseline::Head, None);
+    let _ = diff(repo.path(), Path::new("seed.txt"), Baseline::Base, None, false);
+    let _ = diff(repo.path(), Path::new("feat.txt"), Baseline::Head, None, false);
 
     assert_eq!(before, git(repo.path(), &["status", "--porcelain"]), "AC-N2");
     assert_eq!(head_before, git(repo.path(), &["rev-parse", "HEAD"]), "AC-N2");

--- a/tests/render_delegate.rs
+++ b/tests/render_delegate.rs
@@ -13,6 +13,7 @@ fn cat() -> Renderers {
     Renderers {
         markdown: vec!["cat".into()],
         diff: vec!["cat".into()],
+        full_diff: vec!["cat".into()],
         syntax: vec!["cat".into()],
         timeout: Duration::from_secs(5),
     }
@@ -72,6 +73,7 @@ fn missing_renderer_falls_back_to_plain_text_with_a_notice() {
     let renderers = Renderers {
         markdown: vec!["herdr-no-such-binary-xyz".into()],
         diff: vec!["cat".into()],
+        full_diff: vec!["cat".into()],
         syntax: vec!["cat".into()],
         timeout: Duration::from_secs(5),
     };
@@ -98,6 +100,7 @@ fn syntax_renderer_receives_the_file_name_via_placeholder() {
     let renderers = Renderers {
         markdown: vec!["cat".into()],
         diff: vec!["cat".into()],
+        full_diff: vec!["cat".into()],
         syntax: vec!["sh".into(), "-c".into(), "echo {name}".into()],
         timeout: Duration::from_secs(5),
     };
@@ -115,6 +118,7 @@ fn a_malicious_file_name_cannot_inject_via_the_placeholder() {
     let renderers = Renderers {
         markdown: vec!["cat".into()],
         diff: vec!["cat".into()],
+        full_diff: vec!["cat".into()],
         syntax: vec!["sh".into(), "-c".into(), "echo {name}".into()],
         timeout: Duration::from_secs(5),
     };
@@ -127,17 +131,25 @@ fn a_malicious_file_name_cannot_inject_via_the_placeholder() {
 }
 
 #[test]
-fn raw_content_mode_does_not_invoke_a_renderer() {
+fn full_diff_mode_renders_the_diff_text_via_the_full_diff_renderer() {
+    // FullDiff renders from git's (full-context) diff text on raw_diff — not the file bytes —
+    // and delegates to the dedicated `full_diff` renderer, NOT the compact `diff` one. A
+    // renderer that fails for `diff` but succeeds for `full_diff` proves the right one is used.
     let renderers = Renderers {
-        markdown: vec!["nope-xyz".into()],
-        diff: vec!["nope-xyz".into()],
-        syntax: vec!["nope-xyz".into()],
+        markdown: vec!["cat".into()],
+        diff: vec!["herdr-no-such-binary-xyz".into()], // would fail if FullDiff used it
+        full_diff: vec!["cat".into()],
+        syntax: vec!["cat".into()],
         timeout: Duration::from_secs(5),
     };
-    let prepared = Prepared::Full { text: "plain text here".into() };
-    let (text, notice) = render(&renderers, &prepared, ViewMode::RawContent, None, None);
-    assert!(flatten(&text).contains("plain text here"));
-    assert!(notice.is_none(), "raw content needs no renderer → no fallback notice");
+    let full = "@@ -1,2 +1,2 @@\n fn main() {\n-    old();\n+    new();\n }";
+    // Prepared::Binary on purpose: like Diff, FullDiff renders from git, so a deleted/binary
+    // file still shows its diff (AC-9) rather than the binary placeholder.
+    let (text, notice) = render(&renderers, &Prepared::Binary, ViewMode::FullDiff, Some(full), None);
+    let s = flatten(&text);
+    assert!(s.contains("fn main()") && s.contains("new()"), "full-context diff is shown: {s}");
+    assert!(!s.to_lowercase().contains("binary file"), "no binary placeholder in full-diff mode");
+    assert!(notice.is_none(), "the full_diff renderer succeeded → no fallback notice");
 }
 
 #[test]
@@ -145,6 +157,7 @@ fn a_hanging_renderer_times_out_and_falls_back() {
     let renderers = Renderers {
         markdown: vec!["sleep".into(), "30".into()],
         diff: vec!["cat".into()],
+        full_diff: vec!["cat".into()],
         syntax: vec!["cat".into()],
         timeout: Duration::from_millis(150),
     };

--- a/tests/render_delegate.rs
+++ b/tests/render_delegate.rs
@@ -153,6 +153,17 @@ fn full_diff_mode_renders_the_diff_text_via_the_full_diff_renderer() {
 }
 
 #[test]
+fn an_oversized_full_diff_is_truncated_with_a_notice() {
+    // AC-13 on the FullDiff path: a full-context diff of a large file is bounded with a visible
+    // truncation notice before it is rendered, so it can't blow up the content pane.
+    let big_diff = "+line\n".repeat(6000); // > the 5000-line cap
+    let (text, notice) = render(&cat(), &Prepared::Binary, ViewMode::FullDiff, Some(&big_diff), None);
+    let n = notice.expect("AC-13: an oversized full-context diff gets a truncation notice");
+    assert!(n.to_lowercase().contains("truncat"), "the notice names the truncation: {n}");
+    assert!(flatten(&text).lines().count() <= 5000, "the rendered diff is line-bounded (AC-13)");
+}
+
+#[test]
 fn a_hanging_renderer_times_out_and_falls_back() {
     let renderers = Renderers {
         markdown: vec!["sleep".into(), "30".into()],


### PR DESCRIPTION
## What

Two view-cycle changes (bundled, per the agreed plan):

1. **New `FullDiff` view** — a changed file can now cycle to a **full-context diff**: the whole file with a line-number gutter, syntax highlighting on unchanged lines, and the changes shown inline. This is the "show me the whole file *and* what changed" view.
2. **Removed `RawContent`** (plain, no-gutter, no-color) from the cycle.

## Why

- The compact `Diff` shows only the changed hunks; there was no way to see a change *in the context of the whole file* with line numbers. `FullDiff` fills that gap — and stays within "delegate rendering" (ADR-0001): it's just `git diff` with whole-file context piped to `delta --line-numbers`.
- `RawContent` was the cycle's "override floor", but with `bat` present it differed from `SyntaxContent` only by color + gutter, and the renderer-absent plain-text floor is already provided by `SyntaxContent`'s fallback. Dropping it is a deliberate, user-approved simplification.

## How

- **view_policy** — `ViewMode` swaps `RawContent` → `FullDiff`. `applicable_modes` offers `FullDiff` right after `Diff` for a changed file (`Diff → FullDiff → [RenderedMarkdown] → SyntaxContent`), and no longer appends `RawContent`. Unchanged files have no diff modes in their cycle.
- **git** — `diff()` gains a `full_context` flag; `true` passes `git diff -U1000000` so the whole file is emitted as context. The render layer still bounds the result (AC-13).
- **controller** — `GitService::diff` carries `full_context`; the render worker requests it for `FullDiff` (off the input thread, AC-23). `wrap_for` now wraps only rendered markdown (diffs/code stay unwrapped so the gutter aligns).
- **render** — new `Renderers.full_diff`; `FullDiff` renders from git's diff text like `Diff` (so a deleted/binary file still shows its diff, AC-9), delegating to the dedicated renderer.
- **app** — `full_diff = ["delta", "--line-numbers"]`. No new install dependency — it reuses `delta`.

## Spec change (AC-11)

Removing `RawContent` is a scope change, so the spec is updated at the owning stage — **AC-11** (acceptance-criteria.md), the View Policy contract (design.md), and the brief — not just the code. AC-11 now describes the cycle as rendered-markdown / compact-diff / syntax-content / full-context-diff (for a changed file).

## Tests (TDD)

- **view_policy** — changed cycle offers `FullDiff` after `Diff`; unchanged files have no diff modes.
- **git** — `full_context=true` carries whole-file context (distant `TOP_MARKER`/`BOTTOM_MARKER` lines) that the compact diff omits.
- **render** — `FullDiff` renders the diff text via the `full_diff` renderer (proven distinct: the `diff` renderer is set to a failing binary), not the binary placeholder.
- **controller** — a changed file cycles `Diff → FullDiff → SyntaxContent → wrap`; the worker requests `full_context=true` for `FullDiff` (async, recording git stub).

181 tests green; no new clippy warnings. (Repo-wide `cargo fmt` / pedantic-doc-lint drift is pre-existing and untouched — the code is hand-formatted.)
