### PR TITLE
Add 'open viewer in a tab' action + idempotent cross-tab launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,24 @@ Reload with `herdr server reload-config`. Pressing the key then opens / focuses 
 viewer via the same idempotent launcher. (Alternatively, `command` may invoke
 `scripts/open-file-viewer.sh` directly using the absolute install path from `herdr plugin list`.)
 
+**Open in a tab instead of a split.** A second action, `open-file-viewer-tab`, opens the viewer
+in its **own tab** (`scripts/open-file-viewer-tab.sh`, `--placement tab`). Its launcher is
+idempotent *across tabs* — *open-or-switch-or-toggle*:
+
+- no viewer anywhere → open it in a new tab (focused)
+- a viewer in another tab → **switch to that tab** (never a duplicate)
+- a viewer in the current tab, not focused → focus it in place
+- the viewer already focused → close it (herdr auto-closes the emptied tab)
+
+Bind it to its own key — e.g. `prefix+shift+f` alongside `prefix+f` for the split:
+
+```toml
+[[keys.command]]
+key = "prefix+shift+f"
+type = "shell"
+command = "herdr plugin action invoke open-file-viewer-tab --plugin herdr-file-viewer"
+```
+
 **Limitation over `herdr --remote`.** `--remote` attaches with **local** keybindings by
 default, and herdr has no way to fire a plugin action into the *attached* (remote) session from
 a local key: a `type = "shell"` command runs against your **local** herdr (wrong session), and a

--- a/docs/manual-verification.md
+++ b/docs/manual-verification.md
@@ -82,6 +82,14 @@ This procedure verifies the remaining **live-host** behavior.
    - Bind it to a key (README `[[keys.command]]` snippet) and confirm the key drives the same
      open → focus → close cycle.
 
+6b. **Tab launcher (open-or-switch-or-toggle across tabs).**
+   Invoke `open-file-viewer-tab` (or bind `prefix+shift+f`):
+   - With no viewer open → it opens in a **new tab** (focused), not a split.
+   - From a different tab while a viewer tab exists → it **switches to** the viewer tab (no
+     second viewer spawns).
+   - On the viewer tab with the viewer focused → invoking again **closes** it (the now-empty
+     tab disappears).
+
 7. **Mouse (the feel — needs a human; can't be driven over the CLI).** With the viewer open:
    - **Click** a tree row → it selects (the content pane updates). **Click** in the content
      column → it takes focus.
@@ -100,6 +108,8 @@ This procedure verifies the remaining **live-host** behavior.
 - [ ] Step 5 — the close key closed the viewer and returned focus to the origin pane (AC-20).
 - [ ] Step 6 — repeated invocation focuses the existing viewer (no duplicate panes) and toggles
       it closed; a bound key drives the same cycle.
+- [ ] Step 6b — `open-file-viewer-tab` opens the viewer in its own tab, switches to it from
+      another tab (no duplicate), and toggles it closed when on it.
 - [ ] Step 7 — click selects, double-click activates (folder toggle / file editor), the wheel
       scrolls, the divider drags, and `Shift`+drag still selects text in the terminal.
 

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -32,3 +32,12 @@ id = "open-file-viewer"
 title = "Open file viewer"
 description = "Open the git-aware file viewer in a split pane beside the current work."
 command = ["bash", "scripts/open-file-viewer.sh"]
+
+# The same viewer, opened in its own tab instead of a split. Idempotent across tabs: switches
+# to an existing viewer tab rather than duplicating it, and toggles off when already on it.
+# Bind a key to it (e.g. `prefix+shift+f`) in ~/.config/herdr/config.toml.
+[[actions]]
+id = "open-file-viewer-tab"
+title = "Open file viewer (tab)"
+description = "Open the git-aware file viewer in its own tab (switch to it if already open)."
+command = ["bash", "scripts/open-file-viewer-tab.sh"]

--- a/scripts/open-file-viewer-tab.sh
+++ b/scripts/open-file-viewer-tab.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Idempotent launcher for the file viewer in its own TAB — used by the `open-file-viewer-tab`
+# action and a herdr keybinding (e.g. `prefix+shift+f`). "Open-or-switch, toggle on repeat",
+# scoped across tabs:
+#   - no Files pane anywhere                 -> open the viewer in a new tab (focused)
+#   - a Files pane lives in another tab      -> switch to that tab (no duplicate viewer)
+#   - a Files pane is in the current tab,
+#     but not focused                        -> focus it in place
+#   - the focused pane IS the Files pane      -> close it ("toggle off"; herdr auto-closes the
+#                                               now-empty tab — verified)
+#
+# Sibling of scripts/open-file-viewer.sh (the split-pane variant). The OPEN/SWITCHTAB/FOCUS/
+# CLOSE decision is computed in-process by the viewer binary (`--launch-decision-tab`, fed the
+# `pane list` JSON on stdin), so it is unit-tested and the pane/tab ids it returns are validated
+# flag-safe (option-injection guard). Any failure degrades to OPEN (open a fresh viewer tab).
+# herdr has no focus-by-id, so an in-tab focus is a `zoom <id> --on/--off` cycle; a cross-tab
+# switch is `tab focus <tab_id>`.
+set -uo pipefail
+
+herdr_bin="${HERDR_BIN_PATH:-herdr}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+viewer_bin="$script_dir/../target/release/herdr-file-viewer"
+
+open_tab() {
+  exec "$herdr_bin" plugin pane open \
+    --plugin herdr-file-viewer \
+    --entrypoint file-viewer \
+    --placement tab \
+    --focus
+}
+
+decision="OPEN"
+if [ -x "$viewer_bin" ]; then
+  panes="$("$herdr_bin" pane list 2>/dev/null || true)"
+  if [ -n "$panes" ]; then
+    decision="$(printf '%s' "$panes" | "$viewer_bin" --launch-decision-tab 2>/dev/null || echo OPEN)"
+  fi
+fi
+
+case "$decision" in
+  "SWITCHTAB "*)
+    tid="${decision#SWITCHTAB }"
+    exec "$herdr_bin" tab focus "$tid"
+    ;;
+  "FOCUS "*)
+    pid="${decision#FOCUS }"
+    "$herdr_bin" pane zoom "$pid" --on >/dev/null 2>&1 || true
+    exec "$herdr_bin" pane zoom "$pid" --off
+    ;;
+  "CLOSE "*)
+    pid="${decision#CLOSE }"
+    exec "$herdr_bin" pane close "$pid"
+    ;;
+  *)
+    open_tab
+    ;;
+esac

