### PR TITLE
chore: rustfmt + clippy + gitignore AUDIT.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@
 # Review-gate run logs / dismissal records — local audit trail, not part of the plugin
 .review-gate/
 
+# Repo-audit backlog — internal triage snapshot, kept local only
+/AUDIT.md
+
 # Spec / process / meta docs — kept local only, not tracked in the plugin repo (per owner)
 /CLAUDE.md
 /CONTEXT.md

--- a/src/app.rs
+++ b/src/app.rs
@@ -48,19 +48,29 @@ pub fn run() -> io::Result<()> {
     let git: Arc<dyn GitService> = Arc::new(LiveGit {
         // In a non-repo there is no repo_root; git is never queried then, but a path is still
         // required, so fall back to the tree root.
-        repo_root: resolved.repo_root.clone().unwrap_or_else(|| resolved.root.clone()),
+        repo_root: resolved
+            .repo_root
+            .clone()
+            .unwrap_or_else(|| resolved.root.clone()),
         base_hint: resolved.base_branch.clone(),
     });
-    let content: Box<dyn ContentProvider> =
-        Box::new(LiveContent { root: resolved.root.clone(), renderers: default_renderers() });
-    let editor: Box<dyn EditorHandoff> =
-        Box::new(LiveEditor { editor: std::env::var_os("EDITOR") });
+    let content: Box<dyn ContentProvider> = Box::new(LiveContent {
+        root: resolved.root.clone(),
+        renderers: default_renderers(),
+    });
+    let editor: Box<dyn EditorHandoff> = Box::new(LiveEditor {
+        editor: std::env::var_os("EDITOR"),
+    });
 
     let mut controller = Controller::new(
         resolved.root.clone(),
         resolved.is_git_repo,
         baseline,
-        Components { git, content, editor },
+        Components {
+            git,
+            content,
+            editor,
+        },
     );
 
     let mut terminal = ratatui::try_init()?;
@@ -177,7 +187,13 @@ impl GitService for LiveGit {
         git::changed_set(&self.repo_root, baseline, self.base_hint.as_deref())
     }
     fn diff(&self, rel_path: &Path, baseline: Baseline, full_context: bool) -> String {
-        git::diff(&self.repo_root, rel_path, baseline, self.base_hint.as_deref(), full_context)
+        git::diff(
+            &self.repo_root,
+            rel_path,
+            baseline,
+            self.base_hint.as_deref(),
+            full_context,
+        )
     }
 }
 
@@ -200,7 +216,10 @@ impl ContentProvider for LiveContent {
         };
         let name = path.file_name().and_then(OsStr::to_str);
         let (content, notice) = render::render(&self.renderers, &prepared, mode, raw_diff, name);
-        RenderResult { content, notices: notice.into_iter().collect() }
+        RenderResult {
+            content,
+            notices: notice.into_iter().collect(),
+        }
     }
 }
 
