### PR TITLE
Esc backs out of zoom first; double-tap tolerant of column jitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,9 +163,9 @@ the same locally and remotely; it's only *which* keymap fires them across `--rem
 | `Tab` | Move focus between the tree and content columns |
 | `<` / `>` | Narrow / widen the tree column (move the divider) |
 | `w` | Toggle line wrapping for the content pane |
-| `z` | Zoom — hide the tree so the content pane fills the frame; press again to restore the two-column layout |
+| `z` | Zoom — hide the tree so the content pane fills the frame; press again (or `q`/`Esc`) to restore the two-column layout |
 | `r` | Refresh git state — pick up changes made outside the viewer (a merge / pull / commit elsewhere) |
-| `q` / `Esc` | Close the viewer and return to the prior pane |
+| `q` / `Esc` | Back out of zoom if zoomed; otherwise close the viewer and return to the prior pane (AC-20) |
 
 `Tab` to the content pane, then the arrow keys (or `h`/`j`/`k`/`l`) scroll it in all four
 directions; `Tab` back to the tree to move between files. Long lines wrap in prose (markdown /

--- a/docs/manual-verification.md
+++ b/docs/manual-verification.md
@@ -65,7 +65,8 @@ This procedure verifies the remaining **live-host** behavior.
    - Press `z` to zoom: the tree disappears and the content pane fills the whole frame (focus
      moves to it, so `↑`/`↓` scroll the file); press `z` again to restore the two columns.
    - Press `Enter` on a folder → it expands/collapses; press `Enter` on a file → it opens in
-     zoom mode (content full-screen). `z` returns to the two columns.
+     zoom mode (content full-screen). `z` — or `q`/`Esc` — returns to the two columns; pressing
+     `q`/`Esc` again (now un-zoomed) closes the viewer.
    - Press `e` on a file (with `$EDITOR` set) and confirm your editor opens on that file, then
      exit the editor and confirm the viewer redraws cleanly.
    - Resize the pane (e.g. `herdr pane resize`) and confirm the layout reflows to the new size.

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -449,13 +449,18 @@ impl Controller {
     fn handle_click(&mut self, col: u16, row: u16) -> Effects {
         let region = self.hit_test(col, row);
         let now = Instant::now();
-        let double = is_double_click(self.last_click, (col, row), now);
-        self.last_click = Some((col, row, now));
         match region {
             MouseRegion::TreeRow(idx) => {
                 if idx >= self.tree.visible_nodes().len() {
-                    return Effects::noop(); // the empty area below the last node — inert
+                    self.last_click = None; // empty area below the nodes — inert, and breaks any
+                    return Effects::noop(); // pending double-click sequence
                 }
+                // A double-click is two clicks on the SAME tree row within the window. Because
+                // every non-tree-row click clears `last_click` (below), it only ever holds prior
+                // tree-row clicks — so the column-agnostic same-row match in `is_double_click`
+                // can never be tripped by a click in another pane that happens to share a row.
+                let double = is_double_click(self.last_click, (col, row), now);
+                self.last_click = Some((col, row, now));
                 self.action_notice = None;
                 self.focus = Focus::Tree;
                 self.tree.set_cursor(idx);
@@ -466,10 +471,14 @@ impl Controller {
                 Effects::redraw()
             }
             MouseRegion::Content => {
+                self.last_click = None; // a non-tree click breaks any pending double-click
                 self.focus = Focus::Content;
                 Effects::redraw()
             }
-            MouseRegion::Divider | MouseRegion::Outside => Effects::noop(),
+            MouseRegion::Divider | MouseRegion::Outside => {
+                self.last_click = None;
+                Effects::noop()
+            }
         }
     }
 

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -407,7 +407,7 @@ impl Controller {
             Intent::ToggleWrap => self.toggle_wrap(),
             Intent::ToggleZoom => self.toggle_zoom(),
             Intent::Refresh => self.refresh(),
-            Intent::Close => Effects { quit: true, ..Default::default() },
+            Intent::Close => self.close_or_unzoom(),
         }
     }
 
@@ -766,6 +766,18 @@ impl Controller {
         Effects::redraw()
     }
 
+    /// The close key (`q`/`Esc`): when zoomed, back out of zoom first (the instinctive "escape
+    /// the full-screen view") and stay in the viewer; otherwise quit (AC-20). So from a zoomed
+    /// file it takes two presses to leave — one to un-zoom, one to close.
+    fn close_or_unzoom(&mut self) -> Effects {
+        if self.zoomed {
+            self.zoomed = false;
+            self.focus = Focus::Tree;
+            return Effects::redraw();
+        }
+        Effects { quit: true, ..Default::default() }
+    }
+
     /// Move the tree/content divider by `delta` percentage points, clamped so neither column
     /// can collapse. Pure layout state — no re-render is needed (the content is unchanged).
     fn resize_split(&mut self, delta: i16) -> Effects {
@@ -926,10 +938,14 @@ enum MouseRegion {
     Outside,
 }
 
-/// Two left-clicks at the same cell within [`DOUBLE_CLICK`] are a double-click. Pure over its
-/// timestamps so the timing rule is unit-testable without sleeping.
+/// Two left-clicks on the same **row** within [`DOUBLE_CLICK`] are a double-click. The column
+/// is ignored on purpose: a tree row is a single node end-to-end, so a click anywhere along it
+/// targets that node, and a touchpad double-tap commonly lands a column or two apart between
+/// taps — requiring the exact cell would silently drop those. (The column still matters for
+/// *which* node a click selects; that is the caller's hit-test, not this timing rule.) Pure over
+/// its timestamps so the timing rule is unit-testable without sleeping.
 fn is_double_click(prev: Option<(u16, u16, Instant)>, pos: (u16, u16), now: Instant) -> bool {
-    matches!(prev, Some((px, py, t)) if (px, py) == pos && now.saturating_duration_since(t) <= DOUBLE_CLICK)
+    matches!(prev, Some((_px, py, t)) if py == pos.1 && now.saturating_duration_since(t) <= DOUBLE_CLICK)
 }
 
 /// Whether a path names a markdown file (by extension, case-insensitive).
@@ -978,16 +994,20 @@ mod tests {
     use std::time::Instant;
 
     #[test]
-    fn is_double_click_requires_same_cell_within_the_window() {
+    fn is_double_click_requires_the_same_row_within_the_window() {
         let t0 = Instant::now();
         let within = t0 + DOUBLE_CLICK / 2;
         let after = t0 + DOUBLE_CLICK * 2;
         // Same cell, inside the window → double-click.
         assert!(is_double_click(Some((5, 5, t0)), (5, 5), within));
+        // Same ROW, different column, inside the window → still a double-click. A tree row is
+        // one node end-to-end, and a touchpad double-tap often lands a column or two apart, so
+        // requiring the exact cell would drop legitimate double-taps.
+        assert!(is_double_click(Some((5, 5, t0)), (40, 5), within));
         // Too slow → not a double-click.
         assert!(!is_double_click(Some((5, 5, t0)), (5, 5), after));
-        // A different cell → not a double-click (even if fast).
-        assert!(!is_double_click(Some((5, 5, t0)), (6, 5), within));
+        // A different ROW → not a double-click (it would target a different node).
+        assert!(!is_double_click(Some((5, 5, t0)), (5, 6), within));
         // No previous click → never a double-click.
         assert!(!is_double_click(None, (5, 5), within));
     }

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -713,6 +713,28 @@ fn double_click_a_folder_toggles_expansion() {
 }
 
 #[test]
+fn a_content_click_then_a_same_row_tree_click_is_not_a_double_click() {
+    // Regression (opus review of PR #16): the tree and content panes share row numbers, so with
+    // the column-agnostic double-click match a content click followed by a tree click on the
+    // SAME row must NOT register as a double-click (no spurious activation). A non-tree click
+    // clears the pending double-click.
+    let dir = TempDir::new();
+    std::fs::create_dir(dir.path().join("sub")).unwrap();
+    std::fs::write(dir.path().join("sub/inner.txt"), "x").unwrap();
+    let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
+    ctrl.set_pane_geometry(wide_geometry());
+    assert_eq!(ctrl.tree().visible_nodes().len(), 1, "folder starts collapsed");
+
+    ctrl.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 50, 1)); // content pane, row 1
+    ctrl.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 4, 1)); // tree folder, same row
+    assert_eq!(
+        ctrl.tree().visible_nodes().len(),
+        1,
+        "a content→tree same-row sequence must NOT activate (no spurious expand)"
+    );
+}
+
+#[test]
 fn double_tap_on_the_same_row_activates_even_with_column_jitter() {
     // A touchpad double-tap often lands a column or two apart between taps; as long as both
     // taps are on the same row within the double-click window, it activates (here: expands a

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -291,11 +291,31 @@ fn tab_is_inert_while_zoomed_so_focus_stays_on_content() {
 
 #[test]
 fn close_intent_signals_quit() {
-    // AC-20: the close key ends the session.
+    // AC-20: the close key ends the session (when not zoomed).
     let dir = TempDir::new();
     let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
     let fx = ctrl.handle(Intent::Close);
     assert!(fx.quit, "Close signals the run loop to exit (AC-20)");
+}
+
+#[test]
+fn close_backs_out_of_zoom_first_then_quits() {
+    // When zoomed, the close key (q/Esc) backs out of zoom rather than quitting — the
+    // instinctive "escape the full-screen view". A second press (now un-zoomed) quits (AC-20).
+    let dir = TempDir::new();
+    let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
+
+    ctrl.handle(Intent::ToggleZoom);
+    assert!(ctrl.zoomed());
+
+    let fx = ctrl.handle(Intent::Close);
+    assert!(!fx.quit, "Close while zoomed does NOT quit");
+    assert!(fx.redraw, "it redraws (the tree reappears)");
+    assert!(!ctrl.zoomed(), "Close while zoomed un-zooms");
+    assert_eq!(ctrl.focus(), Focus::Tree, "un-zoom returns focus to the tree");
+
+    let fx2 = ctrl.handle(Intent::Close);
+    assert!(fx2.quit, "Close again (no longer zoomed) quits (AC-20)");
 }
 
 #[test]
@@ -689,6 +709,27 @@ fn double_click_a_folder_toggles_expansion() {
         ctrl.tree().visible_nodes().len(),
         2,
         "double-clicking the folder expands it to reveal its child"
+    );
+}
+
+#[test]
+fn double_tap_on_the_same_row_activates_even_with_column_jitter() {
+    // A touchpad double-tap often lands a column or two apart between taps; as long as both
+    // taps are on the same row within the double-click window, it activates (here: expands a
+    // folder) just like an exact double-click.
+    let dir = TempDir::new();
+    std::fs::create_dir(dir.path().join("sub")).unwrap();
+    std::fs::write(dir.path().join("sub/inner.txt"), "x").unwrap();
+    let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
+    ctrl.set_pane_geometry(wide_geometry());
+    assert_eq!(ctrl.tree().visible_nodes().len(), 1, "folder starts collapsed");
+
+    ctrl.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 4, 1)); // tap 1, column 4
+    ctrl.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 9, 1)); // tap 2, column 9 (jitter)
+    assert_eq!(
+        ctrl.tree().visible_nodes().len(),
+        2,
+        "a same-row double-tap with column jitter still expands the folder"
     );
 }
 