--- a/scripts/open-file-viewer-tab.sh
+++ b/scripts/open-file-viewer-tab.sh
@@ -40,7 +40,10 @@ fi
 case "$decision" in
   "SWITCHTAB "*)
     tid="${decision#SWITCHTAB }"
-    exec "$herdr_bin" tab focus "$tid"
+    # If the target tab vanished between the pane-list snapshot and now (a race — the viewer tab
+    # was closed in between), fall back to opening a fresh viewer tab rather than leaving the
+    # keypress a silent no-op. (No `exec`, so the `||` fallback can run.)
+    "$herdr_bin" tab focus "$tid" || open_tab
     ;;
   "FOCUS "*)
     pid="${decision#FOCUS }"

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -61,6 +61,54 @@ pub fn launch_decision(pane_list_json: &str) -> String {
     }
 }
 
+/// Decide the launcher action for the **tab** variant (`scripts/open-file-viewer-tab.sh`),
+/// returning one line: `OPEN`, `SWITCHTAB <tab_id>`, `FOCUS <pane_id>`, or `CLOSE <pane_id>`.
+///
+/// Like [`launch_decision`] but tab-scoped: a `"Files"` pane in *another* tab is **switched to**
+/// (`herdr tab focus <tab_id>`) rather than duplicated — the idempotency that makes a single
+/// keystroke reach the one viewer wherever it lives.
+///
+/// - Unparseable JSON, or no focused pane (current tab unknown) → `OPEN`.
+/// - A `"Files"` pane in the **focused** tab: `CLOSE` it when it *is* the focused pane (toggle
+///   off — herdr auto-closes the emptied tab), otherwise `FOCUS` it in place.
+/// - Else a `"Files"` pane in **any other** tab: `SWITCHTAB` to its tab.
+/// - Else `OPEN`.
+/// - A pane/tab id that is not flag-safe is never emitted (→ `OPEN`), so a host-supplied id can
+///   never option-inject when the launcher passes it to `herdr pane`/`herdr tab`.
+pub fn launch_decision_tab(pane_list_json: &str) -> String {
+    let Ok(list) = serde_json::from_str::<PaneList>(pane_list_json) else {
+        return "OPEN".to_string();
+    };
+    let panes = &list.result.panes;
+    let Some(focused) = panes.iter().find(|p| p.focused) else {
+        return "OPEN".to_string();
+    };
+    let is_viewer = |p: &&Pane| p.label.as_deref() == Some("Files");
+
+    // Prefer a viewer in the focused tab (toggle/focus in place) over one elsewhere.
+    if let Some(here) = panes
+        .iter()
+        .find(|p| is_viewer(p) && p.tab_id.as_deref() == focused.tab_id.as_deref())
+    {
+        let Some(id) = here.pane_id.as_deref().filter(|id| is_flag_safe(id)) else {
+            return "OPEN".to_string();
+        };
+        return if Some(id) == focused.pane_id.as_deref() {
+            format!("CLOSE {id}")
+        } else {
+            format!("FOCUS {id}")
+        };
+    }
+
+    // Otherwise switch to a viewer living in another tab, by its (validated) tab id.
+    if let Some(elsewhere) = panes.iter().find(is_viewer)
+        && let Some(tab) = elsewhere.tab_id.as_deref().filter(|t| is_flag_safe(t))
+    {
+        return format!("SWITCHTAB {tab}");
+    }
+    "OPEN".to_string()
+}
+
 /// A pane id is safe to place in an argv iff it is a non-empty token of `[A-Za-z0-9_:.-]` that
 /// does not start with `-` (which would option-inject). Mirrors `host::is_safe_pane_id`'s
 /// anti-option-injection intent, but also allows `:` and `.` because herdr pane ids are