@@ -243,8 +262,9 @@ struct ProcessSpawner;
 
 impl Spawner for ProcessSpawner {
     fn spawn(&mut self, argv: &[OsString]) -> io::Result<()> {
-        let (prog, args) =
-            argv.split_first().ok_or_else(|| io::Error::other("empty editor command"))?;
+        let (prog, args) = argv
+            .split_first()
+            .ok_or_else(|| io::Error::other("empty editor command"))?;
         let status = Command::new(prog).args(args).status()?;
         if status.success() {
             Ok(())
@@ -255,7 +275,9 @@ impl Spawner for ProcessSpawner {
     fn open_pane(&mut self, _editor: &OsStr, _file: &Path) -> io::Result<()> {
         // v1's keyboard OpenInEditor uses the configured-editor path (Target::Editor); the
         // new-pane sequence is implemented and tested in the Host Adapter (host.rs).
-        Err(io::Error::other("new-pane hand-off is not on the v1 keyboard path"))
+        Err(io::Error::other(
+            "new-pane hand-off is not on the v1 keyboard path",
+        ))
     }
 }
 
@@ -366,8 +388,14 @@ mod tests {
         std::fs::write(root.join("assets/markdown-style.json"), "{}").unwrap();
         let exe = root.join("target/release/herdr-file-viewer");
         let s = bundled_style_path(Some(&exe)).expect("style found in the install tree");
-        assert!(s.ends_with("markdown-style.json"), "points at the bundled style: {s}");
-        assert!(Path::new(&s).is_file(), "the referenced style file exists: {s}");
+        assert!(
+            s.ends_with("markdown-style.json"),
+            "points at the bundled style: {s}"
+        );
+        assert!(
+            Path::new(&s).is_file(),
+            "the referenced style file exists: {s}"
+        );
         let _ = std::fs::remove_dir_all(&root);
     }
 
@@ -379,7 +407,11 @@ mod tests {
         // one. `markdown_style()` then falls back to glow's built-in `dark`.
         let root = tmp("bundled-absent"); // deliberately no assets/ created
         let exe = root.join("target/release/herdr-file-viewer");
-        assert_eq!(bundled_style_path(Some(&exe)), None, "no asset in the install tree → None");
+        assert_eq!(
+            bundled_style_path(Some(&exe)),
+            None,
+            "no asset in the install tree → None"
+        );
         let _ = std::fs::remove_dir_all(&root);
     }
 
@@ -414,8 +446,16 @@ mod tests {
         // bat, like glow, must be told to colorize since its output is piped, not a TTY; and
         // `--style=numbers` shows the line-number gutter the viewer wants for code.
         let r = default_renderers();
-        assert!(r.syntax.iter().any(|a| a == "--color=always"), "bat color forced: {:?}", r.syntax);
-        assert!(r.syntax.iter().any(|a| a == "--style=numbers"), "bat line numbers: {:?}", r.syntax);
+        assert!(
+            r.syntax.iter().any(|a| a == "--color=always"),
+            "bat color forced: {:?}",
+            r.syntax
+        );
+        assert!(
+            r.syntax.iter().any(|a| a == "--style=numbers"),
+            "bat line numbers: {:?}",
+            r.syntax
+        );
     }
 
     #[test]
@@ -423,7 +463,12 @@ mod tests {
         // The full-file diff view (AC-11) is delta WITH a line-number gutter — that gutter is
         // what makes it "the whole file with line numbers". The compact diff omits it.
         let r = default_renderers();
-        assert_eq!(r.full_diff.first().map(String::as_str), Some("delta"), "full_diff uses delta: {:?}", r.full_diff);
+        assert_eq!(
+            r.full_diff.first().map(String::as_str),
+            Some("delta"),
+            "full_diff uses delta: {:?}",
+            r.full_diff
+        );
         assert!(
             r.full_diff.iter().any(|a| a == "--line-numbers"),
             "full_diff shows line numbers: {:?}",

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -105,7 +105,10 @@ pub struct Effects {
 
 impl Effects {
     fn redraw() -> Self {
-        Effects { redraw: true, ..Default::default() }
+        Effects {
+            redraw: true,
+            ..Default::default()
+        }
     }
     fn noop() -> Self {
         Effects::default()
@@ -189,8 +192,17 @@ impl Controller {
     /// status (tree markers, AC-7) and the changed-set against `baseline` are loaded from
     /// git; otherwise the viewer is a plain browser (AC-26). The initial selection's content
     /// is rendered so the first frame is populated.
-    pub fn new(root: PathBuf, is_git_repo: bool, baseline: Baseline, components: Components) -> Self {
-        let Components { git, content, editor } = components;
+    pub fn new(
+        root: PathBuf,
+        is_git_repo: bool,
+        baseline: Baseline,
+        components: Components,
+    ) -> Self {
+        let Components {
+            git,
+            content,
+            editor,
+        } = components;
         // The Content Renderer (and the diff query it needs) live on a worker thread; the
         // controller talks to it over a job channel and reads finished renders off a result
         // channel (AC-23). The worker exits when the job sender (held by the controller) is
@@ -208,13 +220,15 @@ impl Controller {
                 // The diff is read here, off the input thread, so a large/slow diff never
                 // blocks input (AC-23). Other modes don't need git. The full-file diff view
                 // asks git for whole-file context; the compact diff uses git's default.
-                let raw_diff = if matches!(job.mode, ViewMode::Diff | ViewMode::FullDiff) && job.is_git
-                {
-                    let full = job.mode == ViewMode::FullDiff;
-                    job.rel.as_deref().map(|rel| worker_git.diff(rel, job.baseline, full))
-                } else {
-                    None
-                };
+                let raw_diff =
+                    if matches!(job.mode, ViewMode::Diff | ViewMode::FullDiff) && job.is_git {
+                        let full = job.mode == ViewMode::FullDiff;
+                        job.rel
+                            .as_deref()
+                            .map(|rel| worker_git.diff(rel, job.baseline, full))
+                    } else {
+                        None
+                    };
                 // A renderer panic must not kill the worker (rendering would stop forever) nor
                 // fire the global panic hook from this thread (it would reset the main thread's
                 // terminal mid-session). Contain it and surface a placeholder instead.
@@ -519,8 +533,8 @@ impl Controller {
             return Effects::noop();
         }
         let tree_w = col.saturating_sub(self.geom.area_x) as i32;
-        let pct = (tree_w * 100 / self.geom.area_width as i32)
-            .clamp(SPLIT_MIN as i32, SPLIT_MAX as i32);
+        let pct =
+            (tree_w * 100 / self.geom.area_width as i32).clamp(SPLIT_MIN as i32, SPLIT_MAX as i32);
         self.split_pct = pct as u16;
         Effects::redraw()
     }
@@ -576,7 +590,8 @@ impl Controller {
 
     /// The largest valid scroll offset: total rendered lines minus the viewport height.
     fn max_content_scroll(&self) -> u16 {
-        self.rendered_line_count().saturating_sub(self.content_height)
+        self.rendered_line_count()
+            .saturating_sub(self.content_height)
     }
 
     /// How many rows the content occupies once laid out, so the vertical scroll clamps to the
@@ -618,7 +633,13 @@ impl Controller {
         if self.effective_wrap() {
             return 0;
         }
-        let widest = self.content.lines.iter().map(|l| l.width()).max().unwrap_or(0);
+        let widest = self
+            .content
+            .lines
+            .iter()
+            .map(|l| l.width())
+            .max()
+            .unwrap_or(0);
         (widest.min(u16::MAX as usize) as u16).saturating_sub(self.content_width)
     }
 
@@ -658,7 +679,9 @@ impl Controller {
     /// ([`Intent::OpenInEditor`]). The content was already rendered when the file was selected,
     /// so this only flips the layout/focus — no re-render is dispatched.
     fn activate(&mut self) -> Effects {
-        let Some(node) = self.tree.selected() else { return Effects::noop() };
+        let Some(node) = self.tree.selected() else {
+            return Effects::noop();
+        };
         match node.kind {
             NodeKind::Dir => {
                 if node.expanded {
@@ -713,7 +736,9 @@ impl Controller {
     }
 
     fn cycle_view(&mut self) -> Effects {
-        let Some(node) = self.tree.selected() else { return Effects::noop() };
+        let Some(node) = self.tree.selected() else {
+            return Effects::noop();
+        };
         if node.kind != NodeKind::File {
             return Effects::noop();
         }
@@ -727,7 +752,9 @@ impl Controller {
     }
 
     fn open_in_editor(&mut self) -> Effects {
-        let Some(node) = self.tree.selected() else { return Effects::noop() };
+        let Some(node) = self.tree.selected() else {
+            return Effects::noop();
+        };
         if node.kind != NodeKind::File {
             return Effects::noop();
         }
@@ -738,14 +765,22 @@ impl Controller {
                 // force a full repaint (the external program drew over the screen).
                 self.refresh_git_state();
                 self.dispatch_render();
-                Effects { redraw: true, clear: true, ..Default::default() }
+                Effects {
+                    redraw: true,
+                    clear: true,
+                    ..Default::default()
+                }
             }
             Ok(false) => Effects::redraw(), // off-screen hand-off (new pane) — no takeover
             Err(e) => {
                 self.action_notice = Some(format!("Could not open editor: {e}"));
                 // The hand-off may have suspended the terminal before failing, so force a full
                 // repaint to recover from any partial screen state.
-                Effects { redraw: true, clear: true, ..Default::default() }
+                Effects {
+                    redraw: true,
+                    clear: true,
+                    ..Default::default()
+                }
             }
         }
     }
@@ -771,7 +806,11 @@ impl Controller {
     /// and rendered content are unchanged, so no re-render is dispatched.
     fn toggle_zoom(&mut self) -> Effects {
         self.zoomed = !self.zoomed;
-        self.focus = if self.zoomed { Focus::Content } else { Focus::Tree };
+        self.focus = if self.zoomed {
+            Focus::Content
+        } else {
+            Focus::Tree
+        };
         Effects::redraw()
     }
 
@@ -784,7 +823,10 @@ impl Controller {
             self.focus = Focus::Tree;
             return Effects::redraw();
         }
-        Effects { quit: true, ..Default::default() }
+        Effects {
+            quit: true,
+            ..Default::default()
+        }
     }
 
     /// Move the tree/content divider by `delta` percentage points, clamped so neither column
@@ -870,7 +912,9 @@ impl Controller {
         self.content_scroll = 0;
         self.content_hscroll = 0;
 
-        let Some(node) = self.tree.selected() else { return self.clear_content() };
+        let Some(node) = self.tree.selected() else {
+            return self.clear_content();
+        };
         if node.kind != NodeKind::File {
             return self.clear_content();
         }
@@ -929,7 +973,9 @@ impl Controller {
     }
 
     fn is_changed(&self, path: &Path) -> bool {
-        self.rel(path).map(|rel| self.changed.contains_key(&rel)).unwrap_or(false)
+        self.rel(path)
+            .map(|rel| self.changed.contains_key(&rel))
+            .unwrap_or(false)
     }
 
     /// `path` made relative to the tree root (how git keys its maps); `None` if outside it.

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -36,7 +36,9 @@ pub struct EditorLauncher {
 impl EditorLauncher {
     /// Create a launcher for the given editor command (e.g. from `$EDITOR`).
     pub fn new(editor: impl Into<OsString>) -> Self {
-        Self { editor: editor.into() }
+        Self {
+            editor: editor.into(),
+        }
     }
 
     /// Hand `file` off per `target` — spawn the configured editor on it, or ask the host to
@@ -56,8 +58,12 @@ impl EditorLauncher {
     /// new-pane path, which runs the editor as shell text). An empty/whitespace-only editor
     /// falls back to the raw value so the launch fails loudly rather than exec-ing the file.
     fn editor_argv(&self, file: &Path) -> Vec<OsString> {
-        let mut argv: Vec<OsString> =
-            self.editor.to_string_lossy().split_whitespace().map(OsString::from).collect();
+        let mut argv: Vec<OsString> = self
+            .editor
+            .to_string_lossy()
+            .split_whitespace()
+            .map(OsString::from)
+            .collect();
         if argv.is_empty() {
             argv.push(self.editor.clone());
         }

--- a/src/git.rs
+++ b/src/git.rs
@@ -5,8 +5,8 @@
 //! the viewer keeps working as a plain browser (AC-26).
 //!
 //! The viewer opens *untrusted* repositories (e.g. an agent's worktree, a clone), so
-//! every invocation is hardened against repo-controlled code execution: `--no-ext-diff`
-//! + `--no-textconv` refuse repo-configured diff/textconv programs, `core.fsmonitor` and
+//! every invocation is hardened against repo-controlled code execution: `--no-ext-diff` +
+//! `--no-textconv` refuse repo-configured diff/textconv programs, `core.fsmonitor` and
 //! `core.hooksPath` are neutralized, and `GIT_OPTIONAL_LOCKS=0` keeps status/diff from
 //! writing the index (AC-N2). Paths are parsed from NUL-delimited (`-z`) output as raw
 //! bytes, so any filename — spaces, control chars, non-ASCII — maps to the real
@@ -179,7 +179,13 @@ pub fn diff(
     // The path is appended as a raw OsStr arg (not lossy UTF-8) so non-ASCII / non-UTF-8
     // filenames reach git verbatim and their diffs are not silently empty.
     if is_untracked(repo_root, path) {
-        let mut args = vec!["diff", "--no-ext-diff", "--no-textconv", "--no-index", "--no-color"];
+        let mut args = vec![
+            "diff",
+            "--no-ext-diff",
+            "--no-textconv",
+            "--no-index",
+            "--no-color",
+        ];
         args.extend(unified);
         args.push("--");
         args.push("/dev/null");
@@ -222,7 +228,12 @@ fn git_command(repo_root: &Path, args: &[&str]) -> Command {
         // repo-planted `filter=<driver>` (clean/smudge) or `diff=<driver>` (textconv)
         // cannot run a configured program during a read-only query.
         .arg(format!("--attr-source={EMPTY_TREE}"))
-        .args(["-c", "core.fsmonitor=false", "-c", "core.hooksPath=/dev/null"])
+        .args([
+            "-c",
+            "core.fsmonitor=false",
+            "-c",
+            "core.hooksPath=/dev/null",
+        ])
         .args(args);
     cmd
 }
@@ -297,7 +308,10 @@ fn is_within_root(repo_root: &Path, path: &Path) -> bool {
         return false;
     }
     // If the target resolves (exists), ensure symlinks didn't lead outside the root.
-    match (repo_root.join(path).canonicalize(), repo_root.canonicalize()) {
+    match (
+        repo_root.join(path).canonicalize(),
+        repo_root.canonicalize(),
+    ) {
         (Ok(full), Ok(root)) => full.starts_with(root),
         // Non-existent target (e.g. a deleted file): the lexical checks already bound it.
         _ => true,
@@ -339,10 +353,11 @@ fn is_safe_ref(name: &str) -> bool {
 /// conventional fallback. Remote-tracking refs are included so a freshly-cloned repo or
 /// worktree whose base exists only as `origin/main` still resolves a base (AC-14).
 fn resolve_base_branch(repo_root: &Path, hint: Option<&str>) -> Option<String> {
-    if let Some(h) = hint {
-        if is_safe_ref(h) && ref_exists(repo_root, h) {
-            return Some(h.to_string());
-        }
+    if let Some(h) = hint
+        && is_safe_ref(h)
+        && ref_exists(repo_root, h)
+    {
+        return Some(h.to_string());
     }
     ["main", "master", "origin/main", "origin/master"]
         .into_iter()

--- a/src/host.rs
+++ b/src/host.rs
@@ -95,7 +95,9 @@ pub fn open_pane(
     cli: &mut impl HerdrCli,
 ) -> io::Result<()> {
     if !is_safe_pane_id(current_pane_id) {
-        return Err(invalid(format!("unsafe current pane id: {current_pane_id:?}")));
+        return Err(invalid(format!(
+            "unsafe current pane id: {current_pane_id:?}"
+        )));
     }
 
     let split_out = cli.run(&osv([
@@ -111,7 +113,9 @@ pub fn open_pane(
         .map_err(|e| invalid(format!("could not parse pane split result: {e}")))?;
     let new_pane = parsed.result.pane.pane_id;
     if !is_safe_pane_id(&new_pane) {
-        return Err(invalid(format!("unsafe new pane id from split: {new_pane:?}")));
+        return Err(invalid(format!(
+            "unsafe new pane id from split: {new_pane:?}"
+        )));
     }
 
     // Trust boundary: `editor` is application configuration ($EDITOR / user config), treated
@@ -148,7 +152,8 @@ fn is_safe_pane_id(id: &str) -> bool {
         Some(c) if c.is_ascii_alphanumeric() || c == '_' => {}
         _ => return false,
     }
-    id.chars().all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+    id.chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
 }
 
 /// Render `file` for the `pane run` shell command: POSIX single-quoted so any metacharacter

--- a/src/input.rs
+++ b/src/input.rs
@@ -77,17 +77,26 @@ mod tests {
     #[test]
     fn bound_keys_map_to_their_intents() {
         for &(code, want) in BINDINGS {
-            assert_eq!(map_key(k(code)), Some(want), "{code:?} should map to {want:?}");
+            assert_eq!(
+                map_key(k(code)),
+                Some(want),
+                "{code:?} should map to {want:?}"
+            );
         }
     }
 
     #[test]
     fn every_intent_has_at_least_one_key() {
         // AC-18: keyboard-complete — no viewer function is unreachable from the keyboard.
-        let reachable: HashSet<Intent> =
-            BINDINGS.iter().filter_map(|&(c, _)| map_key(k(c))).collect();
+        let reachable: HashSet<Intent> = BINDINGS
+            .iter()
+            .filter_map(|&(c, _)| map_key(k(c)))
+            .collect();
         for intent in Intent::ALL {
-            assert!(reachable.contains(&intent), "{intent:?} has no bound key (AC-18)");
+            assert!(
+                reachable.contains(&intent),
+                "{intent:?} has no bound key (AC-18)"
+            );
         }
     }
 
@@ -103,9 +112,18 @@ mod tests {
     fn modified_char_keys_do_not_trigger_intents() {
         // Ctrl+C is the terminal interrupt, not "changed-only"; Alt-chords are unbound too.
         // Accidental or reserved chords must not fire a viewer action.
-        assert_eq!(map_key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL)), None);
-        assert_eq!(map_key(KeyEvent::new(KeyCode::Char('e'), KeyModifiers::ALT)), None);
-        assert_eq!(map_key(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::CONTROL)), None);
+        assert_eq!(
+            map_key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL)),
+            None
+        );
+        assert_eq!(
+            map_key(KeyEvent::new(KeyCode::Char('e'), KeyModifiers::ALT)),
+            None
+        );
+        assert_eq!(
+            map_key(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::CONTROL)),
+            None
+        );
     }
 
     #[test]
@@ -120,6 +138,9 @@ mod tests {
             map_key(KeyEvent::new(KeyCode::Char('>'), KeyModifiers::NONE)),
             Some(Intent::GrowTree)
         );
-        assert_eq!(map_key(KeyEvent::new(KeyCode::Char('<'), KeyModifiers::CONTROL)), None);
+        assert_eq!(
+            map_key(KeyEvent::new(KeyCode::Char('<'), KeyModifiers::CONTROL)),
+            None
+        );
     }
 }

--- a/src/intent.rs
+++ b/src/intent.rs
@@ -104,13 +104,20 @@ mod tests {
                 | Intent::Refresh
                 | Intent::Close => false,
             };
-            assert!(!mutates_file, "{intent:?} must not mutate file contents (AC-N3)");
+            assert!(
+                !mutates_file,
+                "{intent:?} must not mutate file contents (AC-N3)"
+            );
         }
     }
 
     #[test]
     fn all_lists_every_variant_once() {
         let set: HashSet<&Intent> = Intent::ALL.iter().collect();
-        assert_eq!(set.len(), Intent::ALL.len(), "Intent::ALL must have no duplicates");
+        assert_eq!(
+            set.len(),
+            Intent::ALL.len(),
+            "Intent::ALL must have no duplicates"
+        );
     }
 }

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -116,7 +116,9 @@ pub fn launch_decision_tab(pane_list_json: &str) -> String {
 fn is_flag_safe(id: &str) -> bool {
     !id.is_empty()
         && !id.starts_with('-')
-        && id.chars().all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | ':' | '.'))
+        && id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | ':' | '.'))
 }
 
 #[cfg(test)]
@@ -138,20 +140,29 @@ mod tests {
 
     #[test]
     fn files_pane_focused_closes() {
-        let j = list(&[pane("wE:p1", "", false, "wE:t1"), pane("wE:pD", "Files", true, "wE:t1")]);
+        let j = list(&[
+            pane("wE:p1", "", false, "wE:t1"),
+            pane("wE:pD", "Files", true, "wE:t1"),
+        ]);
         assert_eq!(launch_decision(&j), "CLOSE wE:pD");
     }
 
     #[test]
     fn files_pane_unfocused_in_current_tab_is_focused() {
-        let j = list(&[pane("wE:p1", "", true, "wE:t1"), pane("wE:pD", "Files", false, "wE:t1")]);
+        let j = list(&[
+            pane("wE:p1", "", true, "wE:t1"),
+            pane("wE:pD", "Files", false, "wE:t1"),
+        ]);
         assert_eq!(launch_decision(&j), "FOCUS wE:pD");
     }
 
     #[test]
     fn files_pane_in_another_tab_is_ignored() {
         // The focused pane is in tab wE:t1; a Files pane in wC:t1 must not be touched.
-        let j = list(&[pane("wE:p1", "", true, "wE:t1"), pane("wC:pD", "Files", false, "wC:t1")]);
+        let j = list(&[
+            pane("wE:p1", "", true, "wE:t1"),
+            pane("wC:pD", "Files", false, "wC:t1"),
+        ]);
         assert_eq!(launch_decision(&j), "OPEN");
     }
 
@@ -165,7 +176,10 @@ mod tests {
     fn unsafe_pane_id_is_never_emitted() {
         // A pane id beginning with '-' could option-inject `herdr pane zoom <id>`; it must
         // degrade to OPEN, never FOCUS/CLOSE.
-        let j = list(&[pane("wE:p1", "", true, "wE:t1"), pane("-rf", "Files", false, "wE:t1")]);
+        let j = list(&[
+            pane("wE:p1", "", true, "wE:t1"),
+            pane("-rf", "Files", false, "wE:t1"),
+        ]);
         assert_eq!(launch_decision(&j), "OPEN");
     }
 
@@ -195,7 +209,10 @@ mod tests {
     fn tab_viewer_focused_closes() {
         // On the viewer's own tab with it focused → toggle off (close the pane; herdr auto-
         // closes the now-empty tab).
-        let j = list(&[pane("wE:p1", "", false, "wE:t1"), pane("wE:pD", "Files", true, "wE:t4")]);
+        let j = list(&[
+            pane("wE:p1", "", false, "wE:t1"),
+            pane("wE:pD", "Files", true, "wE:t4"),
+        ]);
         assert_eq!(launch_decision_tab(&j), "CLOSE wE:pD");
     }
 
@@ -203,14 +220,20 @@ mod tests {
     fn tab_viewer_in_another_tab_switches_to_that_tab() {
         // THE key difference from the pane launcher: a viewer in a different tab is switched to
         // (by tab id), not duplicated.
-        let j = list(&[pane("wE:p1", "", true, "wE:t1"), pane("wE:pD", "Files", false, "wE:t4")]);
+        let j = list(&[
+            pane("wE:p1", "", true, "wE:t1"),
+            pane("wE:pD", "Files", false, "wE:t4"),
+        ]);
         assert_eq!(launch_decision_tab(&j), "SWITCHTAB wE:t4");
     }
 
     #[test]
     fn tab_viewer_in_current_tab_unfocused_is_focused() {
         // Edge: the viewer was split into the current tab and isn't focused → focus it in place.
-        let j = list(&[pane("wE:p1", "", true, "wE:t1"), pane("wE:pD", "Files", false, "wE:t1")]);
+        let j = list(&[
+            pane("wE:p1", "", true, "wE:t1"),
+            pane("wE:pD", "Files", false, "wE:t1"),
+        ]);
         assert_eq!(launch_decision_tab(&j), "FOCUS wE:pD");
     }
 
@@ -223,13 +246,19 @@ mod tests {
     #[test]
     fn tab_unsafe_tab_id_is_never_emitted() {
         // A tab id that could option-inject `herdr tab focus <id>` must degrade to OPEN.
-        let j = list(&[pane("wE:p1", "", true, "wE:t1"), pane("wE:pD", "Files", false, "-rf")]);
+        let j = list(&[
+            pane("wE:p1", "", true, "wE:t1"),
+            pane("wE:pD", "Files", false, "-rf"),
+        ]);
         assert_eq!(launch_decision_tab(&j), "OPEN");
     }
 
     #[test]
     fn tab_unsafe_pane_id_is_never_emitted() {
-        let j = list(&[pane("wE:p1", "", false, "wE:t4"), pane("-rf", "Files", true, "wE:t4")]);
+        let j = list(&[
+            pane("wE:p1", "", false, "wE:t4"),
+            pane("-rf", "Files", true, "wE:t4"),
+        ]);
         assert_eq!(launch_decision_tab(&j), "OPEN");
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,10 @@ fn main() -> std::io::Result<()> {
     // `--launch-decision-tab` is the same, for the tab launcher: it may also emit
     // `SWITCHTAB <tab_id>` so a viewer in another tab is switched to, not duplicated.
     let mode = std::env::args().nth(1);
-    if matches!(mode.as_deref(), Some("--launch-decision") | Some("--launch-decision-tab")) {
+    if matches!(
+        mode.as_deref(),
+        Some("--launch-decision") | Some("--launch-decision-tab")
+    ) {
         let mut json = String::new();
         std::io::stdin().read_to_string(&mut json)?;
         let decision = if mode.as_deref() == Some("--launch-decision-tab") {

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -169,7 +169,8 @@ fn draw_content(frame: &mut Frame, area: Rect, state: &ViewState) -> (u16, u16) 
     // A notice strip (truncation AC-13, fallback AC-25) sits above the content, bounded so
     // it can never crowd out the file itself.
     let max_notices = (inner.height.saturating_sub(1)).min(state.notices.len() as u16);
-    let parts = Layout::vertical([Constraint::Length(max_notices), Constraint::Min(0)]).split(inner);
+    let parts =
+        Layout::vertical([Constraint::Length(max_notices), Constraint::Min(0)]).split(inner);
 
     if max_notices > 0 {
         let notice_lines: Vec<Line> = state
@@ -273,13 +274,20 @@ mod tests {
     #[test]
     fn sanitize_label_strips_control_bytes_keeps_printable() {
         // ESC + CSI + C0 controls removed; the printable remainder (incl. unicode) survives.
-        assert_eq!(sanitize_label("evil\u{1b}[2J\u{1b}[10;10Hpwned"), "evil[2J[10;10Hpwned");
+        assert_eq!(
+            sanitize_label("evil\u{1b}[2J\u{1b}[10;10Hpwned"),
+            "evil[2J[10;10Hpwned"
+        );
         assert_eq!(sanitize_label("a\u{07}\u{08}\rb\tc"), "abc");
         assert_eq!(sanitize_label("plain_name.rs"), "plain_name.rs");
         assert_eq!(sanitize_label("café—ok"), "café—ok");
         // C1 controls (U+0080..U+009F) are also dropped.
         assert_eq!(sanitize_label("x\u{0090}y"), "xy");
         // No control codepoint survives, ever.
-        assert!(!sanitize_label("\u{1b}\u{07}\u{7f}\u{9b}z").chars().any(|c| c.is_control()));
+        assert!(
+            !sanitize_label("\u{1b}\u{07}\u{7f}\u{9b}z")
+                .chars()
+                .any(|c| c.is_control())
+        );
     }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -59,7 +59,9 @@ pub fn classify(root: &Path, path: &Path) -> Prepared {
     // Bounded read: at most MAX_BYTES, so a giant/hostile file is never slurped whole.
     let mut buf = Vec::new();
     if file.take(MAX_BYTES).read_to_end(&mut buf).is_err() {
-        return Prepared::Full { text: String::new() };
+        return Prepared::Full {
+            text: String::new(),
+        };
     }
 
     // Binary: a NUL byte anywhere in the (bounded) content. No raw bytes are emitted.
@@ -82,11 +84,7 @@ pub fn classify(root: &Path, path: &Path) -> Prepared {
     let line_count = text.lines().count();
     let over_lines = line_count >= MAX_LINES;
     if over_bytes || over_lines {
-        let preview: String = text
-            .lines()
-            .take(MAX_LINES)
-            .collect::<Vec<_>>()
-            .join("\n");
+        let preview: String = text.lines().take(MAX_LINES).collect::<Vec<_>>().join("\n");
         let cap = if over_bytes { "1 MB size" } else { "5000-line" };
         let notice = format!(
             "⚠ Truncated preview — showing {} lines ({} of {} bytes); file exceeds the {} cap.",
@@ -95,7 +93,10 @@ pub fn classify(root: &Path, path: &Path) -> Prepared {
             byte_len,
             cap
         );
-        return Prepared::Truncated { text: preview, notice };
+        return Prepared::Truncated {
+            text: preview,
+            notice,
+        };
     }
     Prepared::Full { text }
 }
@@ -135,9 +136,19 @@ pub fn render(
     // they differ only in the diff git produced (default vs. whole-file context) and the
     // delegate used (the full-context one numbers lines).
     if mode == ViewMode::Diff || mode == ViewMode::FullDiff {
-        let cmd = if mode == ViewMode::FullDiff { &renderers.full_diff } else { &renderers.diff };
+        let cmd = if mode == ViewMode::FullDiff {
+            &renderers.full_diff
+        } else {
+            &renderers.diff
+        };
         let (diff, notice) = cap_preview(raw_diff.unwrap_or(""));
-        return delegate(&with_name(cmd, name), &diff, mode, renderers.timeout, notice);
+        return delegate(
+            &with_name(cmd, name),
+            &diff,
+            mode,
+            renderers.timeout,
+            notice,
+        );
     }
 
     // Content modes: a binary file shows a placeholder, never raw bytes (AC-12).
@@ -170,7 +181,10 @@ pub fn render(
 /// so a stdin-fed renderer (e.g. `bat --file-name={name}`) can still infer the language —
 /// keeping the secure stdin design while enabling syntax highlighting (AC-10).
 fn with_name(command: &[String], name: &str) -> Vec<String> {
-    command.iter().map(|arg| arg.replace("{name}", name)).collect()
+    command
+        .iter()
+        .map(|arg| arg.replace("{name}", name))
+        .collect()
 }
 
 /// Bound a text block to the size cap, returning a preview plus a truncation notice when
@@ -191,7 +205,10 @@ fn cap_preview(text: &str) -> (String, Option<String>) {
             .unwrap_or(0);
         preview.truncate(end);
     }
-    (preview, Some("⚠ Truncated diff preview — diff exceeds the size cap.".into()))
+    (
+        preview,
+        Some("⚠ Truncated diff preview — diff exceeds the size cap.".into()),
+    )
 }
 
 /// Reduce an untrusted file name to a safe basename — directory parts stripped, only
@@ -205,7 +222,13 @@ fn sanitize_name(name: &str) -> String {
         .unwrap_or("");
     let safe: String = base
         .chars()
-        .map(|c| if c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-') { c } else { '_' })
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-') {
+                c
+            } else {
+                '_'
+            }
+        })
         .collect();
     // A leading '-' would be parsed as an option by a renderer (e.g. `bat -rf.rs`); prefix
     // it so the value is always treated as a file name.
@@ -316,7 +339,10 @@ fn run_renderer(command: &[String], input: &str, timeout: Duration) -> Result<St
 }
 
 /// Wait for a child to exit within `grace`, polling; kill and reap it if it overruns.
-fn wait_bounded(child: &mut std::process::Child, grace: Duration) -> Option<std::process::ExitStatus> {
+fn wait_bounded(
+    child: &mut std::process::Child,
+    grace: Duration,
+) -> Option<std::process::ExitStatus> {
     let deadline = std::time::Instant::now() + grace;
     loop {
         match child.try_wait() {
@@ -463,7 +489,10 @@ mod tests {
         let p = tmp("many.txt", many.as_bytes());
         match classify(&std::env::temp_dir(), &p) {
             Prepared::Truncated { text, notice } => {
-                assert!(text.lines().count() <= MAX_LINES, "AC-13: preview line-bounded");
+                assert!(
+                    text.lines().count() <= MAX_LINES,
+                    "AC-13: preview line-bounded"
+                );
                 assert!(notice.contains("line"), "notice describes the line cap");
             }
             other => panic!("expected Truncated, got {other:?}"),
@@ -497,7 +526,11 @@ mod tests {
         let outside = tmp("secret", b"TOPSECRET"); // lives in temp_dir, outside `root`
         let link = root.join("link.txt");
         symlink(&outside, &link).unwrap();
-        assert_eq!(classify(&root, &link), Prepared::Binary, "AC-N5: no out-of-root read");
+        assert_eq!(
+            classify(&root, &link),
+            Prepared::Binary,
+            "AC-N5: no out-of-root read"
+        );
         fs::remove_dir_all(&root).ok();
         fs::remove_file(&outside).ok();
     }
@@ -538,7 +571,10 @@ mod tests {
         let forced = cmd
             .get_envs()
             .any(|(k, v)| k == OsStr::new("CLICOLOR_FORCE") && v == Some(OsStr::new("1")));
-        assert!(forced, "CLICOLOR_FORCE=1 must be set on the renderer subprocess");
+        assert!(
+            forced,
+            "CLICOLOR_FORCE=1 must be set on the renderer subprocess"
+        );
     }
 
     #[test]
@@ -548,7 +584,15 @@ mod tests {
         // them — rather than being flattened to fixed RGB.
         use ratatui::style::Color;
         let t = to_text("\u{1b}[34mhi\u{1b}[0m");
-        let fg = t.lines.iter().flat_map(|l| l.spans.iter()).find_map(|s| s.style.fg);
-        assert_eq!(fg, Some(Color::Blue), "SGR 34 must map to the named Blue, not RGB");
+        let fg = t
+            .lines
+            .iter()
+            .flat_map(|l| l.spans.iter())
+            .find_map(|s| s.style.fg);
+        assert_eq!(
+            fg,
+            Some(Color::Blue),
+            "SGR 34 must map to the named Blue, not RGB"
+        );
     }
 }

--- a/src/root.rs
+++ b/src/root.rs
@@ -62,7 +62,12 @@ fn git_output(dir: &Path, args: &[&str]) -> Option<String> {
         .env_remove("GIT_OBJECT_DIRECTORY")
         .arg("-C")
         .arg(dir)
-        .args(["-c", "core.fsmonitor=false", "-c", "core.hooksPath=/dev/null"])
+        .args([
+            "-c",
+            "core.fsmonitor=false",
+            "-c",
+            "core.hooksPath=/dev/null",
+        ])
         .args(args)
         .output()
         .ok()?;
@@ -77,7 +82,10 @@ fn git_output(dir: &Path, args: &[&str]) -> Option<String> {
 /// common dir (`.git`); the main working tree's are the same.
 fn is_linked_worktree(dir: &Path) -> bool {
     let git_dir = git_output(dir, &["rev-parse", "--path-format=absolute", "--git-dir"]);
-    let common = git_output(dir, &["rev-parse", "--path-format=absolute", "--git-common-dir"]);
+    let common = git_output(
+        dir,
+        &["rev-parse", "--path-format=absolute", "--git-common-dir"],
+    );
     match (git_dir, common) {
         (Some(g), Some(c)) => g != c,
         _ => false,

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -198,7 +198,9 @@ impl TreeModel {
     /// contains changes (AC-7). Component-wise prefix match, so `src` is not matched by
     /// `src2/…`; excludes the directory's own path.
     fn dir_contains_change(&self, path: &Path) -> bool {
-        let Ok(rel) = path.strip_prefix(&self.root) else { return false };
+        let Ok(rel) = path.strip_prefix(&self.root) else {
+            return false;
+        };
         self.markers
             .keys()
             .chain(self.changed_filter.keys())

--- a/src/view_policy.rs
+++ b/src/view_policy.rs
@@ -66,12 +66,19 @@ mod tests {
     use super::*;
 
     fn fd(name: &str, is_markdown: bool, is_changed: bool) -> FileDescriptor {
-        FileDescriptor { path: PathBuf::from(name), is_markdown, is_changed }
+        FileDescriptor {
+            path: PathBuf::from(name),
+            is_markdown,
+            is_changed,
+        }
     }
 
     #[test]
     fn unchanged_markdown_defaults_to_rendered_markdown() {
-        assert_eq!(default_mode(&fd("README.md", true, false)), ViewMode::RenderedMarkdown);
+        assert_eq!(
+            default_mode(&fd("README.md", true, false)),
+            ViewMode::RenderedMarkdown
+        );
     }
 
     #[test]
@@ -82,7 +89,10 @@ mod tests {
 
     #[test]
     fn unchanged_non_markdown_defaults_to_syntax_content() {
-        assert_eq!(default_mode(&fd("main.rs", false, false)), ViewMode::SyntaxContent);
+        assert_eq!(
+            default_mode(&fd("main.rs", false, false)),
+            ViewMode::SyntaxContent
+        );
     }
 
     #[test]
@@ -90,7 +100,10 @@ mod tests {
         // AC-11: a changed file can cycle from the compact diff to a full-context diff
         // (whole file + line numbers + inline diff) before the content views.
         let modes = applicable_modes(&fd("main.rs", false, true));
-        assert_eq!(modes, vec![ViewMode::Diff, ViewMode::FullDiff, ViewMode::SyntaxContent]);
+        assert_eq!(
+            modes,
+            vec![ViewMode::Diff, ViewMode::FullDiff, ViewMode::SyntaxContent]
+        );
         // For a changed markdown file the rendered view sits after the two diff views.
         let md = applicable_modes(&fd("README.md", true, true));
         assert_eq!(
@@ -110,8 +123,14 @@ mod tests {
         // diff for an unchanged one, so neither diff mode is offered.
         for md in [true, false] {
             let modes = applicable_modes(&fd("x", md, false));
-            assert!(!modes.contains(&ViewMode::Diff), "no compact diff when unchanged (md={md})");
-            assert!(!modes.contains(&ViewMode::FullDiff), "no full diff when unchanged (md={md})");
+            assert!(
+                !modes.contains(&ViewMode::Diff),
+                "no compact diff when unchanged (md={md})"
+            );
+            assert!(
+                !modes.contains(&ViewMode::FullDiff),
+                "no full diff when unchanged (md={md})"
+            );
         }
     }
 

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -24,11 +24,13 @@ fn viewer_draws_a_filename_then_exits_zero_on_close() {
     p.set_expect_timeout(Some(Duration::from_secs(10)));
 
     // The tree column lists the file in the launch directory (AC-3 display / AC-17 launch).
-    p.expect("hello.txt").expect("viewer should draw the file tree");
+    p.expect("hello.txt")
+        .expect("viewer should draw the file tree");
 
     // The close key returns control and exits the process (AC-20).
     p.send("q").expect("send the close key");
-    p.expect(Eof).expect("process should terminate after the close key");
+    p.expect(Eof)
+        .expect("process should terminate after the close key");
 
     match p.get_process().wait().expect("reap the viewer process") {
         WaitStatus::Exited(_, code) => assert_eq!(code, 0, "AC-20: clean exit on close"),

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -7,10 +7,10 @@
 mod common;
 
 use common::TempDir;
+use crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 use herdr_file_viewer::controller::{
     Components, ContentProvider, Controller, EditorHandoff, GitService, RenderResult,
 };
-use crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 use herdr_file_viewer::git::{Baseline, Status};
 use herdr_file_viewer::intent::Intent;
 use herdr_file_viewer::presenter::{Focus, PaneGeometry};
@@ -58,7 +58,10 @@ impl GitService for StubGit {
 struct StubContent;
 impl ContentProvider for StubContent {
     fn render(&self, _path: &Path, _mode: ViewMode, _raw_diff: Option<&str>) -> RenderResult {
-        RenderResult { content: Text::raw("stub-content"), notices: Vec::new() }
+        RenderResult {
+            content: Text::raw("stub-content"),
+            notices: Vec::new(),
+        }
     }
 }
 
@@ -92,7 +95,10 @@ fn controller(
     let components = Components {
         git: Arc::new(git),
         content: Box::new(StubContent),
-        editor: Box::new(StubEditor { fail: editor_fails, opened: opened.clone() }),
+        editor: Box::new(StubEditor {
+            fail: editor_fails,
+            opened: opened.clone(),
+        }),
     };
     let ctrl = Controller::new(root.to_path_buf(), is_git_repo, Baseline::Head, components);
     (ctrl, changed_calls, opened)
@@ -106,9 +112,15 @@ fn toggle_ignore_flips_show_ignored_and_signals_redraw() {
     let dir = TempDir::new();
     let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
 
-    assert!(!ctrl.show_ignored(), "ignored files hidden by default (AC-4)");
+    assert!(
+        !ctrl.show_ignored(),
+        "ignored files hidden by default (AC-4)"
+    );
     let fx = ctrl.handle(Intent::ToggleIgnore);
-    assert!(ctrl.show_ignored(), "ToggleIgnore reveals ignored files (AC-5)");
+    assert!(
+        ctrl.show_ignored(),
+        "ToggleIgnore reveals ignored files (AC-5)"
+    );
     assert!(fx.redraw, "a state change signals a redraw");
 
     ctrl.handle(Intent::ToggleIgnore);
@@ -123,11 +135,17 @@ fn toggle_changed_only_flips_in_a_repo() {
 
     assert!(!ctrl.changed_only());
     let fx = ctrl.handle(Intent::ToggleChangedOnly);
-    assert!(ctrl.changed_only(), "ToggleChangedOnly restricts to changed files (AC-6)");
+    assert!(
+        ctrl.changed_only(),
+        "ToggleChangedOnly restricts to changed files (AC-6)"
+    );
     assert!(fx.redraw);
 
     ctrl.handle(Intent::ToggleChangedOnly);
-    assert!(!ctrl.changed_only(), "toggling again restores the full tree");
+    assert!(
+        !ctrl.changed_only(),
+        "toggling again restores the full tree"
+    );
 }
 
 #[test]
@@ -138,12 +156,24 @@ fn cycle_view_advances_the_selected_files_mode_through_the_applicable_set() {
     // Non-git → unchanged markdown: applicable modes are [RenderedMarkdown, SyntaxContent].
     let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
 
-    assert_eq!(ctrl.selected_view_mode(), Some(ViewMode::RenderedMarkdown), "markdown default");
+    assert_eq!(
+        ctrl.selected_view_mode(),
+        Some(ViewMode::RenderedMarkdown),
+        "markdown default"
+    );
     let fx = ctrl.handle(Intent::CycleView);
-    assert_eq!(ctrl.selected_view_mode(), Some(ViewMode::SyntaxContent), "advances to the override");
+    assert_eq!(
+        ctrl.selected_view_mode(),
+        Some(ViewMode::SyntaxContent),
+        "advances to the override"
+    );
     assert!(fx.redraw);
     ctrl.handle(Intent::CycleView);
-    assert_eq!(ctrl.selected_view_mode(), Some(ViewMode::RenderedMarkdown), "cycle wraps around");
+    assert_eq!(
+        ctrl.selected_view_mode(),
+        Some(ViewMode::RenderedMarkdown),
+        "cycle wraps around"
+    );
 }
 
 #[test]
@@ -154,16 +184,36 @@ fn cycle_view_on_a_changed_file_reaches_the_full_context_diff() {
     std::fs::write(dir.path().join("changed.rs"), "fn main() {}\n").unwrap();
     let mut changed = BTreeMap::new();
     changed.insert(PathBuf::from("changed.rs"), Status::Modified);
-    let git = StubGit { status: changed.clone(), changed, ..StubGit::default() };
+    let git = StubGit {
+        status: changed.clone(),
+        changed,
+        ..StubGit::default()
+    };
     let (mut ctrl, _, _) = controller(dir.path(), true, git, false);
 
-    assert_eq!(ctrl.selected_view_mode(), Some(ViewMode::Diff), "a changed file defaults to diff");
+    assert_eq!(
+        ctrl.selected_view_mode(),
+        Some(ViewMode::Diff),
+        "a changed file defaults to diff"
+    );
     ctrl.handle(Intent::CycleView);
-    assert_eq!(ctrl.selected_view_mode(), Some(ViewMode::FullDiff), "→ full-context diff");
+    assert_eq!(
+        ctrl.selected_view_mode(),
+        Some(ViewMode::FullDiff),
+        "→ full-context diff"
+    );
     ctrl.handle(Intent::CycleView);
-    assert_eq!(ctrl.selected_view_mode(), Some(ViewMode::SyntaxContent), "→ syntax content");
+    assert_eq!(
+        ctrl.selected_view_mode(),
+        Some(ViewMode::SyntaxContent),
+        "→ syntax content"
+    );
     ctrl.handle(Intent::CycleView);
-    assert_eq!(ctrl.selected_view_mode(), Some(ViewMode::Diff), "cycle wraps back to the compact diff");
+    assert_eq!(
+        ctrl.selected_view_mode(),
+        Some(ViewMode::Diff),
+        "cycle wraps back to the compact diff"
+    );
 }
 
 #[test]
@@ -175,7 +225,11 @@ fn toggle_baseline_recomputes_the_changed_set_and_updates_state() {
 
     assert_eq!(ctrl.baseline(), Baseline::Head);
     let fx = ctrl.handle(Intent::ToggleBaseline);
-    assert_eq!(ctrl.baseline(), Baseline::Base, "baseline toggles Head→Base (AC-16)");
+    assert_eq!(
+        ctrl.baseline(),
+        Baseline::Base,
+        "baseline toggles Head→Base (AC-16)"
+    );
     assert!(fx.redraw);
     assert_eq!(
         *changed_calls.lock().unwrap(),
@@ -191,11 +245,21 @@ fn git_intents_are_inert_without_a_repo() {
     let (mut ctrl, changed_calls, _) = controller(dir.path(), false, StubGit::default(), false);
 
     ctrl.handle(Intent::ToggleChangedOnly);
-    assert!(!ctrl.changed_only(), "changed-only is inert without git (AC-26)");
+    assert!(
+        !ctrl.changed_only(),
+        "changed-only is inert without git (AC-26)"
+    );
 
     ctrl.handle(Intent::ToggleBaseline);
-    assert_eq!(ctrl.baseline(), Baseline::Head, "baseline is inert without git (AC-26)");
-    assert!(changed_calls.lock().unwrap().is_empty(), "no git query is issued without a repo");
+    assert_eq!(
+        ctrl.baseline(),
+        Baseline::Head,
+        "baseline is inert without git (AC-26)"
+    );
+    assert!(
+        changed_calls.lock().unwrap().is_empty(),
+        "no git query is issued without a repo"
+    );
 }
 
 #[test]
@@ -207,8 +271,15 @@ fn an_editor_handoff_error_becomes_a_nonfatal_notice() {
     let (mut ctrl, _, opened) = controller(dir.path(), false, StubGit::default(), true);
 
     let fx = ctrl.handle(Intent::OpenInEditor);
-    assert_eq!(opened.lock().unwrap().len(), 1, "the editor hand-off was attempted");
-    assert!(!ctrl.notices().is_empty(), "the failure is surfaced as a notice");
+    assert_eq!(
+        opened.lock().unwrap().len(),
+        1,
+        "the editor hand-off was attempted"
+    );
+    assert!(
+        !ctrl.notices().is_empty(),
+        "the failure is surfaced as a notice"
+    );
     assert!(!fx.quit, "a component error does not end the session");
 }
 
@@ -258,13 +329,27 @@ fn zoom_toggle_hides_tree_and_pins_content_focus() {
     let fx = ctrl.handle(Intent::ToggleZoom);
     assert!(fx.redraw, "toggling zoom redraws");
     assert!(ctrl.zoomed(), "the viewer is zoomed after the toggle");
-    assert_eq!(ctrl.focus(), Focus::Content, "entering zoom focuses the content pane");
-    assert!(ctrl.view_state().zoomed, "the view state reflects the zoom for the Presenter");
+    assert_eq!(
+        ctrl.focus(),
+        Focus::Content,
+        "entering zoom focuses the content pane"
+    );
+    assert!(
+        ctrl.view_state().zoomed,
+        "the view state reflects the zoom for the Presenter"
+    );
 
     ctrl.handle(Intent::ToggleZoom);
     assert!(!ctrl.zoomed(), "the toggle un-zooms");
-    assert_eq!(ctrl.focus(), Focus::Tree, "leaving zoom returns focus to the tree");
-    assert!(!ctrl.view_state().zoomed, "the view state reflects the un-zoom");
+    assert_eq!(
+        ctrl.focus(),
+        Focus::Tree,
+        "leaving zoom returns focus to the tree"
+    );
+    assert!(
+        !ctrl.view_state().zoomed,
+        "the view state reflects the un-zoom"
+    );
 }
 
 #[test]
@@ -276,17 +361,33 @@ fn tab_is_inert_while_zoomed_so_focus_stays_on_content() {
     let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
 
     ctrl.handle(Intent::ToggleZoom);
-    assert_eq!(ctrl.focus(), Focus::Content, "entering zoom focuses the content pane");
+    assert_eq!(
+        ctrl.focus(),
+        Focus::Content,
+        "entering zoom focuses the content pane"
+    );
 
     let fx = ctrl.handle(Intent::ToggleFocus); // Tab while zoomed
-    assert_eq!(ctrl.focus(), Focus::Content, "Tab is inert while zoomed — focus stays on content");
+    assert_eq!(
+        ctrl.focus(),
+        Focus::Content,
+        "Tab is inert while zoomed — focus stays on content"
+    );
     assert!(!fx.redraw, "an inert Tab need not redraw");
 
     // Un-zoom: Tab works normally again (the guard is scoped to the zoom session).
     ctrl.handle(Intent::ToggleZoom);
-    assert_eq!(ctrl.focus(), Focus::Tree, "leaving zoom returns focus to the tree");
+    assert_eq!(
+        ctrl.focus(),
+        Focus::Tree,
+        "leaving zoom returns focus to the tree"
+    );
     ctrl.handle(Intent::ToggleFocus);
-    assert_eq!(ctrl.focus(), Focus::Content, "Tab switches columns again once un-zoomed");
+    assert_eq!(
+        ctrl.focus(),
+        Focus::Content,
+        "Tab switches columns again once un-zoomed"
+    );
 }
 
 #[test]
@@ -312,7 +413,11 @@ fn close_backs_out_of_zoom_first_then_quits() {
     assert!(!fx.quit, "Close while zoomed does NOT quit");
     assert!(fx.redraw, "it redraws (the tree reappears)");
     assert!(!ctrl.zoomed(), "Close while zoomed un-zooms");
-    assert_eq!(ctrl.focus(), Focus::Tree, "un-zoom returns focus to the tree");
+    assert_eq!(
+        ctrl.focus(),
+        Focus::Tree,
+        "un-zoom returns focus to the tree"
+    );
 
     let fx2 = ctrl.handle(Intent::Close);
     assert!(fx2.quit, "Close again (no longer zoomed) quits (AC-20)");
@@ -351,7 +456,11 @@ fn no_handled_intent_mutates_the_filesystem() {
         let _ = ctrl.handle(intent);
     }
 
-    assert_eq!(snapshot(dir.path()), before, "no intent mutated any file (AC-N1, AC-N3)");
+    assert_eq!(
+        snapshot(dir.path()),
+        before,
+        "no intent mutated any file (AC-N1, AC-N3)"
+    );
 }
 
 // ---- content scrolling + wrap (focus-aware navigation) --------------------------------
@@ -363,8 +472,14 @@ struct LinesContent {
 }
 impl ContentProvider for LinesContent {
     fn render(&self, _path: &Path, _mode: ViewMode, _raw_diff: Option<&str>) -> RenderResult {
-        let body = (0..self.n).map(|i| format!("L{i}")).collect::<Vec<_>>().join("\n");
-        RenderResult { content: Text::raw(body), notices: Vec::new() }
+        let body = (0..self.n)
+            .map(|i| format!("L{i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        RenderResult {
+            content: Text::raw(body),
+            notices: Vec::new(),
+        }
     }
 }
 
@@ -375,7 +490,10 @@ impl ContentProvider for WideContent {
     fn render(&self, _path: &Path, _mode: ViewMode, _raw_diff: Option<&str>) -> RenderResult {
         let line = format!("WIDE{}", "x".repeat(96)); // 100 columns
         let body = std::iter::repeat_n(line, 5).collect::<Vec<_>>().join("\n");
-        RenderResult { content: Text::raw(body), notices: Vec::new() }
+        RenderResult {
+            content: Text::raw(body),
+            notices: Vec::new(),
+        }
     }
 }
 
@@ -383,7 +501,12 @@ impl ContentProvider for WideContent {
 fn flatten(t: &Text) -> String {
     t.lines
         .iter()
-        .map(|l| l.spans.iter().map(|s| s.content.as_ref()).collect::<String>())
+        .map(|l| {
+            l.spans
+                .iter()
+                .map(|s| s.content.as_ref())
+                .collect::<String>()
+        })
         .collect::<Vec<_>>()
         .join("\n")
 }
@@ -393,7 +516,10 @@ fn await_marker(ctrl: &mut Controller, marker: &str) {
     let deadline = Instant::now() + Duration::from_secs(5);
     while !flatten(ctrl.content()).contains(marker) {
         ctrl.poll();
-        assert!(Instant::now() < deadline, "content '{marker}' never rendered");
+        assert!(
+            Instant::now() < deadline,
+            "content '{marker}' never rendered"
+        );
         std::thread::sleep(Duration::from_millis(5));
     }
 }
@@ -403,7 +529,10 @@ fn controller_with_lines(root: &Path, n: usize) -> Controller {
     let components = Components {
         git: Arc::new(StubGit::default()),
         content: Box::new(LinesContent { n }),
-        editor: Box::new(StubEditor { fail: false, opened: Arc::new(Mutex::new(Vec::new())) }),
+        editor: Box::new(StubEditor {
+            fail: false,
+            opened: Arc::new(Mutex::new(Vec::new())),
+        }),
     };
     Controller::new(root.to_path_buf(), false, Baseline::Head, components)
 }
@@ -420,7 +549,11 @@ fn nav_does_not_scroll_content_while_the_tree_is_focused() {
     assert_eq!(ctrl.focus(), Focus::Tree);
     ctrl.handle(Intent::NavDown);
     ctrl.handle(Intent::NavDown);
-    assert_eq!(ctrl.view_state().content_scroll, 0, "tree focus: content never scrolls");
+    assert_eq!(
+        ctrl.view_state().content_scroll,
+        0,
+        "tree focus: content never scrolls"
+    );
 }
 
 #[test]
@@ -437,19 +570,35 @@ fn nav_scrolls_the_content_pane_when_focused_and_clamps_both_ends() {
 
     ctrl.handle(Intent::NavDown);
     ctrl.handle(Intent::NavDown);
-    assert_eq!(ctrl.view_state().content_scroll, 2, "NavDown scrolls the content down");
+    assert_eq!(
+        ctrl.view_state().content_scroll,
+        2,
+        "NavDown scrolls the content down"
+    );
     ctrl.handle(Intent::NavUp);
-    assert_eq!(ctrl.view_state().content_scroll, 1, "NavUp scrolls the content up");
+    assert_eq!(
+        ctrl.view_state().content_scroll,
+        1,
+        "NavUp scrolls the content up"
+    );
 
     for _ in 0..10 {
         ctrl.handle(Intent::NavUp);
     }
-    assert_eq!(ctrl.view_state().content_scroll, 0, "cannot scroll above the first line");
+    assert_eq!(
+        ctrl.view_state().content_scroll,
+        0,
+        "cannot scroll above the first line"
+    );
 
     for _ in 0..200 {
         ctrl.handle(Intent::NavDown);
     }
-    assert_eq!(ctrl.view_state().content_scroll, 40, "cannot scroll past the last screenful");
+    assert_eq!(
+        ctrl.view_state().content_scroll,
+        40,
+        "cannot scroll past the last screenful"
+    );
 }
 
 #[test]
@@ -469,7 +618,11 @@ fn selecting_a_different_file_resets_the_scroll_to_the_top() {
 
     ctrl.handle(Intent::ToggleFocus); // back to the tree
     ctrl.handle(Intent::NavDown); // select the next file
-    assert_eq!(ctrl.view_state().content_scroll, 0, "a new selection resets the scroll");
+    assert_eq!(
+        ctrl.view_state().content_scroll,
+        0,
+        "a new selection resets the scroll"
+    );
 }
 
 #[test]
@@ -479,7 +632,10 @@ fn wrap_is_on_for_markdown_and_off_for_code() {
     let md = TempDir::new();
     std::fs::write(md.path().join("a.md"), "# hi\n").unwrap();
     let (ctrl_md, _, _) = controller(md.path(), false, StubGit::default(), false);
-    assert_eq!(ctrl_md.selected_view_mode(), Some(ViewMode::RenderedMarkdown));
+    assert_eq!(
+        ctrl_md.selected_view_mode(),
+        Some(ViewMode::RenderedMarkdown)
+    );
     assert!(ctrl_md.view_state().wrap, "markdown content wraps");
 
     let rs = TempDir::new();
@@ -502,7 +658,10 @@ fn wrap_toggle_forces_wrapping_on_for_code_then_back_to_the_mode_default() {
     assert!(fx.redraw);
     assert!(ctrl.view_state().wrap, "`w` forces wrap on for code");
     ctrl.handle(Intent::ToggleWrap);
-    assert!(!ctrl.view_state().wrap, "toggling again returns to the mode default");
+    assert!(
+        !ctrl.view_state().wrap,
+        "toggling again returns to the mode default"
+    );
 }
 
 #[test]
@@ -515,33 +674,58 @@ fn left_right_scroll_the_content_horizontally_when_focused_and_unwrapped() {
     let components = Components {
         git: Arc::new(StubGit::default()),
         content: Box::new(WideContent),
-        editor: Box::new(StubEditor { fail: false, opened: Arc::new(Mutex::new(Vec::new())) }),
+        editor: Box::new(StubEditor {
+            fail: false,
+            opened: Arc::new(Mutex::new(Vec::new())),
+        }),
     };
     let mut ctrl = Controller::new(dir.path().to_path_buf(), false, Baseline::Head, components);
     await_marker(&mut ctrl, "WIDE");
     ctrl.set_content_viewport(20, 10); // widest line 100, viewport 20 → max hscroll = 80
-    assert!(!ctrl.view_state().wrap, "a .rs file does not wrap, so horizontal scroll applies");
+    assert!(
+        !ctrl.view_state().wrap,
+        "a .rs file does not wrap, so horizontal scroll applies"
+    );
 
     ctrl.handle(Intent::ToggleFocus); // focus the content pane
-    assert_eq!(ctrl.view_state().content_hscroll, 0, "starts at the left edge");
+    assert_eq!(
+        ctrl.view_state().content_hscroll,
+        0,
+        "starts at the left edge"
+    );
 
     let fx = ctrl.handle(Intent::Expand); // → scrolls right
     assert!(fx.redraw);
     let after_one = ctrl.view_state().content_hscroll;
     assert!(after_one > 0, "→ scrolls the content right when focused");
     ctrl.handle(Intent::Expand);
-    assert!(ctrl.view_state().content_hscroll > after_one, "→ again scrolls further right");
+    assert!(
+        ctrl.view_state().content_hscroll > after_one,
+        "→ again scrolls further right"
+    );
     ctrl.handle(Intent::Collapse); // ← scrolls left
-    assert_eq!(ctrl.view_state().content_hscroll, after_one, "← scrolls back left");
+    assert_eq!(
+        ctrl.view_state().content_hscroll,
+        after_one,
+        "← scrolls back left"
+    );
 
     for _ in 0..50 {
         ctrl.handle(Intent::Collapse);
     }
-    assert_eq!(ctrl.view_state().content_hscroll, 0, "cannot scroll left of the start");
+    assert_eq!(
+        ctrl.view_state().content_hscroll,
+        0,
+        "cannot scroll left of the start"
+    );
     for _ in 0..500 {
         ctrl.handle(Intent::Expand);
     }
-    assert_eq!(ctrl.view_state().content_hscroll, 80, "clamps at the widest line minus the viewport");
+    assert_eq!(
+        ctrl.view_state().content_hscroll,
+        80,
+        "clamps at the widest line minus the viewport"
+    );
 }
 
 #[test]
@@ -554,7 +738,10 @@ fn wrapped_content_scrolls_vertically_to_the_bottom_and_not_horizontally() {
     let components = Components {
         git: Arc::new(StubGit::default()),
         content: Box::new(WideContent), // 5 lines × 100 columns
-        editor: Box::new(StubEditor { fail: false, opened: Arc::new(Mutex::new(Vec::new())) }),
+        editor: Box::new(StubEditor {
+            fail: false,
+            opened: Arc::new(Mutex::new(Vec::new())),
+        }),
     };
     let mut ctrl = Controller::new(dir.path().to_path_buf(), false, Baseline::Head, components);
     await_marker(&mut ctrl, "WIDE");
@@ -568,11 +755,18 @@ fn wrapped_content_scrolls_vertically_to_the_bottom_and_not_horizontally() {
     // Wrapped rows (20) are counted, not raw lines (5, which would clamp to 0): the bottom is
     // reachable. Exact count via ratatui means no over-scroll into blank past row 20.
     let vmax = ctrl.view_state().content_scroll;
-    assert_eq!(vmax, 10, "scrolls to exactly the last wrapped row (20 rows − 10 tall)");
+    assert_eq!(
+        vmax, 10,
+        "scrolls to exactly the last wrapped row (20 rows − 10 tall)"
+    );
 
     let h_before = ctrl.view_state().content_hscroll;
     ctrl.handle(Intent::Expand); // → : would scroll right, but wrap leaves nothing to scroll past
-    assert_eq!(ctrl.view_state().content_hscroll, h_before, "no horizontal scroll while wrapping");
+    assert_eq!(
+        ctrl.view_state().content_hscroll,
+        h_before,
+        "no horizontal scroll while wrapping"
+    );
 }
 
 #[test]
@@ -588,10 +782,18 @@ fn shrinking_the_viewport_reclamps_an_existing_scroll_offset() {
     for _ in 0..200 {
         ctrl.handle(Intent::NavDown);
     }
-    assert_eq!(ctrl.view_state().content_scroll, 40, "scrolled to the bottom");
+    assert_eq!(
+        ctrl.view_state().content_scroll,
+        40,
+        "scrolled to the bottom"
+    );
 
     ctrl.set_content_viewport(40, 30); // taller viewport → max 20; the offset must re-clamp
-    assert_eq!(ctrl.view_state().content_scroll, 20, "offset re-clamped to the new, smaller max");
+    assert_eq!(
+        ctrl.view_state().content_scroll,
+        20,
+        "offset re-clamped to the new, smaller max"
+    );
 }
 
 #[test]
@@ -605,35 +807,59 @@ fn resize_intents_move_the_tree_content_divider_and_clamp() {
     let start = ctrl.view_state().split_pct;
     let fx = ctrl.handle(Intent::GrowTree);
     assert!(fx.redraw);
-    assert!(ctrl.view_state().split_pct > start, "GrowTree widens the tree column");
+    assert!(
+        ctrl.view_state().split_pct > start,
+        "GrowTree widens the tree column"
+    );
     ctrl.handle(Intent::ShrinkTree);
-    assert_eq!(ctrl.view_state().split_pct, start, "ShrinkTree narrows it back");
+    assert_eq!(
+        ctrl.view_state().split_pct,
+        start,
+        "ShrinkTree narrows it back"
+    );
 
     // Clamp at the wide end.
     for _ in 0..50 {
         ctrl.handle(Intent::GrowTree);
     }
     let max = ctrl.view_state().split_pct;
-    assert!((20..=80).contains(&max), "split stays within bounds ({max})");
+    assert!(
+        (20..=80).contains(&max),
+        "split stays within bounds ({max})"
+    );
     ctrl.handle(Intent::GrowTree);
-    assert_eq!(ctrl.view_state().split_pct, max, "cannot grow past the maximum");
+    assert_eq!(
+        ctrl.view_state().split_pct,
+        max,
+        "cannot grow past the maximum"
+    );
 
     // Clamp at the narrow end.
     for _ in 0..50 {
         ctrl.handle(Intent::ShrinkTree);
     }
     let min = ctrl.view_state().split_pct;
-    assert!((20..=80).contains(&min) && min < max, "split clamps to a minimum ({min})");
+    assert!(
+        (20..=80).contains(&min) && min < max,
+        "split clamps to a minimum ({min})"
+    );
     ctrl.handle(Intent::ShrinkTree);
-    assert_eq!(ctrl.view_state().split_pct, min, "cannot shrink past the minimum");
+    assert_eq!(
+        ctrl.view_state().split_pct,
+        min,
+        "cannot shrink past the minimum"
+    );
 }
 
 /// A sorted (path, bytes) snapshot of every file under `root`, for an exact read-only check.
 fn snapshot(root: &Path) -> Vec<(PathBuf, Vec<u8>)> {
     let mut out = Vec::new();
     fn walk(dir: &Path, out: &mut Vec<(PathBuf, Vec<u8>)>) {
-        let mut entries: Vec<_> =
-            std::fs::read_dir(dir).unwrap().filter_map(Result::ok).map(|e| e.path()).collect();
+        let mut entries: Vec<_> = std::fs::read_dir(dir)
+            .unwrap()
+            .filter_map(Result::ok)
+            .map(|e| e.path())
+            .collect();
         entries.sort();
         for p in entries {
             if p.is_dir() {
@@ -650,7 +876,12 @@ fn snapshot(root: &Path) -> Vec<(PathBuf, Vec<u8>)> {
 // ---- mouse (AC-18 is keyboard-first; mouse is additive) -------------------------------
 
 fn mouse(kind: MouseEventKind, col: u16, row: u16) -> MouseEvent {
-    MouseEvent { kind, column: col, row, modifiers: KeyModifiers::NONE }
+    MouseEvent {
+        kind,
+        column: col,
+        row,
+        modifiers: KeyModifiers::NONE,
+    }
 }
 
 /// A standard wide two-column layout: tree interior at x=1,y=1 (so visible node `i` is at row
@@ -660,8 +891,18 @@ fn wide_geometry() -> PaneGeometry {
     PaneGeometry {
         area_x: 0,
         area_width: 100,
-        tree_inner: Some(Rect { x: 1, y: 1, width: 38, height: 20 }),
-        content_inner: Some(Rect { x: 41, y: 1, width: 58, height: 20 }),
+        tree_inner: Some(Rect {
+            x: 1,
+            y: 1,
+            width: 38,
+            height: 20,
+        }),
+        content_inner: Some(Rect {
+            x: 41,
+            y: 1,
+            width: 58,
+            height: 20,
+        }),
         divider_x: Some(40),
     }
 }
@@ -677,7 +918,11 @@ fn left_click_selects_the_tree_row_it_lands_on() {
 
     // Row 3 = tree_inner.y (1) + index 2 → selects the third visible node and focuses the tree.
     let fx = ctrl.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 6, 3));
-    assert_eq!(ctrl.tree().cursor(), 2, "clicking row 3 selects visible node index 2");
+    assert_eq!(
+        ctrl.tree().cursor(),
+        2,
+        "clicking row 3 selects visible node index 2"
+    );
     assert_eq!(ctrl.focus(), Focus::Tree, "a tree click focuses the tree");
     assert!(fx.redraw);
 }
@@ -690,7 +935,11 @@ fn left_click_in_the_content_column_focuses_it() {
     ctrl.set_pane_geometry(wide_geometry());
 
     ctrl.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 50, 5));
-    assert_eq!(ctrl.focus(), Focus::Content, "clicking the content column focuses it");
+    assert_eq!(
+        ctrl.focus(),
+        Focus::Content,
+        "clicking the content column focuses it"
+    );
 }
 
 #[test]
@@ -700,7 +949,11 @@ fn double_click_a_folder_toggles_expansion() {
     std::fs::write(dir.path().join("sub/inner.txt"), "x").unwrap();
     let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
     ctrl.set_pane_geometry(wide_geometry());
-    assert_eq!(ctrl.tree().visible_nodes().len(), 1, "only the collapsed folder is visible");
+    assert_eq!(
+        ctrl.tree().visible_nodes().len(),
+        1,
+        "only the collapsed folder is visible"
+    );
 
     // Two rapid clicks on row 1 (the folder): the first selects, the second (double) expands.
     ctrl.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 6, 1));
@@ -723,7 +976,11 @@ fn a_content_click_then_a_same_row_tree_click_is_not_a_double_click() {
     std::fs::write(dir.path().join("sub/inner.txt"), "x").unwrap();
     let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
     ctrl.set_pane_geometry(wide_geometry());
-    assert_eq!(ctrl.tree().visible_nodes().len(), 1, "folder starts collapsed");
+    assert_eq!(
+        ctrl.tree().visible_nodes().len(),
+        1,
+        "folder starts collapsed"
+    );
 
     ctrl.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 50, 1)); // content pane, row 1
     ctrl.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 4, 1)); // tree folder, same row
@@ -744,7 +1001,11 @@ fn double_tap_on_the_same_row_activates_even_with_column_jitter() {
     std::fs::write(dir.path().join("sub/inner.txt"), "x").unwrap();
     let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
     ctrl.set_pane_geometry(wide_geometry());
-    assert_eq!(ctrl.tree().visible_nodes().len(), 1, "folder starts collapsed");
+    assert_eq!(
+        ctrl.tree().visible_nodes().len(),
+        1,
+        "folder starts collapsed"
+    );
 
     ctrl.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 4, 1)); // tap 1, column 4
     ctrl.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 9, 1)); // tap 2, column 9 (jitter)
@@ -766,12 +1027,25 @@ fn double_click_a_file_opens_it_in_zoom_mode_single_click_does_not() {
 
     ctrl.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 6, 1)); // single → select only
     assert!(!ctrl.zoomed(), "a single click does not zoom");
-    assert!(opened.lock().unwrap().is_empty(), "a single click does not open the editor");
+    assert!(
+        opened.lock().unwrap().is_empty(),
+        "a single click does not open the editor"
+    );
 
     ctrl.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 6, 1)); // double → zoom
-    assert!(ctrl.zoomed(), "double-clicking a file opens it in zoom mode");
-    assert_eq!(ctrl.focus(), Focus::Content, "zoom focuses the content pane");
-    assert!(opened.lock().unwrap().is_empty(), "double-clicking a file does NOT open the editor");
+    assert!(
+        ctrl.zoomed(),
+        "double-clicking a file opens it in zoom mode"
+    );
+    assert_eq!(
+        ctrl.focus(),
+        Focus::Content,
+        "zoom focuses the content pane"
+    );
+    assert!(
+        opened.lock().unwrap().is_empty(),
+        "double-clicking a file does NOT open the editor"
+    );
 }
 
 #[test]
@@ -781,12 +1055,24 @@ fn activate_a_folder_toggles_expansion() {
     std::fs::create_dir(dir.path().join("sub")).unwrap();
     std::fs::write(dir.path().join("sub/inner.txt"), "x").unwrap();
     let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
-    assert_eq!(ctrl.tree().visible_nodes().len(), 1, "folder starts collapsed");
+    assert_eq!(
+        ctrl.tree().visible_nodes().len(),
+        1,
+        "folder starts collapsed"
+    );
 
     ctrl.handle(Intent::Activate); // cursor is on the folder (only node)
-    assert_eq!(ctrl.tree().visible_nodes().len(), 2, "Enter on a folder expands it");
+    assert_eq!(
+        ctrl.tree().visible_nodes().len(),
+        2,
+        "Enter on a folder expands it"
+    );
     ctrl.handle(Intent::Activate);
-    assert_eq!(ctrl.tree().visible_nodes().len(), 1, "Enter again collapses it");
+    assert_eq!(
+        ctrl.tree().visible_nodes().len(),
+        1,
+        "Enter again collapses it"
+    );
     assert!(!ctrl.zoomed(), "activating a folder never zooms");
 }
 
@@ -801,8 +1087,15 @@ fn activate_a_file_opens_it_in_zoom_mode() {
     let fx = ctrl.handle(Intent::Activate); // cursor on the file
     assert!(fx.redraw, "activating redraws");
     assert!(ctrl.zoomed(), "Enter on a file opens it in zoom mode");
-    assert_eq!(ctrl.focus(), Focus::Content, "zoom focuses the content pane");
-    assert!(opened.lock().unwrap().is_empty(), "activating a file does NOT open the editor");
+    assert_eq!(
+        ctrl.focus(),
+        Focus::Content,
+        "zoom focuses the content pane"
+    );
+    assert!(
+        opened.lock().unwrap().is_empty(),
+        "activating a file does NOT open the editor"
+    );
 }
 
 #[test]
@@ -817,9 +1110,17 @@ fn wheel_scrolls_the_pane_under_the_cursor() {
     // Over the content column → scrolls the content by WHEEL_STEP (3) per notch.
     assert_eq!(ctrl.content_scroll(), 0);
     ctrl.handle_mouse(mouse(MouseEventKind::ScrollDown, 50, 5));
-    assert_eq!(ctrl.content_scroll(), 3, "wheel-down over content scrolls it down");
+    assert_eq!(
+        ctrl.content_scroll(),
+        3,
+        "wheel-down over content scrolls it down"
+    );
     ctrl.handle_mouse(mouse(MouseEventKind::ScrollUp, 50, 5));
-    assert_eq!(ctrl.content_scroll(), 0, "wheel-up scrolls it back to the top");
+    assert_eq!(
+        ctrl.content_scroll(),
+        0,
+        "wheel-up scrolls it back to the top"
+    );
 }
 
 #[test]
@@ -834,7 +1135,11 @@ fn wheel_over_the_tree_moves_the_selection() {
 
     // The tree does not scroll independently, so the wheel moves the selection (its equivalent).
     ctrl.handle_mouse(mouse(MouseEventKind::ScrollDown, 5, 5));
-    assert_eq!(ctrl.tree().cursor(), 1, "wheel-down over the tree moves the selection down");
+    assert_eq!(
+        ctrl.tree().cursor(),
+        1,
+        "wheel-down over the tree moves the selection down"
+    );
     ctrl.handle_mouse(mouse(MouseEventKind::ScrollUp, 5, 5));
     assert_eq!(ctrl.tree().cursor(), 0, "wheel-up moves it back up");
 }
@@ -848,12 +1153,20 @@ fn dragging_the_divider_resizes_the_split() {
     assert_eq!(ctrl.view_state().split_pct, 40, "default split");
     ctrl.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 40, 0)); // grab the divider
     ctrl.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 60, 0)); // drag right
-    assert_eq!(ctrl.view_state().split_pct, 60, "the divider tracks the cursor → 60% tree");
+    assert_eq!(
+        ctrl.view_state().split_pct,
+        60,
+        "the divider tracks the cursor → 60% tree"
+    );
 
     // Releasing ends the drag; a later move is not a resize.
     ctrl.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 60, 0));
     ctrl.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 80, 0));
-    assert_eq!(ctrl.view_state().split_pct, 60, "no drag in progress → no resize");
+    assert_eq!(
+        ctrl.view_state().split_pct,
+        60,
+        "no drag in progress → no resize"
+    );
 }
 
 #[test]
@@ -873,8 +1186,15 @@ fn shift_mouse_is_left_to_the_terminal_for_selection() {
         modifiers: KeyModifiers::SHIFT,
     };
     let fx = ctrl.handle_mouse(ev);
-    assert_eq!(ctrl.tree().cursor(), before, "Shift+click is the terminal's selection, not ours");
-    assert!(!fx.redraw && !fx.quit, "Shift+mouse is a no-op for the viewer");
+    assert_eq!(
+        ctrl.tree().cursor(),
+        before,
+        "Shift+click is the terminal's selection, not ours"
+    );
+    assert!(
+        !fx.redraw && !fx.quit,
+        "Shift+mouse is a no-op for the viewer"
+    );
 }
 
 #[test]
@@ -889,7 +1209,11 @@ fn a_click_below_the_last_row_selects_nothing() {
 
     // Row 12 maps to index 11, past the 2 visible nodes → no selection change.
     ctrl.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 6, 12));
-    assert_eq!(ctrl.tree().cursor(), before, "clicking the empty area below the tree is inert");
+    assert_eq!(
+        ctrl.tree().cursor(),
+        before,
+        "clicking the empty area below the tree is inert"
+    );
 }
 
 #[test]
@@ -901,24 +1225,45 @@ fn horizontal_wheel_scrolls_the_content_sideways() {
     let components = Components {
         git: Arc::new(StubGit::default()),
         content: Box::new(WideContent),
-        editor: Box::new(StubEditor { fail: false, opened: Arc::new(Mutex::new(Vec::new())) }),
+        editor: Box::new(StubEditor {
+            fail: false,
+            opened: Arc::new(Mutex::new(Vec::new())),
+        }),
     };
     let mut ctrl = Controller::new(dir.path().to_path_buf(), false, Baseline::Head, components);
     await_marker(&mut ctrl, "WIDE");
     ctrl.set_content_viewport(20, 10); // widest line 100, viewport 20 → max hscroll = 80
     ctrl.set_pane_geometry(wide_geometry());
-    assert!(!ctrl.view_state().wrap, "a .rs file is unwrapped, so horizontal scroll applies");
-    assert_eq!(ctrl.view_state().content_hscroll, 0, "starts at the left edge");
+    assert!(
+        !ctrl.view_state().wrap,
+        "a .rs file is unwrapped, so horizontal scroll applies"
+    );
+    assert_eq!(
+        ctrl.view_state().content_hscroll,
+        0,
+        "starts at the left edge"
+    );
 
     // Wheel right over the content column (no focus change needed — scroll what's under the cursor).
     ctrl.handle_mouse(mouse(MouseEventKind::ScrollRight, 50, 5));
-    assert!(ctrl.view_state().content_hscroll > 0, "horizontal wheel-right scrolls the content right");
+    assert!(
+        ctrl.view_state().content_hscroll > 0,
+        "horizontal wheel-right scrolls the content right"
+    );
     ctrl.handle_mouse(mouse(MouseEventKind::ScrollLeft, 50, 5));
-    assert_eq!(ctrl.view_state().content_hscroll, 0, "wheel-left scrolls back to the start");
+    assert_eq!(
+        ctrl.view_state().content_hscroll,
+        0,
+        "wheel-left scrolls back to the start"
+    );
 
     // Over the tree, horizontal wheel is inert (the tree has no horizontal scroll).
     ctrl.handle_mouse(mouse(MouseEventKind::ScrollRight, 5, 5));
-    assert_eq!(ctrl.view_state().content_hscroll, 0, "horizontal wheel over the tree does nothing");
+    assert_eq!(
+        ctrl.view_state().content_hscroll,
+        0,
+        "horizontal wheel over the tree does nothing"
+    );
 }
 
 // ---- refresh: pick up external git changes (the `r` key + focus-gain) ------------------
@@ -950,7 +1295,10 @@ fn focus_gained_re_queries_git_but_preserves_content_scroll() {
     let components = Components {
         git: Arc::new(git),
         content: Box::new(LinesContent { n: 50 }),
-        editor: Box::new(StubEditor { fail: false, opened: Arc::new(Mutex::new(Vec::new())) }),
+        editor: Box::new(StubEditor {
+            fail: false,
+            opened: Arc::new(Mutex::new(Vec::new())),
+        }),
     };
     let mut ctrl = Controller::new(dir.path().to_path_buf(), true, Baseline::Head, components);
     await_marker(&mut ctrl, "L0");
@@ -958,13 +1306,24 @@ fn focus_gained_re_queries_git_but_preserves_content_scroll() {
     ctrl.handle(Intent::ToggleFocus); // focus the content pane
     ctrl.handle(Intent::NavDown);
     ctrl.handle(Intent::NavDown);
-    assert_eq!(ctrl.view_state().content_scroll, 2, "scrolled down two lines");
+    assert_eq!(
+        ctrl.view_state().content_scroll,
+        2,
+        "scrolled down two lines"
+    );
     let before = changed_calls.lock().unwrap().len();
 
     let fx = ctrl.handle_focus_gained();
     assert!(fx.redraw, "focus-gain redraws (fresh tree colours)");
-    assert!(changed_calls.lock().unwrap().len() > before, "focus-gain re-queries git");
-    assert_eq!(ctrl.view_state().content_scroll, 2, "focus-gain does NOT reset the content scroll");
+    assert!(
+        changed_calls.lock().unwrap().len() > before,
+        "focus-gain re-queries git"
+    );
+    assert_eq!(
+        ctrl.view_state().content_scroll,
+        2,
+        "focus-gain does NOT reset the content scroll"
+    );
 }
 
 #[test]
@@ -992,7 +1351,11 @@ impl GitService for EvolvingGit {
     fn changed_set(&self, _baseline: Baseline) -> BTreeMap<PathBuf, Status> {
         let mut n = self.calls.lock().unwrap();
         *n += 1;
-        if *n <= 1 { self.first.clone() } else { self.rest.clone() }
+        if *n <= 1 {
+            self.first.clone()
+        } else {
+            self.rest.clone()
+        }
     }
     fn diff(&self, _p: &Path, _b: Baseline, _full: bool) -> String {
         String::new()
@@ -1004,7 +1367,10 @@ impl GitService for EvolvingGit {
 struct PathContent;
 impl ContentProvider for PathContent {
     fn render(&self, path: &Path, _m: ViewMode, _d: Option<&str>) -> RenderResult {
-        RenderResult { content: Text::raw(format!("showing {}", path.display())), notices: Vec::new() }
+        RenderResult {
+            content: Text::raw(format!("showing {}", path.display())),
+            notices: Vec::new(),
+        }
     }
 }
 
@@ -1028,17 +1394,30 @@ fn focus_gained_keeps_tree_and_content_in_sync_after_a_changed_only_refilter() {
     let components = Components {
         git: Arc::new(git),
         content: Box::new(PathContent),
-        editor: Box::new(StubEditor { fail: false, opened: Arc::new(Mutex::new(Vec::new())) }),
+        editor: Box::new(StubEditor {
+            fail: false,
+            opened: Arc::new(Mutex::new(Vec::new())),
+        }),
     };
     let mut ctrl = Controller::new(dir.path().to_path_buf(), true, Baseline::Head, components);
     ctrl.handle(Intent::ToggleChangedOnly); // changed-only: only a.rs visible → it's selected
     await_marker(&mut ctrl, "a.rs");
-    assert_eq!(ctrl.tree().selected().unwrap().path.file_name().unwrap(), "a.rs");
+    assert_eq!(
+        ctrl.tree().selected().unwrap().path.file_name().unwrap(),
+        "a.rs"
+    );
 
     // Focus-gain: the changed-set is now {b.rs}, so a.rs filters out and the cursor moves to
     // b.rs. The render is async — await it; pre-fix the content stayed on a.rs and this times out.
     ctrl.handle_focus_gained();
     await_marker(&mut ctrl, "b.rs");
-    assert_eq!(ctrl.tree().selected().unwrap().path.file_name().unwrap(), "b.rs", "cursor moved to b.rs");
-    assert!(flatten(ctrl.content()).contains("b.rs"), "content pane shows the selected file — in sync");
+    assert_eq!(
+        ctrl.tree().selected().unwrap().path.file_name().unwrap(),
+        "b.rs",
+        "cursor moved to b.rs"
+    );
+    assert!(
+        flatten(ctrl.content()).contains("b.rs"),
+        "content pane shows the selected file — in sync"
+    );
 }

--- a/tests/controller_async.rs
+++ b/tests/controller_async.rs
@@ -27,7 +27,10 @@ impl ContentProvider for SlowContent {
     fn render(&self, path: &Path, _mode: ViewMode, _raw_diff: Option<&str>) -> RenderResult {
         std::thread::sleep(self.delay);
         let name = path.file_name().unwrap().to_string_lossy().into_owned();
-        RenderResult { content: Text::raw(format!("rendered:{name}")), notices: Vec::new() }
+        RenderResult {
+            content: Text::raw(format!("rendered:{name}")),
+            notices: Vec::new(),
+        }
     }
 }
 
@@ -67,7 +70,11 @@ impl GitService for RecordingGit {
     }
     fn diff(&self, _: &Path, _: Baseline, full_context: bool) -> String {
         self.diff_full_calls.lock().unwrap().push(full_context);
-        if full_context { "FULL".into() } else { "COMPACT".into() }
+        if full_context {
+            "FULL".into()
+        } else {
+            "COMPACT".into()
+        }
     }
 }
 
@@ -75,7 +82,12 @@ impl GitService for RecordingGit {
 fn flatten(text: &Text) -> String {
     text.lines
         .iter()
-        .map(|l| l.spans.iter().map(|s| s.content.as_ref()).collect::<String>())
+        .map(|l| {
+            l.spans
+                .iter()
+                .map(|s| s.content.as_ref())
+                .collect::<String>()
+        })
         .collect::<Vec<_>>()
         .join("\n")
 }
@@ -92,14 +104,16 @@ fn a_select_intent_does_not_block_on_a_slow_render_and_content_arrives_later() {
         content: Box::new(SlowContent { delay }),
         editor: Box::new(NoEditor),
     };
-    let mut ctrl =
-        Controller::new(dir.path().to_path_buf(), false, Baseline::Head, components);
+    let mut ctrl = Controller::new(dir.path().to_path_buf(), false, Baseline::Head, components);
 
     // A select intent must return far faster than the render takes — it only dispatches.
     let start = Instant::now();
     let fx = ctrl.handle(Intent::NavDown);
     let handle_took = start.elapsed();
-    assert!(fx.redraw, "the select still asks for a redraw (stale content shown meanwhile)");
+    assert!(
+        fx.redraw,
+        "the select still asks for a redraw (stale content shown meanwhile)"
+    );
     // Non-blocking proof: had handle() waited for the render it would take at least `delay`
     // (the worker's sleep). The dispatch is an in-process channel send (sub-millisecond), so
     // a comfortable margin below `delay` is a robust, non-flaky bound.
@@ -127,7 +141,11 @@ fn a_select_intent_does_not_block_on_a_slow_render_and_content_arrives_later() {
         std::thread::sleep(Duration::from_millis(5));
     }
     assert!(redrew, "the arriving content signalled a redraw via poll()");
-    assert_eq!(flatten(ctrl.content()), "rendered:b.rs", "the selected file rendered");
+    assert_eq!(
+        flatten(ctrl.content()),
+        "rendered:b.rs",
+        "the selected file rendered"
+    );
 }
 
 #[test]
@@ -140,8 +158,13 @@ fn full_diff_mode_asks_git_for_whole_file_context() {
     changed.insert(PathBuf::from("c.rs"), Status::Modified);
     let calls = Arc::new(Mutex::new(Vec::new()));
     let components = Components {
-        git: Arc::new(RecordingGit { changed, diff_full_calls: calls.clone() }),
-        content: Box::new(SlowContent { delay: Duration::from_millis(0) }),
+        git: Arc::new(RecordingGit {
+            changed,
+            diff_full_calls: calls.clone(),
+        }),
+        content: Box::new(SlowContent {
+            delay: Duration::from_millis(0),
+        }),
         editor: Box::new(NoEditor),
     };
     let mut ctrl = Controller::new(dir.path().to_path_buf(), true, Baseline::Head, components);
@@ -156,7 +179,10 @@ fn full_diff_mode_asks_git_for_whole_file_context() {
         if calls.lock().unwrap().iter().any(|&full| full) {
             break;
         }
-        assert!(Instant::now() < deadline, "the worker never requested a full-context diff");
+        assert!(
+            Instant::now() < deadline,
+            "the worker never requested a full-context diff"
+        );
         std::thread::sleep(Duration::from_millis(5));
     }
     assert!(
@@ -176,11 +202,12 @@ fn a_superseded_render_does_not_overwrite_a_newer_selection() {
 
     let components = Components {
         git: Arc::new(NoGit),
-        content: Box::new(SlowContent { delay: Duration::from_millis(80) }),
+        content: Box::new(SlowContent {
+            delay: Duration::from_millis(80),
+        }),
         editor: Box::new(NoEditor),
     };
-    let mut ctrl =
-        Controller::new(dir.path().to_path_buf(), false, Baseline::Head, components);
+    let mut ctrl = Controller::new(dir.path().to_path_buf(), false, Baseline::Head, components);
 
     // Fire several selections back-to-back; only the last (c.rs) should win.
     ctrl.handle(Intent::NavDown); // b.rs

--- a/tests/e2e_editor.rs
+++ b/tests/e2e_editor.rs
@@ -11,7 +11,7 @@
 
 mod common;
 
-use common::{viewer_command, TempDir};
+use common::{TempDir, viewer_command};
 use expectrl::process::unix::WaitStatus;
 use expectrl::{Eof, Expect, Session};
 use std::os::unix::fs::PermissionsExt;
@@ -49,19 +49,30 @@ fn open_in_editor_invokes_the_editor_on_the_selected_file_without_modifying_it()
         if contents.ends_with("edit.txt") {
             break contents;
         }
-        assert!(Instant::now() < deadline, "editor was never invoked on the selected file");
+        assert!(
+            Instant::now() < deadline,
+            "editor was never invoked on the selected file"
+        );
         std::thread::sleep(Duration::from_millis(25));
     };
-    assert!(recorded.ends_with("edit.txt"), "editor invoked on the selected file: {recorded:?}");
+    assert!(
+        recorded.ends_with("edit.txt"),
+        "editor invoked on the selected file: {recorded:?}"
+    );
 
     // AC-N1: the hand-off must not have modified the file.
-    assert_eq!(std::fs::read_to_string(p.join("edit.txt")).unwrap(), "EDITME\n", "file unchanged");
+    assert_eq!(
+        std::fs::read_to_string(p.join("edit.txt")).unwrap(),
+        "EDITME\n",
+        "file unchanged"
+    );
 
     // The recorder is written before the editor exits, and the viewer re-enables raw mode
     // only after it returns; give that a moment so the close key is read in raw mode.
     std::thread::sleep(Duration::from_millis(150));
     s.send("q").expect("send close");
-    s.expect(Eof).expect("the viewer terminates after the close key");
+    s.expect(Eof)
+        .expect("the viewer terminates after the close key");
     match s.get_process().wait().expect("reap the viewer") {
         // exit==0 also guards the best-effort post-editor clear (see the module doc).
         WaitStatus::Exited(_, code) => assert_eq!(code, 0, "clean exit after editor hand-off"),
@@ -83,11 +94,17 @@ fn a_missing_editor_is_a_non_fatal_notice_not_a_crash() {
     s.set_expect_timeout(Some(Duration::from_secs(15)));
 
     s.expect("edit.txt").expect("tree should list the file");
-    s.send("e").expect("send open-in-editor with no editor configured");
+    s.send("e")
+        .expect("send open-in-editor with no editor configured");
     // The file must still be intact, and the viewer must still close cleanly.
     s.send("q").expect("send close");
-    s.expect(Eof).expect("viewer terminates after a failed hand-off + close");
-    assert_eq!(std::fs::read_to_string(p.join("edit.txt")).unwrap(), "EDITME\n", "file unchanged");
+    s.expect(Eof)
+        .expect("viewer terminates after a failed hand-off + close");
+    assert_eq!(
+        std::fs::read_to_string(p.join("edit.txt")).unwrap(),
+        "EDITME\n",
+        "file unchanged"
+    );
     match s.get_process().wait().expect("reap the viewer") {
         WaitStatus::Exited(_, code) => assert_eq!(code, 0, "a missing editor does not crash"),
         other => panic!("expected a clean exit, got {other:?}"),

--- a/tests/e2e_keyboard.rs
+++ b/tests/e2e_keyboard.rs
@@ -16,7 +16,7 @@
 
 mod common;
 
-use common::{git, init_repo_with_commit, viewer_command, TempDir};
+use common::{TempDir, git, init_repo_with_commit, viewer_command};
 use expectrl::process::unix::WaitStatus;
 use expectrl::{Eof, Expect, Session};
 use std::time::Duration;
@@ -43,13 +43,15 @@ fn every_keyboard_function_drives_the_viewer_and_it_exits_cleanly() {
     s.set_expect_timeout(Some(Duration::from_secs(15)));
 
     // Initial full draw lists the tree (AC-3 display, AC-17 launch).
-    s.expect("aaa.txt").expect("tree should list files on launch");
+    s.expect("aaa.txt")
+        .expect("tree should list files on launch");
 
     // Expand the selected directory, then navigate onto the revealed child: its content fills
     // the empty pane — proving expand (l) AND navigation (j) AND content render functionally.
     s.send("l").expect("send expand");
     s.send("j").expect("send nav-down onto the revealed child");
-    s.expect("GRANDCHILD").expect("expand revealed the child and navigation rendered it");
+    s.expect("GRANDCHILD")
+        .expect("expand revealed the child and navigation rendered it");
 
     // Back up onto the directory and collapse it (h acts on the selected directory).
     s.send("k").expect("send nav-up to the directory");
@@ -71,10 +73,14 @@ fn every_keyboard_function_drives_the_viewer_and_it_exits_cleanly() {
 
     // The close key returns control and exits cleanly (AC-20).
     s.send("q").expect("send close");
-    s.expect(Eof).expect("the viewer terminates after the close key");
+    s.expect(Eof)
+        .expect("the viewer terminates after the close key");
     match s.get_process().wait().expect("reap the viewer") {
         WaitStatus::Exited(_, code) => {
-            assert_eq!(code, 0, "AC-18/AC-20: no keyboard action crashed the viewer")
+            assert_eq!(
+                code, 0,
+                "AC-18/AC-20: no keyboard action crashed the viewer"
+            )
         }
         other => panic!("expected a clean exit, got {other:?}"),
     }

--- a/tests/e2e_nongit.rs
+++ b/tests/e2e_nongit.rs
@@ -4,7 +4,7 @@
 
 mod common;
 
-use common::{viewer_command, TempDir};
+use common::{TempDir, viewer_command};
 use expectrl::process::unix::WaitStatus;
 use expectrl::{Eof, Expect, Session};
 use std::time::Duration;
@@ -21,9 +21,11 @@ fn non_git_directory_browses_and_renders_with_git_keys_inert() {
     s.set_expect_timeout(Some(Duration::from_secs(15)));
 
     // Tree browsing works without git (AC-2 / AC-26).
-    s.expect("notes.txt").expect("tree should list files in a non-git directory");
+    s.expect("notes.txt")
+        .expect("tree should list files in a non-git directory");
     // A file renders (content pane fills from empty with the selected file).
-    s.expect("PLAINVIEW").expect("a file renders in a non-git directory");
+    s.expect("PLAINVIEW")
+        .expect("a file renders in a non-git directory");
 
     // The git-only keys must be inert here — no panic, no error. Driving them then exiting
     // cleanly proves they degrade gracefully (AC-26).
@@ -32,10 +34,14 @@ fn non_git_directory_browses_and_renders_with_git_keys_inert() {
     }
 
     s.send("q").expect("send close");
-    s.expect(Eof).expect("the viewer terminates after the close key");
+    s.expect(Eof)
+        .expect("the viewer terminates after the close key");
     match s.get_process().wait().expect("reap the viewer") {
         WaitStatus::Exited(_, code) => {
-            assert_eq!(code, 0, "AC-26: git keys are inert in a non-git dir, no crash")
+            assert_eq!(
+                code, 0,
+                "AC-26: git keys are inert in a non-git dir, no crash"
+            )
         }
         other => panic!("expected a clean exit, got {other:?}"),
     }

--- a/tests/editor.rs
+++ b/tests/editor.rs
@@ -46,8 +46,14 @@ fn editor_target_spawns_configured_editor_with_the_selected_file() {
     launcher.open(&file, Target::Editor, &mut sp).unwrap();
 
     // AC-19: the configured editor is launched on exactly the selected file.
-    assert_eq!(sp.spawned, vec![vec![OsString::from("vim"), file.clone().into_os_string()]]);
-    assert!(sp.panes.is_empty(), "the editor path must not open a herdr pane");
+    assert_eq!(
+        sp.spawned,
+        vec![vec![OsString::from("vim"), file.clone().into_os_string()]]
+    );
+    assert!(
+        sp.panes.is_empty(),
+        "the editor path must not open a herdr pane"
+    );
     // AC-N1: the hand-off never writes the file.
     assert_eq!(fs::read_to_string(&file).unwrap(), "content");
 }
@@ -86,7 +92,10 @@ fn new_pane_target_requests_a_herdr_pane_carrying_the_file() {
 
     // AC-19: a new-pane request carries the exact file (and the editor to run there).
     assert_eq!(sp.panes, vec![(OsString::from("nano"), file.clone())]);
-    assert!(sp.spawned.is_empty(), "the new-pane path must not spawn a local editor");
+    assert!(
+        sp.spawned.is_empty(),
+        "the new-pane path must not spawn a local editor"
+    );
     // AC-N1: still no write.
     assert_eq!(fs::read_to_string(&file).unwrap(), "fn main() {}");
 }
@@ -100,7 +109,10 @@ fn launch_failure_is_an_error_not_a_panic_and_leaves_the_file_intact() {
     fs::write(&file, "x").unwrap();
 
     let launcher = EditorLauncher::new("editor");
-    let mut sp = FakeSpawner { fail: true, ..Default::default() };
+    let mut sp = FakeSpawner {
+        fail: true,
+        ..Default::default()
+    };
     assert!(launcher.open(&file, Target::Editor, &mut sp).is_err());
     assert_eq!(fs::read_to_string(&file).unwrap(), "x");
 }

--- a/tests/git_baseline.rs
+++ b/tests/git_baseline.rs
@@ -3,8 +3,8 @@
 
 mod common;
 
-use common::{git, TempDir};
-use herdr_file_viewer::git::{changed_set, default_baseline, diff, status, Baseline, Status};
+use common::{TempDir, git};
+use herdr_file_viewer::git::{Baseline, Status, changed_set, default_baseline, diff, status};
 use herdr_file_viewer::root::Resolved;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -78,13 +78,34 @@ fn diff_returns_unified_text_and_varies_with_baseline() {
     git(repo.path(), &["add", "."]);
     git(repo.path(), &["commit", "-q", "-m", "extend seed"]);
 
-    let base_diff = diff(repo.path(), Path::new("seed.txt"), Baseline::Base, None, false);
-    assert!(base_diff.contains("@@"), "base diff is a unified diff (AC-9)");
-    assert!(base_diff.contains("+2"), "base diff shows the committed addition");
+    let base_diff = diff(
+        repo.path(),
+        Path::new("seed.txt"),
+        Baseline::Base,
+        None,
+        false,
+    );
+    assert!(
+        base_diff.contains("@@"),
+        "base diff is a unified diff (AC-9)"
+    );
+    assert!(
+        base_diff.contains("+2"),
+        "base diff shows the committed addition"
+    );
 
     // No uncommitted change → empty HEAD diff; the two baselines differ (AC-16).
-    let head_diff = diff(repo.path(), Path::new("seed.txt"), Baseline::Head, None, false);
-    assert!(!head_diff.contains("@@"), "HEAD diff is empty (no uncommitted change)");
+    let head_diff = diff(
+        repo.path(),
+        Path::new("seed.txt"),
+        Baseline::Head,
+        None,
+        false,
+    );
+    assert!(
+        !head_diff.contains("@@"),
+        "HEAD diff is empty (no uncommitted change)"
+    );
     assert_ne!(base_diff, head_diff);
 }
 
@@ -99,7 +120,9 @@ fn full_context_diff_includes_whole_file_context_the_compact_diff_omits() {
         lines.push(format!("body{n}"));
     }
     lines.push("BOTTOM_MARKER".into());
-    let write = |ls: &[String]| fs::write(repo.path().join("big.txt"), format!("{}\n", ls.join("\n"))).unwrap();
+    let write = |ls: &[String]| {
+        fs::write(repo.path().join("big.txt"), format!("{}\n", ls.join("\n"))).unwrap()
+    };
     write(&lines);
     git(repo.path(), &["add", "."]);
     git(repo.path(), &["commit", "-q", "-m", "add big"]);
@@ -107,10 +130,25 @@ fn full_context_diff_includes_whole_file_context_the_compact_diff_omits() {
     lines[10] = "CHANGED".into();
     write(&lines);
 
-    let compact = diff(repo.path(), Path::new("big.txt"), Baseline::Head, None, false);
-    let full = diff(repo.path(), Path::new("big.txt"), Baseline::Head, None, true);
+    let compact = diff(
+        repo.path(),
+        Path::new("big.txt"),
+        Baseline::Head,
+        None,
+        false,
+    );
+    let full = diff(
+        repo.path(),
+        Path::new("big.txt"),
+        Baseline::Head,
+        None,
+        true,
+    );
 
-    assert!(compact.contains("CHANGED") && full.contains("CHANGED"), "both show the change");
+    assert!(
+        compact.contains("CHANGED") && full.contains("CHANGED"),
+        "both show the change"
+    );
     assert!(
         !compact.contains("TOP_MARKER") && !compact.contains("BOTTOM_MARKER"),
         "the compact (3-line) hunk omits distant context:\n{compact}"
@@ -144,7 +182,16 @@ fn base_branch_hint_drives_base_queries_for_non_main_master_repos() {
     // With the hint, committed feature work is in the base set...
     let hinted = changed_set(repo.path(), Baseline::Base, Some("trunk"));
     assert!(hinted.contains_key(&PathBuf::from("feat.txt")));
-    assert!(diff(repo.path(), Path::new("feat.txt"), Baseline::Base, Some("trunk"), false).contains("@@"));
+    assert!(
+        diff(
+            repo.path(),
+            Path::new("feat.txt"),
+            Baseline::Base,
+            Some("trunk"),
+            false
+        )
+        .contains("@@")
+    );
 
     // ...without it (and with no main/master fallback), the Base query degrades to a
     // HEAD comparison, where the committed file is clean — proving the hint is honored.
@@ -158,8 +205,17 @@ fn untracked_file_diff_shows_added_content() {
     let repo = make_repo();
     fs::write(repo.path().join("brand_new.txt"), "hello\nworld\n").unwrap();
 
-    let d = diff(repo.path(), Path::new("brand_new.txt"), Baseline::Head, None, false);
-    assert!(d.contains("+hello"), "untracked file diff shows its content as added");
+    let d = diff(
+        repo.path(),
+        Path::new("brand_new.txt"),
+        Baseline::Head,
+        None,
+        false,
+    );
+    assert!(
+        d.contains("+hello"),
+        "untracked file diff shows its content as added"
+    );
     assert!(d.contains("+world"));
 }
 
@@ -180,7 +236,10 @@ fn remote_tracking_base_branch_is_used_when_no_local_base_exists() {
     fs::write(repo.path().join("feat.txt"), "x\n").unwrap();
     git(repo.path(), &["add", "."]);
     git(repo.path(), &["commit", "-q", "-m", "feature"]);
-    git(repo.path(), &["update-ref", "refs/remotes/origin/main", &main_sha]);
+    git(
+        repo.path(),
+        &["update-ref", "refs/remotes/origin/main", &main_sha],
+    );
     git(repo.path(), &["branch", "-D", "main"]); // base now only remote-tracking
 
     assert_eq!(default_baseline(&resolved(repo.path())), Baseline::Base); // AC-14
@@ -208,7 +267,17 @@ fn detached_worktree_defaults_to_base() {
     // the base (AC-14), even though there is no current branch name.
     let main = make_repo(); // on "main"
     let wt = main.path().join("wt");
-    git(main.path(), &["worktree", "add", "-q", wt.to_str().unwrap(), "-b", "feature"]);
+    git(
+        main.path(),
+        &[
+            "worktree",
+            "add",
+            "-q",
+            wt.to_str().unwrap(),
+            "-b",
+            "feature",
+        ],
+    );
     git(&wt, &["checkout", "-q", "--detach"]); // detached HEAD inside the worktree
 
     let mut r = resolved(&wt);
@@ -230,7 +299,13 @@ fn non_ascii_filename_round_trips_through_status_and_diff() {
         set.get(&PathBuf::from("résumé.txt")),
         Some(&Status::Modified)
     );
-    let d = diff(repo.path(), Path::new("résumé.txt"), Baseline::Head, None, false);
+    let d = diff(
+        repo.path(),
+        Path::new("résumé.txt"),
+        Baseline::Head,
+        None,
+        false,
+    );
     assert!(d.contains("+noël"), "diff of a non-ASCII path is not empty");
 }
 
@@ -244,16 +319,43 @@ fn staged_file_in_unborn_repo_diffs_as_added() {
     fs::write(repo.path().join("first.txt"), "hello\n").unwrap();
     git(repo.path(), &["add", "first.txt"]);
 
-    let d = diff(repo.path(), Path::new("first.txt"), Baseline::Head, None, false);
-    assert!(d.contains("+hello"), "unborn-repo staged file shows an added diff (AC-9)");
+    let d = diff(
+        repo.path(),
+        Path::new("first.txt"),
+        Baseline::Head,
+        None,
+        false,
+    );
+    assert!(
+        d.contains("+hello"),
+        "unborn-repo staged file shows an added diff (AC-9)"
+    );
 }
 
 #[test]
 fn diff_refuses_paths_outside_the_root() {
     // No arbitrary file reads; the viewer never resolves above its root (AC-N5).
     let repo = make_repo();
-    assert!(diff(repo.path(), Path::new("/etc/hostname"), Baseline::Head, None, false).is_empty());
-    assert!(diff(repo.path(), Path::new("../../etc/hostname"), Baseline::Head, None, false).is_empty());
+    assert!(
+        diff(
+            repo.path(),
+            Path::new("/etc/hostname"),
+            Baseline::Head,
+            None,
+            false
+        )
+        .is_empty()
+    );
+    assert!(
+        diff(
+            repo.path(),
+            Path::new("../../etc/hostname"),
+            Baseline::Head,
+            None,
+            false
+        )
+        .is_empty()
+    );
 }
 
 #[test]
@@ -263,7 +365,11 @@ fn malicious_repo_config_is_not_executed_during_queries() {
     let repo = make_repo();
     let marker = repo.path().join("PWNED");
     let script = repo.path().join("payload.sh");
-    fs::write(&script, format!("#!/bin/sh\ntouch '{}'\n", marker.display())).unwrap();
+    fs::write(
+        &script,
+        format!("#!/bin/sh\ntouch '{}'\n", marker.display()),
+    )
+    .unwrap();
     {
         use std::os::unix::fs::PermissionsExt;
         fs::set_permissions(&script, fs::Permissions::from_mode(0o755)).unwrap();
@@ -271,7 +377,11 @@ fn malicious_repo_config_is_not_executed_during_queries() {
     let s = script.to_str().unwrap();
     git(repo.path(), &["config", "core.fsmonitor", s]);
     // Cover every attribute/config-driven exec vector: textconv, ext-diff, clean/smudge.
-    fs::write(repo.path().join(".gitattributes"), "* diff=pwn filter=pwn\n").unwrap();
+    fs::write(
+        repo.path().join(".gitattributes"),
+        "* diff=pwn filter=pwn\n",
+    )
+    .unwrap();
     git(repo.path(), &["config", "diff.pwn.textconv", s]);
     git(repo.path(), &["config", "filter.pwn.clean", s]);
     git(repo.path(), &["config", "filter.pwn.smudge", s]);
@@ -279,7 +389,13 @@ fn malicious_repo_config_is_not_executed_during_queries() {
 
     let _ = status(repo.path());
     let _ = changed_set(repo.path(), Baseline::Head, None);
-    let _ = diff(repo.path(), Path::new("seed.txt"), Baseline::Head, None, false);
+    let _ = diff(
+        repo.path(),
+        Path::new("seed.txt"),
+        Baseline::Head,
+        None,
+        false,
+    );
 
     assert!(
         !marker.exists(),
@@ -295,8 +411,17 @@ fn diff_refuses_symlink_escaping_the_root() {
     fs::write(outside.path().join("secret.txt"), "TOPSECRET\n").unwrap();
     std::os::unix::fs::symlink(outside.path(), repo.path().join("escape")).unwrap();
 
-    let d = diff(repo.path(), Path::new("escape/secret.txt"), Baseline::Head, None, false);
-    assert!(d.is_empty(), "must not read files via a symlink escaping the root (AC-N5)");
+    let d = diff(
+        repo.path(),
+        Path::new("escape/secret.txt"),
+        Baseline::Head,
+        None,
+        false,
+    );
+    assert!(
+        d.is_empty(),
+        "must not read files via a symlink escaping the root (AC-N5)"
+    );
     assert!(!d.contains("TOPSECRET"));
 }
 
@@ -315,9 +440,29 @@ fn baseline_queries_do_not_mutate_the_repo() {
     let _ = default_baseline(&resolved(repo.path()));
     let _ = changed_set(repo.path(), Baseline::Base, None);
     let _ = changed_set(repo.path(), Baseline::Head, None);
-    let _ = diff(repo.path(), Path::new("seed.txt"), Baseline::Base, None, false);
-    let _ = diff(repo.path(), Path::new("feat.txt"), Baseline::Head, None, false);
+    let _ = diff(
+        repo.path(),
+        Path::new("seed.txt"),
+        Baseline::Base,
+        None,
+        false,
+    );
+    let _ = diff(
+        repo.path(),
+        Path::new("feat.txt"),
+        Baseline::Head,
+        None,
+        false,
+    );
 
-    assert_eq!(before, git(repo.path(), &["status", "--porcelain"]), "AC-N2");
-    assert_eq!(head_before, git(repo.path(), &["rev-parse", "HEAD"]), "AC-N2");
+    assert_eq!(
+        before,
+        git(repo.path(), &["status", "--porcelain"]),
+        "AC-N2"
+    );
+    assert_eq!(
+        head_before,
+        git(repo.path(), &["rev-parse", "HEAD"]),
+        "AC-N2"
+    );
 }

--- a/tests/git_status.rs
+++ b/tests/git_status.rs
@@ -2,8 +2,8 @@
 
 mod common;
 
-use common::{git, init_repo_with_commit, TempDir};
-use herdr_file_viewer::git::{status, Status};
+use common::{TempDir, git, init_repo_with_commit};
+use herdr_file_viewer::git::{Status, status};
 use std::fs;
 use std::path::PathBuf;
 
@@ -51,8 +51,14 @@ fn status_does_not_mutate_the_repo() {
 
     let after = git(repo.path(), &["status", "--porcelain"]);
     let head_after = git(repo.path(), &["rev-parse", "HEAD"]);
-    assert_eq!(before, after, "AC-N2: working state unchanged after status()");
-    assert_eq!(head_before, head_after, "AC-N2: HEAD unchanged after status()");
+    assert_eq!(
+        before, after,
+        "AC-N2: working state unchanged after status()"
+    );
+    assert_eq!(
+        head_before, head_after,
+        "AC-N2: HEAD unchanged after status()"
+    );
 }
 
 #[test]
@@ -82,6 +88,6 @@ fn untracked_directory_is_listed_per_file_not_collapsed() {
         Some(&Status::Untracked)
     );
     // The collapsed directory form must NOT be present.
-    assert!(map.get(&PathBuf::from("newdir")).is_none());
-    assert!(map.get(&PathBuf::from("newdir/")).is_none());
+    assert!(!map.contains_key(&PathBuf::from("newdir")));
+    assert!(!map.contains_key(&PathBuf::from("newdir/")));
 }

--- a/tests/host_context.rs
+++ b/tests/host_context.rs
@@ -2,7 +2,7 @@
 //! The herdr CLI is injected and records calls; nothing real is launched.
 
 use herdr_file_viewer::host::{HerdrCli, current_pane_id, from_env, open_pane, parse_context};
-use std::ffi::{OsString, OsStr};
+use std::ffi::{OsStr, OsString};
 use std::io;
 use std::path::PathBuf;
 
@@ -14,7 +14,10 @@ struct FakeCli {
 
 impl FakeCli {
     fn new(split_response: &str) -> Self {
-        Self { calls: Vec::new(), split_response: split_response.to_string() }
+        Self {
+            calls: Vec::new(),
+            split_response: split_response.to_string(),
+        }
     }
 }
 
@@ -107,7 +110,10 @@ fn from_env_without_context_is_cwd_only() {
 
 #[test]
 fn current_pane_id_read_from_context() {
-    assert_eq!(current_pane_id(Some(r#"{"pane_id":"p9"}"#)), Some("p9".to_string()));
+    assert_eq!(
+        current_pane_id(Some(r#"{"pane_id":"p9"}"#)),
+        Some("p9".to_string())
+    );
     assert_eq!(current_pane_id(Some("garbage")), None);
     assert_eq!(current_pane_id(None), None);
 }
@@ -117,15 +123,35 @@ fn current_pane_id_read_from_context() {
 #[test]
 fn open_pane_splits_then_runs_editor_in_the_new_pane() {
     let mut cli = FakeCli::new(r#"{"result":{"pane":{"pane_id":"pane-77"}}}"#);
-    open_pane(&PathBuf::from("/work/src/main.rs"), OsStr::new("vim"), "pane-12", &mut cli).unwrap();
+    open_pane(
+        &PathBuf::from("/work/src/main.rs"),
+        OsStr::new("vim"),
+        "pane-12",
+        &mut cli,
+    )
+    .unwrap();
 
-    assert_eq!(cli.calls.len(), 2, "exactly two herdr CLI calls (split, run)");
+    assert_eq!(
+        cli.calls.len(),
+        2,
+        "exactly two herdr CLI calls (split, run)"
+    );
     assert_eq!(
         cli.calls[0],
-        osv(&["pane", "split", "pane-12", "--direction", "right", "--no-focus"]),
+        osv(&[
+            "pane",
+            "split",
+            "pane-12",
+            "--direction",
+            "right",
+            "--no-focus"
+        ]),
     );
     // The new pane id is parsed from the split's result.pane.pane_id and used for run.
-    assert_eq!(cli.calls[1], osv(&["pane", "run", "pane-77", "vim '/work/src/main.rs'"]));
+    assert_eq!(
+        cli.calls[1],
+        osv(&["pane", "run", "pane-77", "vim '/work/src/main.rs'"])
+    );
 }
 
 #[test]
@@ -173,7 +199,15 @@ fn flag_like_pane_id_from_split_is_rejected() {
 #[test]
 fn flag_like_current_pane_id_is_rejected_before_any_call() {
     let mut cli = FakeCli::new("{}");
-    let r = open_pane(&PathBuf::from("/w/f"), OsStr::new("vim"), "--evil", &mut cli);
+    let r = open_pane(
+        &PathBuf::from("/w/f"),
+        OsStr::new("vim"),
+        "--evil",
+        &mut cli,
+    );
     assert!(r.is_err());
-    assert!(cli.calls.is_empty(), "no split with an unsafe current pane id");
+    assert!(
+        cli.calls.is_empty(),
+        "no split with an unsafe current pane id"
+    );
 }

--- a/tests/manifest.rs
+++ b/tests/manifest.rs
@@ -31,7 +31,10 @@ fn manifest() -> String {
 #[test]
 fn declares_split_pane_launching_the_release_binary() {
     let m = manifest();
-    assert!(m.contains("[[panes]]"), "manifest must declare a [[panes]] entry");
+    assert!(
+        m.contains("[[panes]]"),
+        "manifest must declare a [[panes]] entry"
+    );
     assert!(
         m.contains(r#"placement = "split""#),
         "AC-17: the pane must declare placement = \"split\""
@@ -55,10 +58,22 @@ fn declares_split_and_tab_open_actions() {
     // The viewer can be summoned as a split pane or in its own tab; each action runs its
     // dedicated launcher script.
     let m = manifest();
-    assert!(m.contains(r#"id = "open-file-viewer""#), "split-pane action present");
-    assert!(m.contains(r#"id = "open-file-viewer-tab""#), "tab action present");
-    assert!(m.contains("scripts/open-file-viewer.sh"), "split action runs its launcher");
-    assert!(m.contains("scripts/open-file-viewer-tab.sh"), "tab action runs its launcher");
+    assert!(
+        m.contains(r#"id = "open-file-viewer""#),
+        "split-pane action present"
+    );
+    assert!(
+        m.contains(r#"id = "open-file-viewer-tab""#),
+        "tab action present"
+    );
+    assert!(
+        m.contains("scripts/open-file-viewer.sh"),
+        "split action runs its launcher"
+    );
+    assert!(
+        m.contains("scripts/open-file-viewer-tab.sh"),
+        "tab action runs its launcher"
+    );
 }
 
 #[test]
@@ -72,7 +87,10 @@ fn pins_minimum_herdr_version() {
 #[test]
 fn declares_a_release_build_command() {
     let m = manifest();
-    assert!(m.contains("[[build]]"), "manifest must declare a [[build]] step");
+    assert!(
+        m.contains("[[build]]"),
+        "manifest must declare a [[build]] step"
+    );
     assert!(
         m.contains(r#"command = ["cargo", "build", "--release"]"#),
         "the build step must run `cargo build --release`"

--- a/tests/presenter.rs
+++ b/tests/presenter.rs
@@ -10,19 +10,50 @@ use ratatui::backend::TestBackend;
 use std::path::PathBuf;
 
 fn node(path: &str, kind: NodeKind, depth: usize, expanded: bool, status: Option<Status>) -> Node {
-    Node { path: PathBuf::from(path), kind, depth, expanded, status, dir_dirty: false }
+    Node {
+        path: PathBuf::from(path),
+        kind,
+        depth,
+        expanded,
+        status,
+        dir_dirty: false,
+    }
 }
 
 /// A known tree+content+notices state, wide enough for the two-column layout.
 fn sample_state() -> ViewState {
     let nodes = vec![
         node("/r/src", NodeKind::Dir, 0, true, None),
-        node("/r/src/main.rs", NodeKind::File, 1, false, Some(Status::Modified)),
+        node(
+            "/r/src/main.rs",
+            NodeKind::File,
+            1,
+            false,
+            Some(Status::Modified),
+        ),
         node("/r/src/inner", NodeKind::Dir, 1, true, None),
-        node("/r/src/inner/added.rs", NodeKind::File, 2, false, Some(Status::Added)),
+        node(
+            "/r/src/inner/added.rs",
+            NodeKind::File,
+            2,
+            false,
+            Some(Status::Added),
+        ),
         node("/r/README.md", NodeKind::File, 0, false, None),
-        node("/r/gone.txt", NodeKind::File, 0, false, Some(Status::Deleted)),
-        node("/r/scratch.log", NodeKind::File, 0, false, Some(Status::Untracked)),
+        node(
+            "/r/gone.txt",
+            NodeKind::File,
+            0,
+            false,
+            Some(Status::Deleted),
+        ),
+        node(
+            "/r/scratch.log",
+            NodeKind::File,
+            0,
+            false,
+            Some(Status::Untracked),
+        ),
     ];
     ViewState {
         nodes,
@@ -57,12 +88,26 @@ fn draws_two_columns_tree_and_content() {
     let out = render(&sample_state(), 100, 24);
 
     // Left column: the tree, with every visible node shown (AC-3 — recursive display).
-    for name in ["src", "main.rs", "inner", "added.rs", "README.md", "gone.txt", "scratch.log"] {
+    for name in [
+        "src",
+        "main.rs",
+        "inner",
+        "added.rs",
+        "README.md",
+        "gone.txt",
+        "scratch.log",
+    ] {
         assert!(out.contains(name), "tree should show {name}\n{out}");
     }
     // Right column: the content pane (two columns are present simultaneously).
-    assert!(out.contains("fn main()"), "content pane should render the file\n{out}");
-    assert!(out.contains("hello"), "content pane should render the file body\n{out}");
+    assert!(
+        out.contains("fn main()"),
+        "content pane should render the file\n{out}"
+    );
+    assert!(
+        out.contains("hello"),
+        "content pane should render the file body\n{out}"
+    );
 }
 
 #[test]
@@ -70,7 +115,10 @@ fn shows_status_markers_for_each_state() {
     // AC-7 (display): modified / added / deleted / untracked markers appear in the tree.
     let out = render(&sample_state(), 100, 24);
     for marker in ['M', 'A', 'D', '?'] {
-        assert!(out.contains(marker), "status marker {marker:?} should appear\n{out}");
+        assert!(
+            out.contains(marker),
+            "status marker {marker:?} should appear\n{out}"
+        );
     }
 }
 
@@ -79,9 +127,16 @@ fn nests_deeper_nodes_with_more_indentation() {
     // AC-3 (display): a depth-2 file is indented further than a depth-0 file.
     let out = render(&sample_state(), 100, 24);
     let indent = |needle: &str| -> usize {
-        let line = out.lines().find(|l| l.contains(needle)).expect("row present");
+        let line = out
+            .lines()
+            .find(|l| l.contains(needle))
+            .expect("row present");
         let start = line.find(needle).unwrap();
-        line[..start].chars().rev().take_while(|c| *c == ' ').count()
+        line[..start]
+            .chars()
+            .rev()
+            .take_while(|c| *c == ' ')
+            .count()
     };
     assert!(
         indent("added.rs") > indent("src"),
@@ -95,8 +150,14 @@ fn nests_deeper_nodes_with_more_indentation() {
 fn surfaces_truncation_and_fallback_notices() {
     // AC-13 + AC-25: both notices are visible in the content area.
     let out = render(&sample_state(), 100, 24);
-    assert!(out.contains("truncated"), "truncation notice (AC-13) visible\n{out}");
-    assert!(out.contains("delta not found"), "fallback notice (AC-25) visible\n{out}");
+    assert!(
+        out.contains("truncated"),
+        "truncation notice (AC-13) visible\n{out}"
+    );
+    assert!(
+        out.contains("delta not found"),
+        "fallback notice (AC-25) visible\n{out}"
+    );
 }
 
 #[test]
@@ -105,7 +166,13 @@ fn hostile_file_name_emits_no_control_bytes_to_the_buffer() {
     // move sequences must never reach the terminal as control bytes when drawn in the tree.
     let hostile = "evil\u{1b}[2J\u{1b}[10;10H\u{07}pwned";
     let mut state = sample_state();
-    state.nodes = vec![node(&format!("/r/{hostile}"), NodeKind::File, 0, false, Some(Status::Modified))];
+    state.nodes = vec![node(
+        &format!("/r/{hostile}"),
+        NodeKind::File,
+        0,
+        false,
+        Some(Status::Modified),
+    )];
     state.selected = 0;
 
     let mut terminal = Terminal::new(TestBackend::new(100, 12)).unwrap();
@@ -124,9 +191,15 @@ fn hostile_file_name_emits_no_control_bytes_to_the_buffer() {
             }
         }
     }
-    assert!(!cells.chars().any(|c| c.is_control()), "no control byte may reach a cell");
+    assert!(
+        !cells.chars().any(|c| c.is_control()),
+        "no control byte may reach a cell"
+    );
     assert!(!cells.contains('\u{1b}'), "no ESC byte in the buffer");
-    assert!(cells.contains("pwned"), "the printable remainder is still shown");
+    assert!(
+        cells.contains("pwned"),
+        "the printable remainder is still shown"
+    );
 }
 
 #[test]
@@ -141,7 +214,10 @@ fn content_pane_applies_the_vertical_scroll_offset() {
     let out = render(&state, 100, 12);
     assert!(out.contains("c3"), "the scrolled-to line is visible\n{out}");
     assert!(out.contains("c7"), "lines below it are visible\n{out}");
-    assert!(!out.contains("c0"), "lines scrolled past the top are hidden\n{out}");
+    assert!(
+        !out.contains("c0"),
+        "lines scrolled past the top are hidden\n{out}"
+    );
 }
 
 #[test]
@@ -186,7 +262,10 @@ fn row_fg(buf: &ratatui::buffer::Buffer, needle: &str) -> ratatui::style::Color 
         for x in 0..w {
             let matches = needle.chars().enumerate().all(|(i, ch)| {
                 let cx = x + i as u16;
-                cx < w && buf.cell((cx, y)).is_some_and(|c| c.symbol() == ch.to_string())
+                cx < w
+                    && buf
+                        .cell((cx, y))
+                        .is_some_and(|c| c.symbol() == ch.to_string())
             });
             if matches {
                 return buf.cell((x, y)).unwrap().fg;
@@ -213,18 +292,50 @@ fn tree_rows_are_colored_by_git_status() {
             status: None,
             dir_dirty: true,
         },
-        node("/r/src/mod.rs", NodeKind::File, 1, false, Some(Status::Modified)),
-        node("/r/src/new.rs", NodeKind::File, 1, false, Some(Status::Added)),
+        node(
+            "/r/src/mod.rs",
+            NodeKind::File,
+            1,
+            false,
+            Some(Status::Modified),
+        ),
+        node(
+            "/r/src/new.rs",
+            NodeKind::File,
+            1,
+            false,
+            Some(Status::Added),
+        ),
         node("/r/clean.txt", NodeKind::File, 0, false, None),
     ];
     state.selected = 3; // the clean file
     let buf = render_buffer(&state, 100, 12);
 
-    assert_eq!(row_fg(&buf, "mod.rs"), Color::LightRed, "a modified file is light red");
-    assert_eq!(row_fg(&buf, "new.rs"), Color::LightGreen, "a new file is light green");
-    assert_eq!(row_fg(&buf, "src"), Color::LightRed, "a directory with changes is light red");
-    assert_ne!(row_fg(&buf, "clean.txt"), Color::LightRed, "a clean file is not colored red");
-    assert_ne!(row_fg(&buf, "clean.txt"), Color::LightGreen, "a clean file is not colored green");
+    assert_eq!(
+        row_fg(&buf, "mod.rs"),
+        Color::LightRed,
+        "a modified file is light red"
+    );
+    assert_eq!(
+        row_fg(&buf, "new.rs"),
+        Color::LightGreen,
+        "a new file is light green"
+    );
+    assert_eq!(
+        row_fg(&buf, "src"),
+        Color::LightRed,
+        "a directory with changes is light red"
+    );
+    assert_ne!(
+        row_fg(&buf, "clean.txt"),
+        Color::LightRed,
+        "a clean file is not colored red"
+    );
+    assert_ne!(
+        row_fg(&buf, "clean.txt"),
+        Color::LightGreen,
+        "a clean file is not colored green"
+    );
 }
 
 #[test]
@@ -237,8 +348,14 @@ fn content_pane_applies_the_horizontal_scroll_offset() {
     state.wrap = false;
     state.content_hscroll = 5;
     let out = render(&state, 100, 12);
-    assert!(out.contains("FGHIJ"), "columns from the offset are visible\n{out}");
-    assert!(!out.contains("ABCDE"), "columns scrolled past the left edge are hidden\n{out}");
+    assert!(
+        out.contains("FGHIJ"),
+        "columns from the offset are visible\n{out}"
+    );
+    assert!(
+        !out.contains("ABCDE"),
+        "columns scrolled past the left edge are hidden\n{out}"
+    );
 }
 
 #[test]
@@ -249,9 +366,16 @@ fn split_ratio_controls_the_tree_column_width() {
         let mut s = sample_state();
         s.split_pct = pct;
         let out = render(&s, 100, 24);
-        out.lines().next().unwrap().find('┐').expect("tree block corner")
+        out.lines()
+            .next()
+            .unwrap()
+            .find('┐')
+            .expect("tree block corner")
     };
-    assert!(corner(60) > corner(20), "a wider split_pct widens the tree column");
+    assert!(
+        corner(60) > corner(20),
+        "a wider split_pct widens the tree column"
+    );
 }
 
 #[test]
@@ -263,14 +387,32 @@ fn wide_layout_snapshot() {
 fn geometry_matches_the_wide_two_column_layout() {
     use herdr_file_viewer::presenter::geometry;
     use ratatui::layout::Rect;
-    let g = geometry(Rect { x: 0, y: 0, width: 100, height: 24 }, &sample_state());
-    let t = g.tree_inner.expect("tree interior present in a wide layout");
-    let c = g.content_inner.expect("content interior present in a wide layout");
+    let g = geometry(
+        Rect {
+            x: 0,
+            y: 0,
+            width: 100,
+            height: 24,
+        },
+        &sample_state(),
+    );
+    let t = g
+        .tree_inner
+        .expect("tree interior present in a wide layout");
+    let c = g
+        .content_inner
+        .expect("content interior present in a wide layout");
     // Tree rows begin just inside the block border, so node `i` is at row `tree_inner.y + i`.
     assert_eq!(t.x, 1);
     assert_eq!(t.y, 1, "tree rows start just inside the top border");
-    assert!(c.x > t.x + t.width, "the content column is to the right of the tree");
-    assert!(g.divider_x.is_some(), "a wide layout has a draggable divider");
+    assert!(
+        c.x > t.x + t.width,
+        "the content column is to the right of the tree"
+    );
+    assert!(
+        g.divider_x.is_some(),
+        "a wide layout has a draggable divider"
+    );
     assert_eq!((g.area_x, g.area_width), (0, 100));
 }
 
@@ -281,10 +423,19 @@ fn zoomed_layout_hides_the_tree_and_fills_with_content() {
     let mut state = sample_state();
     state.zoomed = true;
     let out = render(&state, 100, 24);
-    assert!(out.contains("fn main()"), "content fills the frame when zoomed\n{out}");
+    assert!(
+        out.contains("fn main()"),
+        "content fills the frame when zoomed\n{out}"
+    );
     // No tree-only rows survive: the directory row and a tree-only file are gone.
-    assert!(!out.contains("scratch.log"), "the tree is hidden when zoomed\n{out}");
-    assert!(!out.contains("added.rs"), "no tree rows are drawn when zoomed\n{out}");
+    assert!(
+        !out.contains("scratch.log"),
+        "the tree is hidden when zoomed\n{out}"
+    );
+    assert!(
+        !out.contains("added.rs"),
+        "no tree rows are drawn when zoomed\n{out}"
+    );
 }
 
 #[test]
@@ -294,9 +445,20 @@ fn geometry_is_content_only_when_zoomed() {
     let mut st = sample_state();
     st.zoomed = true;
     // Even at a wide width (which normally shows both columns), zoom draws content only.
-    let g = geometry(Rect { x: 0, y: 0, width: 100, height: 24 }, &st);
+    let g = geometry(
+        Rect {
+            x: 0,
+            y: 0,
+            width: 100,
+            height: 24,
+        },
+        &st,
+    );
     assert!(g.tree_inner.is_none(), "no tree interior when zoomed");
-    assert!(g.content_inner.is_some(), "the content pane fills the frame when zoomed");
+    assert!(
+        g.content_inner.is_some(),
+        "the content pane fills the frame when zoomed"
+    );
     assert!(g.divider_x.is_none(), "no divider when the tree is hidden");
 }
 
@@ -307,8 +469,22 @@ fn geometry_is_single_column_when_narrow() {
     let mut st = sample_state();
     st.focus = Focus::Tree;
     // Below the 80-col narrow threshold only the focused column is drawn (AC-21).
-    let g = geometry(Rect { x: 0, y: 0, width: 60, height: 24 }, &st);
+    let g = geometry(
+        Rect {
+            x: 0,
+            y: 0,
+            width: 60,
+            height: 24,
+        },
+        &st,
+    );
     assert!(g.tree_inner.is_some(), "narrow + tree focus draws the tree");
-    assert!(g.content_inner.is_none(), "the content column is not drawn when narrow");
-    assert!(g.divider_x.is_none(), "no divider in a single-column layout");
+    assert!(
+        g.content_inner.is_none(),
+        "the content column is not drawn when narrow"
+    );
+    assert!(
+        g.divider_x.is_none(),
+        "no divider in a single-column layout"
+    );
 }

--- a/tests/presenter_narrow.rs
+++ b/tests/presenter_narrow.rs
@@ -11,7 +11,14 @@ use ratatui::backend::TestBackend;
 use std::path::PathBuf;
 
 fn node(path: &str, kind: NodeKind, depth: usize, status: Option<Status>) -> Node {
-    Node { path: PathBuf::from(path), kind, depth, expanded: true, status, dir_dirty: false }
+    Node {
+        path: PathBuf::from(path),
+        kind,
+        depth,
+        expanded: true,
+        status,
+        dir_dirty: false,
+    }
 }
 
 fn state(width: u16, focus: Focus) -> ViewState {
@@ -48,16 +55,28 @@ fn render(state: &ViewState, w: u16, h: u16) -> String {
 fn narrow_tree_focus_gives_tree_full_width_and_hides_content() {
     let out = render(&state(60, Focus::Tree), 60, 20);
     assert!(out.contains("scratch.log"), "tree shown full-width\n{out}");
-    assert!(!out.contains("fn main()"), "AC-21: content hidden when tree focused\n{out}");
-    assert!(!out.contains("delta not found"), "AC-21: content notices hidden too\n{out}");
+    assert!(
+        !out.contains("fn main()"),
+        "AC-21: content hidden when tree focused\n{out}"
+    );
+    assert!(
+        !out.contains("delta not found"),
+        "AC-21: content notices hidden too\n{out}"
+    );
 }
 
 #[test]
 fn narrow_content_focus_gives_content_full_width_and_hides_tree() {
     let out = render(&state(60, Focus::Content), 60, 20);
     assert!(out.contains("fn main()"), "content shown full-width\n{out}");
-    assert!(out.contains("delta not found"), "notices shown with content\n{out}");
-    assert!(!out.contains("scratch.log"), "AC-21: tree hidden when content focused\n{out}");
+    assert!(
+        out.contains("delta not found"),
+        "notices shown with content\n{out}"
+    );
+    assert!(
+        !out.contains("scratch.log"),
+        "AC-21: tree hidden when content focused\n{out}"
+    );
 }
 
 #[test]
@@ -67,15 +86,27 @@ fn zoom_overrides_narrow_layout_and_fills_with_content() {
     let mut st = state(60, Focus::Tree);
     st.zoomed = true;
     let out = render(&st, 60, 20);
-    assert!(out.contains("fn main()"), "content fills the frame when zoomed, even narrow\n{out}");
-    assert!(!out.contains("scratch.log"), "the tree is hidden when zoomed, even narrow\n{out}");
+    assert!(
+        out.contains("fn main()"),
+        "content fills the frame when zoomed, even narrow\n{out}"
+    );
+    assert!(
+        !out.contains("scratch.log"),
+        "the tree is hidden when zoomed, even narrow\n{out}"
+    );
 }
 
 #[test]
 fn wide_shows_both_columns_regardless_of_focus() {
     let out = render(&state(100, Focus::Tree), 100, 20);
-    assert!(out.contains("scratch.log"), "tree column present at >= 80 cols\n{out}");
-    assert!(out.contains("fn main()"), "content column present at >= 80 cols\n{out}");
+    assert!(
+        out.contains("scratch.log"),
+        "tree column present at >= 80 cols\n{out}"
+    );
+    assert!(
+        out.contains("fn main()"),
+        "content column present at >= 80 cols\n{out}"
+    );
 }
 
 #[test]
@@ -86,20 +117,32 @@ fn split_decision_follows_the_live_frame_not_a_stale_state_width() {
     let mut st = state(100, Focus::Tree);
     let out = render(&st, 60, 20);
     assert!(out.contains("scratch.log"), "tree shown\n{out}");
-    assert!(!out.contains("fn main()"), "narrow layout follows the 60-col frame, content hidden\n{out}");
+    assert!(
+        !out.contains("fn main()"),
+        "narrow layout follows the 60-col frame, content hidden\n{out}"
+    );
 
     // Conversely, a stale "narrow" width with a wide frame must show both columns.
     st.width = 40;
     let out = render(&st, 100, 20);
-    assert!(out.contains("scratch.log") && out.contains("fn main()"), "wide frame → both columns\n{out}");
+    assert!(
+        out.contains("scratch.log") && out.contains("fn main()"),
+        "wide frame → both columns\n{out}"
+    );
 }
 
 #[test]
 fn narrow_tree_snapshot() {
-    insta::assert_snapshot!("presenter_narrow_tree", render(&state(60, Focus::Tree), 60, 20));
+    insta::assert_snapshot!(
+        "presenter_narrow_tree",
+        render(&state(60, Focus::Tree), 60, 20)
+    );
 }
 
 #[test]
 fn narrow_content_snapshot() {
-    insta::assert_snapshot!("presenter_narrow_content", render(&state(60, Focus::Content), 60, 20));
+    insta::assert_snapshot!(
+        "presenter_narrow_content",
+        render(&state(60, Focus::Content), 60, 20)
+    );
 }

--- a/tests/render_delegate.rs
+++ b/tests/render_delegate.rs
@@ -4,7 +4,7 @@
 //! Renderer commands are injected: `cat` echoes stdin (a working renderer), a nonexistent
 //! program simulates a missing one — so the tests never depend on glow/delta/bat.
 
-use herdr_file_viewer::render::{render, Prepared, Renderers};
+use herdr_file_viewer::render::{Prepared, Renderers, render};
 use herdr_file_viewer::view_policy::ViewMode;
 use ratatui::text::Text;
 use std::time::{Duration, Instant};
@@ -29,7 +29,9 @@ fn flatten(t: &Text) -> String {
 
 #[test]
 fn syntax_mode_invokes_the_syntax_renderer_and_ingests_output() {
-    let prepared = Prepared::Full { text: "fn main() {}".into() };
+    let prepared = Prepared::Full {
+        text: "fn main() {}".into(),
+    };
     let (text, notice) = render(&cat(), &prepared, ViewMode::SyntaxContent, None, None);
     assert!(flatten(&text).contains("fn main"), "AC-10");
     assert!(notice.is_none());
@@ -37,15 +39,25 @@ fn syntax_mode_invokes_the_syntax_renderer_and_ingests_output() {
 
 #[test]
 fn markdown_mode_invokes_the_markdown_renderer() {
-    let prepared = Prepared::Full { text: "# Title".into() };
+    let prepared = Prepared::Full {
+        text: "# Title".into(),
+    };
     let (text, _) = render(&cat(), &prepared, ViewMode::RenderedMarkdown, None, None);
     assert!(flatten(&text).contains("# Title"), "AC-8");
 }
 
 #[test]
 fn diff_mode_renders_the_supplied_raw_diff() {
-    let prepared = Prepared::Full { text: "ignored".into() };
-    let (text, _) = render(&cat(), &prepared, ViewMode::Diff, Some("@@ -1 +1 @@\n+new line"), None);
+    let prepared = Prepared::Full {
+        text: "ignored".into(),
+    };
+    let (text, _) = render(
+        &cat(),
+        &prepared,
+        ViewMode::Diff,
+        Some("@@ -1 +1 @@\n+new line"),
+        None,
+    );
     assert!(flatten(&text).contains("+new line"), "AC-9");
 }
 
@@ -54,7 +66,10 @@ fn an_oversized_diff_is_truncated_with_a_notice() {
     let huge = "+line\n".repeat(6000); // > 5000 lines
     let prepared = Prepared::Full { text: "x".into() };
     let (text, notice) = render(&cat(), &prepared, ViewMode::Diff, Some(&huge), None);
-    assert!(notice.unwrap().to_lowercase().contains("truncated"), "AC-13: large diff bounded");
+    assert!(
+        notice.unwrap().to_lowercase().contains("truncated"),
+        "AC-13: large diff bounded"
+    );
     assert!(text.lines.len() <= 5000, "diff preview is line-bounded");
 }
 
@@ -62,10 +77,19 @@ fn an_oversized_diff_is_truncated_with_a_notice() {
 fn diff_mode_renders_even_for_a_binary_or_deleted_file() {
     // A deleted file classifies as Binary (gone from disk), but its diff comes from git,
     // so Diff mode must still show the diff — not the binary placeholder (AC-9).
-    let (text, _) = render(&cat(), &Prepared::Binary, ViewMode::Diff, Some("@@ -1 +0 @@\n-removed"), None);
+    let (text, _) = render(
+        &cat(),
+        &Prepared::Binary,
+        ViewMode::Diff,
+        Some("@@ -1 +0 @@\n-removed"),
+        None,
+    );
     let s = flatten(&text);
     assert!(s.contains("-removed"), "deletion diff is shown");
-    assert!(!s.to_lowercase().contains("binary file"), "no binary placeholder in diff mode");
+    assert!(
+        !s.to_lowercase().contains("binary file"),
+        "no binary placeholder in diff mode"
+    );
 }
 
 #[test]
@@ -77,9 +101,20 @@ fn missing_renderer_falls_back_to_plain_text_with_a_notice() {
         syntax: vec!["cat".into()],
         timeout: Duration::from_secs(5),
     };
-    let prepared = Prepared::Full { text: "# Title".into() };
-    let (text, notice) = render(&renderers, &prepared, ViewMode::RenderedMarkdown, None, None);
-    assert!(flatten(&text).contains("# Title"), "AC-24: plain-text fallback, not empty/crash");
+    let prepared = Prepared::Full {
+        text: "# Title".into(),
+    };
+    let (text, notice) = render(
+        &renderers,
+        &prepared,
+        ViewMode::RenderedMarkdown,
+        None,
+        None,
+    );
+    assert!(
+        flatten(&text).contains("# Title"),
+        "AC-24: plain-text fallback, not empty/crash"
+    );
     let notice = notice.expect("AC-25: a non-fatal fallback notice");
     assert!(
         notice.to_lowercase().contains("markdown") || notice.to_lowercase().contains("unavailable"),
@@ -89,8 +124,17 @@ fn missing_renderer_falls_back_to_plain_text_with_a_notice() {
 
 #[test]
 fn binary_shows_a_placeholder_not_raw_bytes() {
-    let (text, _) = render(&cat(), &Prepared::Binary, ViewMode::SyntaxContent, None, None);
-    assert!(flatten(&text).to_lowercase().contains("binary"), "AC-12 placeholder");
+    let (text, _) = render(
+        &cat(),
+        &Prepared::Binary,
+        ViewMode::SyntaxContent,
+        None,
+        None,
+    );
+    assert!(
+        flatten(&text).to_lowercase().contains("binary"),
+        "AC-12 placeholder"
+    );
 }
 
 #[test]
@@ -104,9 +148,20 @@ fn syntax_renderer_receives_the_file_name_via_placeholder() {
         syntax: vec!["sh".into(), "-c".into(), "echo {name}".into()],
         timeout: Duration::from_secs(5),
     };
-    let prepared = Prepared::Full { text: "code".into() };
-    let (text, _) = render(&renderers, &prepared, ViewMode::SyntaxContent, None, Some("main.rs"));
-    assert!(flatten(&text).contains("main.rs"), "file name passed to the syntax renderer");
+    let prepared = Prepared::Full {
+        text: "code".into(),
+    };
+    let (text, _) = render(
+        &renderers,
+        &prepared,
+        ViewMode::SyntaxContent,
+        None,
+        Some("main.rs"),
+    );
+    assert!(
+        flatten(&text).contains("main.rs"),
+        "file name passed to the syntax renderer"
+    );
 }
 
 #[test]
@@ -122,12 +177,23 @@ fn a_malicious_file_name_cannot_inject_via_the_placeholder() {
         syntax: vec!["sh".into(), "-c".into(), "echo {name}".into()],
         timeout: Duration::from_secs(5),
     };
-    let prepared = Prepared::Full { text: "code".into() };
+    let prepared = Prepared::Full {
+        text: "code".into(),
+    };
     let evil = format!("$(touch {}).rs", marker.display());
-    let (text, _) = render(&renderers, &prepared, ViewMode::SyntaxContent, None, Some(&evil));
+    let (text, _) = render(
+        &renderers,
+        &prepared,
+        ViewMode::SyntaxContent,
+        None,
+        Some(&evil),
+    );
     assert!(!marker.exists(), "command substitution must not execute");
     let out = flatten(&text);
-    assert!(!out.contains('$') && !out.contains('('), "metacharacters sanitized: {out}");
+    assert!(
+        !out.contains('$') && !out.contains('('),
+        "metacharacters sanitized: {out}"
+    );
 }
 
 #[test]
@@ -145,11 +211,26 @@ fn full_diff_mode_renders_the_diff_text_via_the_full_diff_renderer() {
     let full = "@@ -1,2 +1,2 @@\n fn main() {\n-    old();\n+    new();\n }";
     // Prepared::Binary on purpose: like Diff, FullDiff renders from git, so a deleted/binary
     // file still shows its diff (AC-9) rather than the binary placeholder.
-    let (text, notice) = render(&renderers, &Prepared::Binary, ViewMode::FullDiff, Some(full), None);
+    let (text, notice) = render(
+        &renderers,
+        &Prepared::Binary,
+        ViewMode::FullDiff,
+        Some(full),
+        None,
+    );
     let s = flatten(&text);
-    assert!(s.contains("fn main()") && s.contains("new()"), "full-context diff is shown: {s}");
-    assert!(!s.to_lowercase().contains("binary file"), "no binary placeholder in full-diff mode");
-    assert!(notice.is_none(), "the full_diff renderer succeeded → no fallback notice");
+    assert!(
+        s.contains("fn main()") && s.contains("new()"),
+        "full-context diff is shown: {s}"
+    );
+    assert!(
+        !s.to_lowercase().contains("binary file"),
+        "no binary placeholder in full-diff mode"
+    );
+    assert!(
+        notice.is_none(),
+        "the full_diff renderer succeeded → no fallback notice"
+    );
 }
 
 #[test]
@@ -157,10 +238,22 @@ fn an_oversized_full_diff_is_truncated_with_a_notice() {
     // AC-13 on the FullDiff path: a full-context diff of a large file is bounded with a visible
     // truncation notice before it is rendered, so it can't blow up the content pane.
     let big_diff = "+line\n".repeat(6000); // > the 5000-line cap
-    let (text, notice) = render(&cat(), &Prepared::Binary, ViewMode::FullDiff, Some(&big_diff), None);
+    let (text, notice) = render(
+        &cat(),
+        &Prepared::Binary,
+        ViewMode::FullDiff,
+        Some(&big_diff),
+        None,
+    );
     let n = notice.expect("AC-13: an oversized full-context diff gets a truncation notice");
-    assert!(n.to_lowercase().contains("truncat"), "the notice names the truncation: {n}");
-    assert!(flatten(&text).lines().count() <= 5000, "the rendered diff is line-bounded (AC-13)");
+    assert!(
+        n.to_lowercase().contains("truncat"),
+        "the notice names the truncation: {n}"
+    );
+    assert!(
+        flatten(&text).lines().count() <= 5000,
+        "the rendered diff is line-bounded (AC-13)"
+    );
 }
 
 #[test]
@@ -172,12 +265,29 @@ fn a_hanging_renderer_times_out_and_falls_back() {
         syntax: vec!["cat".into()],
         timeout: Duration::from_millis(150),
     };
-    let prepared = Prepared::Full { text: "# Title".into() };
+    let prepared = Prepared::Full {
+        text: "# Title".into(),
+    };
     let start = Instant::now();
-    let (text, notice) = render(&renderers, &prepared, ViewMode::RenderedMarkdown, None, None);
-    assert!(start.elapsed() < Duration::from_secs(3), "must not block on a wedged renderer");
-    assert!(flatten(&text).contains("# Title"), "AC-24: plain-text fallback after timeout");
-    assert!(notice.unwrap().to_lowercase().contains("timed out"), "notice reports the timeout");
+    let (text, notice) = render(
+        &renderers,
+        &prepared,
+        ViewMode::RenderedMarkdown,
+        None,
+        None,
+    );
+    assert!(
+        start.elapsed() < Duration::from_secs(3),
+        "must not block on a wedged renderer"
+    );
+    assert!(
+        flatten(&text).contains("# Title"),
+        "AC-24: plain-text fallback after timeout"
+    );
+    assert!(
+        notice.unwrap().to_lowercase().contains("timed out"),
+        "notice reports the timeout"
+    );
 }
 
 #[test]
@@ -187,5 +297,8 @@ fn truncation_notice_is_preserved_through_rendering() {
         notice: "truncated-preview".into(),
     };
     let (_, notice) = render(&cat(), &prepared, ViewMode::SyntaxContent, None, None);
-    assert!(notice.unwrap().contains("truncated-preview"), "AC-13 notice survives");
+    assert!(
+        notice.unwrap().contains("truncated-preview"),
+        "AC-13 notice survives"
+    );
 }

--- a/tests/render_escape.rs
+++ b/tests/render_escape.rs
@@ -18,9 +18,18 @@ fn cursor_and_screen_control_sequences_are_neutralized() {
     let text = to_text(hostile);
     let rendered = flatten(&text);
 
-    assert!(!rendered.contains('\u{1b}'), "AC-27: no ESC byte survives ingestion");
-    assert!(!rendered.contains("[2J"), "AC-27: screen-clear not reproduced");
-    assert!(!rendered.contains("[10;10H"), "AC-27: cursor-move not reproduced");
+    assert!(
+        !rendered.contains('\u{1b}'),
+        "AC-27: no ESC byte survives ingestion"
+    );
+    assert!(
+        !rendered.contains("[2J"),
+        "AC-27: screen-clear not reproduced"
+    );
+    assert!(
+        !rendered.contains("[10;10H"),
+        "AC-27: cursor-move not reproduced"
+    );
     // The actual textual content is preserved.
     assert!(rendered.contains("before") && rendered.contains("mid") && rendered.contains("after"));
 }
@@ -33,10 +42,18 @@ fn c0_control_bytes_are_stripped() {
     let text = to_text(hostile);
     let rendered = flatten(&text);
     for ctl in ['\u{07}', '\u{08}', '\r', '\u{0c}', '\u{0b}'] {
-        assert!(!rendered.contains(ctl), "control {:#x} must be stripped", ctl as u32);
+        assert!(
+            !rendered.contains(ctl),
+            "control {:#x} must be stripped",
+            ctl as u32
+        );
     }
     assert!(rendered.contains('\t'), "tab is kept");
-    assert_eq!(text.lines.len(), 2, "newline is kept as a line break, not stripped");
+    assert_eq!(
+        text.lines.len(),
+        2,
+        "newline is kept as a line break, not stripped"
+    );
     assert!(rendered.contains("tab") && rendered.contains("next"));
 }
 
@@ -46,7 +63,10 @@ fn sgr_styling_is_mapped_to_style_not_left_as_raw_codes() {
     let text = to_text(styled);
     let rendered = flatten(&text);
 
-    assert!(!rendered.contains('\u{1b}'), "SGR codes are consumed, not emitted as bytes");
+    assert!(
+        !rendered.contains('\u{1b}'),
+        "SGR codes are consumed, not emitted as bytes"
+    );
     assert!(rendered.contains("RED"));
     let has_color = text
         .lines

--- a/tests/render_perf.rs
+++ b/tests/render_perf.rs
@@ -5,7 +5,7 @@
 mod common;
 
 use common::TempDir;
-use herdr_file_viewer::render::{classify, to_text, Prepared};
+use herdr_file_viewer::render::{Prepared, classify, to_text};
 use std::fs;
 use std::time::Instant;
 

--- a/tests/root.rs
+++ b/tests/root.rs
@@ -2,7 +2,7 @@
 
 mod common;
 
-use common::{canon, git, init_repo_with_commit, TempDir};
+use common::{TempDir, canon, git, init_repo_with_commit};
 use herdr_file_viewer::context::LaunchContext;
 use herdr_file_viewer::root::resolve;
 use std::fs;
@@ -46,10 +46,20 @@ fn linked_worktree_root_is_the_worktree_and_is_flagged() {
     let wt = main.path().join("wt");
     git(
         main.path(),
-        &["worktree", "add", "-q", wt.to_str().unwrap(), "-b", "feature"],
+        &[
+            "worktree",
+            "add",
+            "-q",
+            wt.to_str().unwrap(),
+            "-b",
+            "feature",
+        ],
     );
     let r = resolve(&ctx(&wt));
     assert!(r.is_git_repo);
-    assert!(r.is_worktree, "a linked worktree must be flagged is_worktree"); // AC-1
+    assert!(
+        r.is_worktree,
+        "a linked worktree must be flagged is_worktree"
+    ); // AC-1
     assert_eq!(canon(&r.root), canon(&wt));
 }

--- a/tests/tree.rs
+++ b/tests/tree.rs
@@ -27,10 +27,19 @@ fn a_directory_with_a_changed_descendant_is_flagged_dirty() {
 
     let nodes = model.visible_nodes();
     let find = |name: &str| {
-        nodes.iter().find(|n| n.path.file_name().unwrap() == name).expect("node present")
+        nodes
+            .iter()
+            .find(|n| n.path.file_name().unwrap() == name)
+            .expect("node present")
     };
-    assert!(find("changed").dir_dirty, "a directory with a modified descendant is dirty");
-    assert!(!find("clean").dir_dirty, "a directory with no changes is not dirty");
+    assert!(
+        find("changed").dir_dirty,
+        "a directory with a modified descendant is dirty"
+    );
+    assert!(
+        !find("clean").dir_dirty,
+        "a directory with no changes is not dirty"
+    );
 }
 
 fn names(model: &TreeModel) -> Vec<String> {
@@ -53,12 +62,18 @@ fn enumerates_immediate_children_and_expands_recursively() {
     let top = names(&model);
     assert!(top.contains(&"src".to_string()));
     assert!(top.contains(&"a.txt".to_string()));
-    assert!(!top.contains(&"b.rs".to_string()), "nested files hidden until expand");
+    assert!(
+        !top.contains(&"b.rs".to_string()),
+        "nested files hidden until expand"
+    );
 
     model.expand(&dir.path().join("src")); // AC-3
     let after = names(&model);
     assert!(after.contains(&"b.rs".to_string()));
-    assert!(!after.contains(&"c.rs".to_string()), "deeper level still collapsed");
+    assert!(
+        !after.contains(&"c.rs".to_string()),
+        "deeper level still collapsed"
+    );
 
     model.expand(&dir.path().join("src/inner"));
     assert!(names(&model).contains(&"c.rs".to_string()));
@@ -75,8 +90,14 @@ fn gitignored_entries_are_absent_by_default() {
 
     let n = names(&TreeModel::new(dir.path()));
     assert!(n.contains(&"kept.txt".to_string()));
-    assert!(!n.contains(&"ignored.txt".to_string()), "AC-4: gitignored file absent");
-    assert!(!n.contains(&"target".to_string()), "AC-4: gitignored dir absent");
+    assert!(
+        !n.contains(&"ignored.txt".to_string()),
+        "AC-4: gitignored file absent"
+    );
+    assert!(
+        !n.contains(&"target".to_string()),
+        "AC-4: gitignored dir absent"
+    );
 }
 
 #[test]
@@ -89,7 +110,10 @@ fn never_lists_paths_outside_the_root() {
     let mut model = TreeModel::new(&root);
     model.expand(&root);
     assert!(
-        model.visible_nodes().iter().all(|n| n.path.starts_with(&root)),
+        model
+            .visible_nodes()
+            .iter()
+            .all(|n| n.path.starts_with(&root)),
         "a node escaped the root"
     );
 }

--- a/tests/tree_filters.rs
+++ b/tests/tree_filters.rs
@@ -28,9 +28,15 @@ fn show_ignored_toggle_reveals_then_hides_ignored_files() {
     let mut model = TreeModel::new(dir.path());
     assert!(!names(&model).contains(&"secret.log".to_string()));
     model.set_show_ignored(true);
-    assert!(names(&model).contains(&"secret.log".to_string()), "AC-5: revealed");
+    assert!(
+        names(&model).contains(&"secret.log".to_string()),
+        "AC-5: revealed"
+    );
     model.set_show_ignored(false);
-    assert!(!names(&model).contains(&"secret.log".to_string()), "AC-5: restored");
+    assert!(
+        !names(&model).contains(&"secret.log".to_string()),
+        "AC-5: restored"
+    );
 }
 
 #[test]
@@ -46,14 +52,29 @@ fn changed_only_restricts_then_restores_full_tree() {
     let mut model = TreeModel::new(dir.path());
     model.set_changed_only(true, &changed);
     let n = names(&model);
-    assert!(n.contains(&"src".to_string()), "ancestor dir of a change is shown");
-    assert!(n.contains(&"changed.rs".to_string()), "AC-6: changed file shown");
-    assert!(!n.contains(&"unchanged.rs".to_string()), "AC-6: unchanged sibling hidden");
-    assert!(!n.contains(&"README.md".to_string()), "AC-6: unchanged top-level file hidden");
+    assert!(
+        n.contains(&"src".to_string()),
+        "ancestor dir of a change is shown"
+    );
+    assert!(
+        n.contains(&"changed.rs".to_string()),
+        "AC-6: changed file shown"
+    );
+    assert!(
+        !n.contains(&"unchanged.rs".to_string()),
+        "AC-6: unchanged sibling hidden"
+    );
+    assert!(
+        !n.contains(&"README.md".to_string()),
+        "AC-6: unchanged top-level file hidden"
+    );
 
     model.set_changed_only(false, &changed);
     let restored = names(&model);
-    assert!(restored.contains(&"README.md".to_string()), "AC-6: full tree restored");
+    assert!(
+        restored.contains(&"README.md".to_string()),
+        "AC-6: full tree restored"
+    );
     assert!(restored.contains(&"src".to_string()));
 }
 
@@ -98,9 +119,15 @@ fn changed_only_shows_files_under_a_deleted_directory() {
         .iter()
         .map(|n| n.path.file_name().unwrap().to_string_lossy().into_owned())
         .collect();
-    assert!(names.contains(&"old".to_string()), "the deleted directory is synthesized");
+    assert!(
+        names.contains(&"old".to_string()),
+        "the deleted directory is synthesized"
+    );
     assert!(names.contains(&"a.rs".to_string()));
-    assert!(names.contains(&"b.rs".to_string()), "files under a deleted dir are shown");
+    assert!(
+        names.contains(&"b.rs".to_string()),
+        "files under a deleted dir are shown"
+    );
 }
 
 #[test]
@@ -123,7 +150,10 @@ fn cursor_moves_and_stays_in_bounds_when_filters_shrink_the_list() {
     let mut changed = BTreeMap::new();
     changed.insert(PathBuf::from("a.txt"), Status::Modified);
     model.set_changed_only(true, &changed);
-    assert!(model.cursor() < model.visible_nodes().len(), "cursor clamped after filtering");
+    assert!(
+        model.cursor() < model.visible_nodes().len(),
+        "cursor clamped after filtering"
+    );
     assert!(model.selected().is_some());
 }
 


### PR DESCRIPTION
Mechanical repo hygiene ahead of the public release — **no behavior change**.

## What
- `cargo fmt` across the whole tree (it was never formatted; this unblocks a CI `fmt --check` gate).
- Fix all 8 clippy warnings:
  - doc-list indentation in `git.rs` module docs (×5)
  - collapse a nested `if` into a let-chain (`resolve_base_branch`)
  - `!contains_key(..)` over `get(..).is_none()` in `tests/git_status.rs` (×2)
- gitignore `/AUDIT.md` (local-only repo-audit backlog, not shipped).

## Verification
- `cargo fmt --check` clean
- `cargo clippy --all-targets -- -D warnings` clean (exit 0)
- `cargo test` — all green, no failures

First of three audit-cleanup PRs (A: hygiene → B: remove dead editor seam → C: dedup git hardening + tests). Reviewed by opus per the lightweight-change rule.