### PR DESCRIPTION
## What

Two small UX fixes you asked for:

1. **`Esc`/`q` backs out of zoom first.** When zoomed, the close key un-zooms (tree reappears, focus returns to it) instead of quitting — the instinctive "escape the full-screen view". A second press (now un-zoomed) quits (AC-20). So leaving a zoomed file is two presses: un-zoom, then close.
2. **Double-tap now works like double-click.** `is_double_click` matched the *exact cell*; a touchpad double-tap often lands a column or two apart between taps, so legitimate double-taps were dropped. It now matches the same **row** within the window (ignoring the column) — a tree row is one node end-to-end, so any column on it targets that node. Single-tap (select) is unchanged.

## How

- `controller::close_or_unzoom()` handles `Intent::Close`: zoomed → un-zoom + focus tree (redraw, no quit); else quit.
- `is_double_click` now compares the row (`py == pos.1`) within `DOUBLE_CLICK`, not the full cell. Only the tree-row Up path uses the result, so the relaxation can't cause spurious content/divider activation.
- docs: README Keys (`q`/`Esc`, `z`) + the manual-verification zoom step.

## Tests

- `close_backs_out_of_zoom_first_then_quits` — Close while zoomed un-zooms (no quit); again quits.
- `double_tap_on_the_same_row_activates_even_with_column_jitter` — taps at cols 4 then 9 on the same row expand a folder.
- `is_double_click_requires_the_same_row_within_the_window` — same-row/diff-column ✓, diff-row ✗, too-slow ✗.

196 tests green; no new clippy warnings.

## Review

Small change — per the owner's call, this skips the full review-gate panel and gets a single **opus** review instead.