@@ -133,5 +181,61 @@ mod tests {
         assert!(!is_flag_safe("-rf"));
         assert!(!is_flag_safe(""));
         assert!(!is_flag_safe("a b"));
+    }
+
+    // ---- tab launcher (`launch_decision_tab`) -----------------------------------------
+
+    #[test]
+    fn tab_no_files_anywhere_opens() {
+        let j = list(&[pane("wE:p1", "", true, "wE:t1")]);
+        assert_eq!(launch_decision_tab(&j), "OPEN");
+    }
+
+    #[test]
+    fn tab_viewer_focused_closes() {
+        // On the viewer's own tab with it focused → toggle off (close the pane; herdr auto-
+        // closes the now-empty tab).
+        let j = list(&[pane("wE:p1", "", false, "wE:t1"), pane("wE:pD", "Files", true, "wE:t4")]);
+        assert_eq!(launch_decision_tab(&j), "CLOSE wE:pD");
+    }
+
+    #[test]
+    fn tab_viewer_in_another_tab_switches_to_that_tab() {
+        // THE key difference from the pane launcher: a viewer in a different tab is switched to
+        // (by tab id), not duplicated.
+        let j = list(&[pane("wE:p1", "", true, "wE:t1"), pane("wE:pD", "Files", false, "wE:t4")]);
+        assert_eq!(launch_decision_tab(&j), "SWITCHTAB wE:t4");
+    }
+
+    #[test]
+    fn tab_viewer_in_current_tab_unfocused_is_focused() {
+        // Edge: the viewer was split into the current tab and isn't focused → focus it in place.
+        let j = list(&[pane("wE:p1", "", true, "wE:t1"), pane("wE:pD", "Files", false, "wE:t1")]);
+        assert_eq!(launch_decision_tab(&j), "FOCUS wE:pD");
+    }
+
+    #[test]
+    fn tab_no_focused_pane_opens() {
+        let j = list(&[pane("wE:pD", "Files", false, "wE:t4")]);
+        assert_eq!(launch_decision_tab(&j), "OPEN");
+    }
+
+    #[test]
+    fn tab_unsafe_tab_id_is_never_emitted() {
+        // A tab id that could option-inject `herdr tab focus <id>` must degrade to OPEN.
+        let j = list(&[pane("wE:p1", "", true, "wE:t1"), pane("wE:pD", "Files", false, "-rf")]);
+        assert_eq!(launch_decision_tab(&j), "OPEN");
+    }
+
+    #[test]
+    fn tab_unsafe_pane_id_is_never_emitted() {
+        let j = list(&[pane("wE:p1", "", false, "wE:t4"), pane("-rf", "Files", true, "wE:t4")]);
+        assert_eq!(launch_decision_tab(&j), "OPEN");
+    }
+
+    #[test]
+    fn tab_garbage_json_opens() {
+        assert_eq!(launch_decision_tab("not json"), "OPEN");
+        assert_eq!(launch_decision_tab(""), "OPEN");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,10 +4,18 @@ fn main() -> std::io::Result<()> {
     // `--launch-decision`: read a herdr `pane list` JSON on stdin and print the launcher's
     // decision (OPEN / FOCUS <id> / CLOSE <id>) for scripts/open-file-viewer.sh. This does NOT
     // start the TUI, so the launcher can compute its action in-process (no extra runtime dep).
-    if std::env::args().nth(1).as_deref() == Some("--launch-decision") {
+    // `--launch-decision-tab` is the same, for the tab launcher: it may also emit
+    // `SWITCHTAB <tab_id>` so a viewer in another tab is switched to, not duplicated.
+    let mode = std::env::args().nth(1);
+    if matches!(mode.as_deref(), Some("--launch-decision") | Some("--launch-decision-tab")) {
         let mut json = String::new();
         std::io::stdin().read_to_string(&mut json)?;
-        println!("{}", herdr_file_viewer::launch::launch_decision(&json));
+        let decision = if mode.as_deref() == Some("--launch-decision-tab") {
+            herdr_file_viewer::launch::launch_decision_tab(&json)
+        } else {
+            herdr_file_viewer::launch::launch_decision(&json)
+        };
+        println!("{decision}");
         return Ok(());
     }
     herdr_file_viewer::run()

--- a/tests/manifest.rs
+++ b/tests/manifest.rs
@@ -51,6 +51,17 @@ fn declares_at_least_one_action() {
 }
 
 #[test]
+fn declares_split_and_tab_open_actions() {
+    // The viewer can be summoned as a split pane or in its own tab; each action runs its
+    // dedicated launcher script.
+    let m = manifest();
+    assert!(m.contains(r#"id = "open-file-viewer""#), "split-pane action present");
+    assert!(m.contains(r#"id = "open-file-viewer-tab""#), "tab action present");
+    assert!(m.contains("scripts/open-file-viewer.sh"), "split action runs its launcher");
+    assert!(m.contains("scripts/open-file-viewer-tab.sh"), "tab action runs its launcher");
+}
+
+#[test]
 fn pins_minimum_herdr_version() {
     assert!(
         manifest().contains(r#"min_herdr_version = "0.7.0""#),


### PR DESCRIPTION
## What

A second way to summon the viewer: **in its own tab** instead of a split pane — for binding to e.g. `prefix+shift+f`. Idempotent *across tabs*.

## Why

`prefix+f` opens the viewer as a split beside the current work. Some workflows want it full-window in a dedicated tab. herdr's `plugin pane open` supports `--placement tab` directly, so this is a thin addition — **the viewer binary is unchanged**; only *where herdr places it* differs.

## Behavior (open-or-switch-or-toggle, across tabs)

- No viewer anywhere → open it in a **new tab** (focused).
- A viewer in **another tab** → **switch to that tab** (`herdr tab focus`) — never a duplicate. *(This is the key difference from the split launcher, which is scoped to the current tab.)*
- A viewer in the **current tab**, not focused → focus it in place.
- The viewer **already focused** → close it (verified: herdr auto-closes the emptied tab).

## How

- **`launch.rs::launch_decision_tab`** — mirrors `launch_decision` but tab-scoped, adding the cross-tab `SWITCHTAB <tab_id>` decision. Pane **and** tab ids are validated `is_flag_safe` before they can reach an argv (option-injection guard), same discipline as the split launcher and the editor hand-off.
- **`main.rs`** — a `--launch-decision-tab` stdin mode prints the decision (no TUI), so the launcher computes it in-process.
- **`scripts/open-file-viewer-tab.sh`** — thin launcher: `OPEN → plugin pane open --placement tab`; `SWITCHTAB → herdr tab focus`; `FOCUS → zoom-cycle`; `CLOSE → pane close`. Degrades to OPEN on any failure. Logic stays in tested Rust (PR #8's lesson).
- **manifest** — a second `[[actions]]` (`open-file-viewer-tab`).
- **docs** — README "Open in a tab" section + the `prefix+shift+f` snippet; a manual-verification step.

## Verified live

`herdr plugin pane open … --placement tab` opens the viewer in a fresh tab; the `--launch-decision-tab` binary returns `SWITCHTAB <tab_id>` when a viewer lives in another tab and `CLOSE <id>` when it's the focused viewer (confirmed against a real `pane list`); closing the last pane in a tab auto-closes the tab.

## Tests (TDD)

`launch_decision_tab`: open / switch-to-another-tab / focus-in-current-tab / toggle-close / no-focused-pane / unsafe-tab-id / unsafe-pane-id / garbage-json. A manifest test asserts both actions and their launcher scripts. 192 tests green; no new clippy warnings.

## Out of scope

The `prefix+shift+f` keybinding lives in the user's `~/.config/herdr/config.toml` (not the repo), like `prefix+f`. The `--remote` keymap caveat (use `--remote-keybindings server`) applies identically.
