### PR TITLE
refactor: remove dead new-pane editor seam + dead code (audit)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -9,7 +9,7 @@
 use crate::controller::{
     Components, ContentProvider, Controller, EditorHandoff, GitService, RenderResult,
 };
-use crate::editor::{EditorLauncher, Spawner, Target};
+use crate::editor::{EditorLauncher, Spawner};
 use crate::git::{self, Baseline, Status};
 use crate::presenter::{self, ViewState};
 use crate::render::{self, Prepared, Renderers};
@@ -241,7 +241,7 @@ impl EditorHandoff for LiveEditor {
         // or outside the alternate screen.
         let suspended = suspend_tui();
         let launched = if suspended.is_ok() {
-            EditorLauncher::new(editor).open(file, Target::Editor, &mut ProcessSpawner)
+            EditorLauncher::new(editor).open(file, &mut ProcessSpawner)
         } else {
             // Don't run the editor over a half-suspended terminal.
             Ok(())
@@ -256,8 +256,7 @@ impl EditorHandoff for LiveEditor {
 }
 
 /// Runs the editor command and waits for it (the hand-off is synchronous, as for a terminal
-/// editor like vim). Only the local-spawn path is used by the keyboard intent; the new-pane
-/// hand-off lives in the Host Adapter (T-17) and is not reached here.
+/// editor like vim).
 struct ProcessSpawner;
 
 impl Spawner for ProcessSpawner {
@@ -271,13 +270,6 @@ impl Spawner for ProcessSpawner {
         } else {
             Err(io::Error::other(format!("editor exited with {status}")))
         }
-    }
-    fn open_pane(&mut self, _editor: &OsStr, _file: &Path) -> io::Result<()> {
-        // v1's keyboard OpenInEditor uses the configured-editor path (Target::Editor); the
-        // new-pane sequence is implemented and tested in the Host Adapter (host.rs).
-        Err(io::Error::other(
-            "new-pane hand-off is not on the v1 keyboard path",
-        ))
     }
 }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -10,10 +10,6 @@ use std::path::PathBuf;
 pub struct LaunchContext {
     /// The invoking pane's working directory.
     pub cwd: PathBuf,
-    /// The worktree root, when herdr launched us inside a managed worktree.
-    pub worktree_root: Option<PathBuf>,
     /// A base-branch hint from herdr (the branch a worktree forked from).
     pub base_branch: Option<String>,
-    /// Whether herdr says this is a worktree launch.
-    pub is_worktree: bool,
 }

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -76,8 +76,8 @@ pub trait ContentProvider: Send {
 
 /// Hand the selected file to an external editor (AC-19). Returns `Ok(true)` when the
 /// hand-off took over the terminal (the run loop must force a full repaint afterwards),
-/// `Ok(false)` for an off-screen hand-off (e.g. a new herdr pane). Behind a trait so the
-/// controller never edits or even spawns directly — and tests launch nothing.
+/// `Ok(false)` if it did not. Behind a trait so the controller never edits or even spawns
+/// directly — and tests launch nothing.
 pub trait EditorHandoff {
     fn open(&mut self, file: &Path) -> io::Result<bool>;
 }
@@ -771,7 +771,7 @@ impl Controller {
                     ..Default::default()
                 }
             }
-            Ok(false) => Effects::redraw(), // off-screen hand-off (new pane) — no takeover
+            Ok(false) => Effects::redraw(), // hand-off without a terminal takeover
             Err(e) => {
                 self.action_notice = Some(format!("Could not open editor: {e}"));
                 // The hand-off may have suspended the terminal before failing, so force a full

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -1,31 +1,19 @@
 //! Editor Launcher — hand the selected file off to an external editor (AC-19).
 //!
-//! Pure hand-off: it either spawns the user's configured editor on the file, or asks the
-//! host to open the file in a **new herdr pane** (whose split→run sequence the Host Adapter
-//! owns, T-17). It never reads, writes, or otherwise mutates the file (AC-N1) — it only
-//! launches another process. External effects go through the injected [`Spawner`] so tests
-//! stay hermetic (nothing is really launched).
+//! Pure hand-off: it spawns the user's configured editor on the file. It never reads,
+//! writes, or otherwise mutates the file (AC-N1) — it only launches another process. The
+//! spawn goes through the injected [`Spawner`] so tests stay hermetic (nothing is really
+//! launched).
 
-use std::ffi::{OsStr, OsString};
+use std::ffi::OsString;
 use std::io;
 use std::path::Path;
 
-/// Where to hand the file off to.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Target {
-    /// The user's configured editor, launched in place of / over the viewer.
-    Editor,
-    /// A new herdr pane that edits the file (Host Adapter performs the split→run, T-17).
-    NewPane,
-}
-
-/// The external-effect seam. The real implementation runs processes / drives the herdr CLI;
-/// tests substitute a recorder so no editor or pane is actually launched.
+/// The external-effect seam. The real implementation runs the editor process; tests
+/// substitute a recorder so no editor is actually launched.
 pub trait Spawner {
     /// Run a local command for the editor hand-off (`argv[0]` is the program).
     fn spawn(&mut self, argv: &[OsString]) -> io::Result<()>;
-    /// Open `file` in a new herdr pane, editing it there with `editor`.
-    fn open_pane(&mut self, editor: &OsStr, file: &Path) -> io::Result<()>;
 }
 
 /// Hands a file off to an external editor, holding the configured editor command.
@@ -41,22 +29,19 @@ impl EditorLauncher {
         }
     }
 
-    /// Hand `file` off per `target` — spawn the configured editor on it, or ask the host to
-    /// open it in a new herdr pane. Returns the launch result; a failure is an `Err` the
-    /// caller surfaces as a non-fatal notice (never a panic). Performs no file I/O (AC-N1).
-    pub fn open(&self, file: &Path, target: Target, spawner: &mut impl Spawner) -> io::Result<()> {
-        match target {
-            Target::Editor => spawner.spawn(&self.editor_argv(file)),
-            Target::NewPane => spawner.open_pane(&self.editor, file),
-        }
+    /// Spawn the configured editor on `file`. Returns the launch result; a failure is an
+    /// `Err` the caller surfaces as a non-fatal notice (never a panic). Performs no file I/O
+    /// (AC-N1).
+    pub fn open(&self, file: &Path, spawner: &mut impl Spawner) -> io::Result<()> {
+        spawner.spawn(&self.editor_argv(file))
     }
 
     /// Build the local-spawn argv: the configured editor split into program + arguments
     /// (so `$EDITOR` values like `"code --wait"` launch correctly), with the selected file
     /// appended as the final argument. Whitespace-split is the conventional `$EDITOR`
-    /// reading; an editor path containing spaces is not supported on this path (use the
-    /// new-pane path, which runs the editor as shell text). An empty/whitespace-only editor
-    /// falls back to the raw value so the launch fails loudly rather than exec-ing the file.
+    /// reading; an editor path containing spaces is not supported. An empty/whitespace-only
+    /// editor falls back to the raw value so the launch fails loudly rather than exec-ing the
+    /// file.
     fn editor_argv(&self, file: &Path) -> Vec<OsString> {
         let mut argv: Vec<OsString> = self
             .editor

--- a/src/host.rs
+++ b/src/host.rs
@@ -1,53 +1,18 @@
-//! Host Adapter — the herdr boundary: parse the injected launch context and issue
-//! open-pane requests to herdr (AC-19, AC-26).
+//! Host Adapter — the herdr boundary: parse the injected launch context (AC-26).
 //!
-//! Two trust boundaries meet here:
-//!  * **herdr-injected context** (`HERDR_PLUGIN_CONTEXT_JSON`) is parsed defensively —
-//!    malformed/missing input degrades to a minimal `{ cwd }`, never a panic (AC-26).
-//!  * **the herdr CLI hand-off** shells out to open a new pane. The untrusted file name is
-//!    single-quoted into the run command so it cannot inject, a relative path that begins
-//!    with `-` is prefixed `./` so the editor can't read it as a flag, and every pane id
-//!    used as an argv element is validated so a flag-like id (`--foo`) cannot option-inject.
-//!
-//! The CLI is reached through the injected [`HerdrCli`] seam so tests stay hermetic.
+//! `HERDR_PLUGIN_CONTEXT_JSON` is parsed defensively — malformed or missing input degrades
+//! to a minimal `{ cwd }` context, never a panic (AC-26).
 
 use crate::context::LaunchContext;
 use serde::Deserialize;
-use std::ffi::{OsStr, OsString};
-use std::io;
-use std::path::{Path, PathBuf};
-
-/// The seam for invoking the herdr CLI (`$HERDR_BIN_PATH`). Returns captured stdout so the
-/// new pane id can be parsed from the `pane split` result. Injected for hermetic tests.
-pub trait HerdrCli {
-    /// Run a herdr subcommand (the implementation prepends `$HERDR_BIN_PATH`); capture stdout.
-    fn run(&mut self, args: &[OsString]) -> io::Result<String>;
-}
+use std::path::PathBuf;
 
 /// The shape of `HERDR_PLUGIN_CONTEXT_JSON`. Every field is optional so a partial or absent
-/// object degrades gracefully rather than failing to parse.
+/// object degrades gracefully rather than failing to parse; unknown fields are ignored.
 #[derive(Deserialize, Default)]
 struct RawContext {
     cwd: Option<String>,
-    worktree_root: Option<String>,
     base_branch: Option<String>,
-    #[serde(default)]
-    is_worktree: bool,
-    pane_id: Option<String>,
-}
-
-/// The `pane split` result envelope we read the new pane id from (`result.pane.pane_id`).
-#[derive(Deserialize)]
-struct SplitResult {
-    result: SplitResultBody,
-}
-#[derive(Deserialize)]
-struct SplitResultBody {
-    pane: SplitPane,
-}
-#[derive(Deserialize)]
-struct SplitPane {
-    pane_id: String,
 }
 
 /// Build a `LaunchContext` from the process environment: the injected context JSON, falling
@@ -66,114 +31,6 @@ pub fn parse_context(json: Option<&str>, fallback_cwd: PathBuf) -> LaunchContext
         .unwrap_or_default();
     LaunchContext {
         cwd: raw.cwd.map(PathBuf::from).unwrap_or(fallback_cwd),
-        worktree_root: raw.worktree_root.map(PathBuf::from),
         base_branch: raw.base_branch,
-        is_worktree: raw.is_worktree,
     }
-}
-
-/// The current pane id from the injected context, if present and well-formed. A malformed
-/// JSON blob or a syntactically unsafe id yields `None` (so it is never used as an argv).
-pub fn current_pane_id(json: Option<&str>) -> Option<String> {
-    let raw: RawContext = json.and_then(|s| serde_json::from_str(s).ok())?;
-    raw.pane_id.filter(|id| is_safe_pane_id(id))
-}
-
-/// Open `file` in a new herdr pane, editing it there with `editor`, via the two-step herdr
-/// CLI sequence:
-///   1. `pane split <current_pane_id> --direction right --no-focus` → capture JSON,
-///   2. parse `result.pane.pane_id`,
-///   3. `pane run <new_pane_id> "<editor> <quoted-file>"`.
-///
-/// Both pane ids are validated before use (option-injection guard) and the file is
-/// shell-escaped (command-injection guard). Any failure is an `Err` the caller surfaces as
-/// a non-fatal notice; it performs no file I/O (AC-N1).
-pub fn open_pane(
-    file: &Path,
-    editor: &OsStr,
-    current_pane_id: &str,
-    cli: &mut impl HerdrCli,
-) -> io::Result<()> {
-    if !is_safe_pane_id(current_pane_id) {
-        return Err(invalid(format!(
-            "unsafe current pane id: {current_pane_id:?}"
-        )));
-    }
-
-    let split_out = cli.run(&osv([
-        "pane",
-        "split",
-        current_pane_id,
-        "--direction",
-        "right",
-        "--no-focus",
-    ]))?;
-
-    let parsed: SplitResult = serde_json::from_str(&split_out)
-        .map_err(|e| invalid(format!("could not parse pane split result: {e}")))?;
-    let new_pane = parsed.result.pane.pane_id;
-    if !is_safe_pane_id(&new_pane) {
-        return Err(invalid(format!(
-            "unsafe new pane id from split: {new_pane:?}"
-        )));
-    }
-
-    // Trust boundary: `editor` is application configuration ($EDITOR / user config), treated
-    // as trusted shell text and left unquoted so editors-with-flags work (as git does with
-    // GIT_EDITOR). `file` is the untrusted, repo-controlled input — it is single-quoted by
-    // `shell_quote_path`, so it is inert data inside the command. (A file name that is not
-    // valid UTF-8 is rendered lossily here — a known v1 limitation on the rare non-UTF-8
-    // path; the herdr `pane run` command is a text string and cannot carry raw bytes.)
-    let command = format!("{} {}", editor.to_string_lossy(), shell_quote_path(file));
-    cli.run(&[
-        OsString::from("pane"),
-        OsString::from("run"),
-        OsString::from(new_pane),
-        OsString::from(command),
-    ])?;
-    Ok(())
-}
-
-/// Build an argv as `OsString`s from string literals.
-fn osv<const N: usize>(parts: [&str; N]) -> Vec<OsString> {
-    parts.iter().map(OsString::from).collect()
-}
-
-/// An `io::Error` for a rejected/garbled host response.
-fn invalid(msg: String) -> io::Error {
-    io::Error::new(io::ErrorKind::InvalidData, msg)
-}
-
-/// A pane id is safe to use as an argv element iff it is a non-empty token of
-/// `[A-Za-z0-9_-]` that does not start with `-` (which would option-inject).
-fn is_safe_pane_id(id: &str) -> bool {
-    let mut chars = id.chars();
-    match chars.next() {
-        Some(c) if c.is_ascii_alphanumeric() || c == '_' => {}
-        _ => return false,
-    }
-    id.chars()
-        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
-}
-
-/// Render `file` for the `pane run` shell command: POSIX single-quoted so any metacharacter
-/// is literal, and `./`-prefixed when a relative path would otherwise begin with `-`.
-fn shell_quote_path(file: &Path) -> String {
-    let raw = file.to_string_lossy();
-    let flag_safe = if raw.starts_with('-') {
-        format!("./{raw}")
-    } else {
-        raw.into_owned()
-    };
-    let mut out = String::with_capacity(flag_safe.len() + 2);
-    out.push('\'');
-    for ch in flag_safe.chars() {
-        if ch == '\'' {
-            out.push_str("'\\''");
-        } else {
-            out.push(ch);
-        }
-    }
-    out.push('\'');
-    out
 }

--- a/src/intent.rs
+++ b/src/intent.rs
@@ -28,7 +28,7 @@ pub enum Intent {
     ToggleBaseline,
     /// Cycle the content pane's view mode over the applicable set (AC-11).
     CycleView,
-    /// Hand the selected file off to an external editor / new pane (AC-19).
+    /// Hand the selected file off to an external editor (AC-19).
     OpenInEditor,
     /// Move focus between the tree and content columns (AC-21).
     ToggleFocus,

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -1,8 +1,7 @@
 //! Launcher decision — the "launch-or-focus-or-toggle" logic behind
 //! `scripts/open-file-viewer.sh`, kept in Rust (not inline shell) so it is hermetically
 //! testable and so pane ids extracted from the host's `pane list` JSON are validated before
-//! they reach an argv (option-injection guard), mirroring the editor hand-off's discipline in
-//! [`crate::host`].
+//! they reach an argv (option-injection guard).
 
 use serde::Deserialize;
 
@@ -110,9 +109,8 @@ pub fn launch_decision_tab(pane_list_json: &str) -> String {
 }
 
 /// A pane id is safe to place in an argv iff it is a non-empty token of `[A-Za-z0-9_:.-]` that
-/// does not start with `-` (which would option-inject). Mirrors `host::is_safe_pane_id`'s
-/// anti-option-injection intent, but also allows `:` and `.` because herdr pane ids are
-/// `workspace:pane` tokens (e.g. `wE:pD`).
+/// does not start with `-` (which would option-inject). `:` and `.` are allowed because herdr
+/// pane ids are `workspace:pane` tokens (e.g. `wE:pD`).
 fn is_flag_safe(id: &str) -> bool {
     !id.is_empty()
         && !id.starts_with('-')

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,9 +1,9 @@
 //! Content Renderer — produce the content-pane text for a file, with safety guards.
 //!
 //! The primary trust boundary: all file bytes are untrusted. This module bounds size
-//! (AC-13), refuses to emit raw bytes for binary files (AC-12), and (in later tasks)
-//! neutralizes control/escape sequences (AC-27) and delegates styling to external CLIs
-//! with a plain-text fallback (AC-24/25). Reads only, never writes (AC-N1).
+//! (AC-13), refuses to emit raw bytes for binary files (AC-12), neutralizes control/escape
+//! sequences (AC-27), and delegates styling to external CLIs with a plain-text fallback
+//! (AC-24/25). Reads only, never writes (AC-N1).
 
 use crate::view_policy::ViewMode;
 use ansi_to_tui::IntoText;

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -85,10 +85,6 @@ impl TreeModel {
         self.markers = status.clone();
     }
 
-    pub fn root(&self) -> &Path {
-        &self.root
-    }
-
     pub fn cursor(&self) -> usize {
         self.cursor
     }
@@ -251,15 +247,6 @@ impl TreeModel {
     pub fn collapse(&mut self, path: &Path) {
         self.expanded.remove(path);
         self.clamp_cursor();
-    }
-
-    /// Toggle a directory's expansion.
-    pub fn toggle(&mut self, path: &Path) {
-        if self.expanded.contains(path) {
-            self.collapse(path);
-        } else {
-            self.expand(path);
-        }
     }
 
     /// Set the cursor to an absolute visible-row index, clamped to the visible range (used by

--- a/tests/editor.rs
+++ b/tests/editor.rs
@@ -1,20 +1,18 @@
-//! T-16 — Editor Launcher: hand-off to editor / new pane (AC-19, AC-N1).
+//! T-16 — Editor Launcher: hand-off to an external editor (AC-19, AC-N1).
 //! The spawner is injected and records requests; nothing is really launched, and the file
 //! on disk is never written by the hand-off.
 
 mod common;
 
 use common::TempDir;
-use herdr_file_viewer::editor::{EditorLauncher, Spawner, Target};
-use std::ffi::{OsStr, OsString};
+use herdr_file_viewer::editor::{EditorLauncher, Spawner};
+use std::ffi::OsString;
 use std::fs;
 use std::io;
-use std::path::{Path, PathBuf};
 
 #[derive(Default)]
 struct FakeSpawner {
     spawned: Vec<Vec<OsString>>,
-    panes: Vec<(OsString, PathBuf)>,
     fail: bool,
 }
 
@@ -26,40 +24,29 @@ impl Spawner for FakeSpawner {
         self.spawned.push(argv.to_vec());
         Ok(())
     }
-    fn open_pane(&mut self, editor: &OsStr, file: &Path) -> io::Result<()> {
-        if self.fail {
-            return Err(io::Error::new(io::ErrorKind::NotFound, "herdr not found"));
-        }
-        self.panes.push((editor.to_owned(), file.to_path_buf()));
-        Ok(())
-    }
 }
 
 #[test]
-fn editor_target_spawns_configured_editor_with_the_selected_file() {
+fn open_spawns_configured_editor_with_the_selected_file() {
     let dir = TempDir::new();
     let file = dir.path().join("notes.txt");
     fs::write(&file, "content").unwrap();
 
     let launcher = EditorLauncher::new("vim");
     let mut sp = FakeSpawner::default();
-    launcher.open(&file, Target::Editor, &mut sp).unwrap();
+    launcher.open(&file, &mut sp).unwrap();
 
     // AC-19: the configured editor is launched on exactly the selected file.
     assert_eq!(
         sp.spawned,
         vec![vec![OsString::from("vim"), file.clone().into_os_string()]]
     );
-    assert!(
-        sp.panes.is_empty(),
-        "the editor path must not open a herdr pane"
-    );
     // AC-N1: the hand-off never writes the file.
     assert_eq!(fs::read_to_string(&file).unwrap(), "content");
 }
 
 #[test]
-fn editor_target_splits_a_configured_editor_with_flags() {
+fn open_splits_a_configured_editor_with_flags() {
     // AC-19: $EDITOR commonly carries flags (e.g. "code --wait"); the local spawn must
     // launch the program with its args, not treat the whole string as one executable name.
     let dir = TempDir::new();
@@ -68,7 +55,7 @@ fn editor_target_splits_a_configured_editor_with_flags() {
 
     let launcher = EditorLauncher::new("code --wait");
     let mut sp = FakeSpawner::default();
-    launcher.open(&file, Target::Editor, &mut sp).unwrap();
+    launcher.open(&file, &mut sp).unwrap();
 
     assert_eq!(
         sp.spawned,
@@ -78,26 +65,6 @@ fn editor_target_splits_a_configured_editor_with_flags() {
             file.clone().into_os_string(),
         ]],
     );
-}
-
-#[test]
-fn new_pane_target_requests_a_herdr_pane_carrying_the_file() {
-    let dir = TempDir::new();
-    let file = dir.path().join("main.rs");
-    fs::write(&file, "fn main() {}").unwrap();
-
-    let launcher = EditorLauncher::new("nano");
-    let mut sp = FakeSpawner::default();
-    launcher.open(&file, Target::NewPane, &mut sp).unwrap();
-
-    // AC-19: a new-pane request carries the exact file (and the editor to run there).
-    assert_eq!(sp.panes, vec![(OsString::from("nano"), file.clone())]);
-    assert!(
-        sp.spawned.is_empty(),
-        "the new-pane path must not spawn a local editor"
-    );
-    // AC-N1: still no write.
-    assert_eq!(fs::read_to_string(&file).unwrap(), "fn main() {}");
 }
 
 #[test]
@@ -113,6 +80,6 @@ fn launch_failure_is_an_error_not_a_panic_and_leaves_the_file_intact() {
         fail: true,
         ..Default::default()
     };
-    assert!(launcher.open(&file, Target::Editor, &mut sp).is_err());
+    assert!(launcher.open(&file, &mut sp).is_err());
     assert_eq!(fs::read_to_string(&file).unwrap(), "x");
 }

--- a/tests/host_context.rs
+++ b/tests/host_context.rs
@@ -1,77 +1,15 @@
-//! T-17 — Host Adapter: parse injected context (AC-26) + open-pane request (AC-19).
-//! The herdr CLI is injected and records calls; nothing real is launched.
+//! T-17 — Host Adapter: parse the injected launch context (AC-26).
 
-use herdr_file_viewer::host::{HerdrCli, current_pane_id, from_env, open_pane, parse_context};
-use std::ffi::{OsStr, OsString};
-use std::io;
+use herdr_file_viewer::host::{from_env, parse_context};
 use std::path::PathBuf;
-
-/// Records every herdr CLI call and replays a canned `pane split` response.
-struct FakeCli {
-    calls: Vec<Vec<OsString>>,
-    split_response: String,
-}
-
-impl FakeCli {
-    fn new(split_response: &str) -> Self {
-        Self {
-            calls: Vec::new(),
-            split_response: split_response.to_string(),
-        }
-    }
-}
-
-impl HerdrCli for FakeCli {
-    fn run(&mut self, args: &[OsString]) -> io::Result<String> {
-        self.calls.push(args.to_vec());
-        if args.get(1).map(|a| a == "split").unwrap_or(false) {
-            Ok(self.split_response.clone())
-        } else {
-            Ok(String::new())
-        }
-    }
-}
-
-fn osv(parts: &[&str]) -> Vec<OsString> {
-    parts.iter().map(OsString::from).collect()
-}
-
-/// Parse a POSIX shell word (single quotes + `\` escapes) back to its literal value, so a
-/// test can prove an escaped command recovers the original string when the shell runs it.
-fn shell_unquote(s: &str) -> String {
-    let mut out = String::new();
-    let mut chars = s.chars();
-    let mut in_single = false;
-    while let Some(c) = chars.next() {
-        if in_single {
-            if c == '\'' {
-                in_single = false;
-            } else {
-                out.push(c);
-            }
-        } else if c == '\'' {
-            in_single = true;
-        } else if c == '\\' {
-            if let Some(n) = chars.next() {
-                out.push(n);
-            }
-        } else {
-            out.push(c);
-        }
-    }
-    out
-}
-
-// ---- context parsing (AC-26) ----------------------------------------------------------
 
 #[test]
 fn populated_context_json_is_parsed() {
+    // Unknown fields (e.g. worktree_root, is_worktree) are ignored gracefully.
     let json = r#"{"cwd":"/w","worktree_root":"/w/wt","base_branch":"main","is_worktree":true}"#;
     let ctx = parse_context(Some(json), PathBuf::from("/fallback"));
     assert_eq!(ctx.cwd, PathBuf::from("/w"));
-    assert_eq!(ctx.worktree_root, Some(PathBuf::from("/w/wt")));
     assert_eq!(ctx.base_branch, Some("main".to_string()));
-    assert!(ctx.is_worktree);
 }
 
 #[test]
@@ -79,9 +17,7 @@ fn missing_json_degrades_to_cwd_only() {
     // AC-26: no context → a minimal { cwd } from the fallback, no panic.
     let ctx = parse_context(None, PathBuf::from("/fallback"));
     assert_eq!(ctx.cwd, PathBuf::from("/fallback"));
-    assert_eq!(ctx.worktree_root, None);
     assert_eq!(ctx.base_branch, None);
-    assert!(!ctx.is_worktree);
 }
 
 #[test]
@@ -89,7 +25,7 @@ fn malformed_json_degrades_without_panic() {
     // AC-26: garbage in → minimal { cwd }, never a crash.
     let ctx = parse_context(Some("{ this is not json"), PathBuf::from("/fallback"));
     assert_eq!(ctx.cwd, PathBuf::from("/fallback"));
-    assert!(!ctx.is_worktree);
+    assert_eq!(ctx.base_branch, None);
 }
 
 #[test]
@@ -104,110 +40,5 @@ fn from_env_without_context_is_cwd_only() {
     // HERDR_PLUGIN_CONTEXT_JSON is unset in the test env → degrade to cwd (AC-26).
     let ctx = from_env();
     assert_eq!(ctx.cwd, std::env::current_dir().unwrap());
-    assert!(!ctx.is_worktree);
-    assert_eq!(ctx.worktree_root, None);
-}
-
-#[test]
-fn current_pane_id_read_from_context() {
-    assert_eq!(
-        current_pane_id(Some(r#"{"pane_id":"p9"}"#)),
-        Some("p9".to_string())
-    );
-    assert_eq!(current_pane_id(Some("garbage")), None);
-    assert_eq!(current_pane_id(None), None);
-}
-
-// ---- open-pane sequence (AC-19) -------------------------------------------------------
-
-#[test]
-fn open_pane_splits_then_runs_editor_in_the_new_pane() {
-    let mut cli = FakeCli::new(r#"{"result":{"pane":{"pane_id":"pane-77"}}}"#);
-    open_pane(
-        &PathBuf::from("/work/src/main.rs"),
-        OsStr::new("vim"),
-        "pane-12",
-        &mut cli,
-    )
-    .unwrap();
-
-    assert_eq!(
-        cli.calls.len(),
-        2,
-        "exactly two herdr CLI calls (split, run)"
-    );
-    assert_eq!(
-        cli.calls[0],
-        osv(&[
-            "pane",
-            "split",
-            "pane-12",
-            "--direction",
-            "right",
-            "--no-focus"
-        ]),
-    );
-    // The new pane id is parsed from the split's result.pane.pane_id and used for run.
-    assert_eq!(
-        cli.calls[1],
-        osv(&["pane", "run", "pane-77", "vim '/work/src/main.rs'"])
-    );
-}
-
-#[test]
-fn hostile_file_name_is_shell_escaped_not_injected() {
-    // A file name carrying shell metacharacters must be neutralized inside single quotes.
-    let mut cli = FakeCli::new(r#"{"result":{"pane":{"pane_id":"p1"}}}"#);
-    let file = PathBuf::from("/work/a'; rm -rf ~; '.txt");
-    open_pane(&file, OsStr::new("vim"), "p0", &mut cli).unwrap();
-
-    let cmd = cli.calls[1][3].to_string_lossy().into_owned();
-    // POSIX single-quote escaping: each embedded ' becomes '\'' .
-    assert_eq!(cmd, r#"vim '/work/a'\''; rm -rf ~; '\''.txt'"#);
-    // Round-trip proof: a shell parsing the quoted word recovers the *literal* filename —
-    // the metacharacters are data inside the quotes, never executed.
-    let quoted = cmd.strip_prefix("vim ").unwrap();
-    assert_eq!(shell_unquote(quoted), "/work/a'; rm -rf ~; '.txt");
-}
-
-#[test]
-fn dash_leading_relative_path_is_made_flag_safe() {
-    // A relative path beginning with '-' must not be readable as an editor flag.
-    let mut cli = FakeCli::new(r#"{"result":{"pane":{"pane_id":"p1"}}}"#);
-    open_pane(&PathBuf::from("-rf"), OsStr::new("vim"), "p0", &mut cli).unwrap();
-    let cmd = cli.calls[1][3].to_string_lossy().into_owned();
-    assert_eq!(cmd, "vim './-rf'");
-}
-
-#[test]
-fn unparseable_split_output_errors_without_a_run_call() {
-    let mut cli = FakeCli::new("not json at all");
-    let r = open_pane(&PathBuf::from("/w/f"), OsStr::new("vim"), "p0", &mut cli);
-    assert!(r.is_err(), "a bad split result must be an error");
-    assert_eq!(cli.calls.len(), 1, "no run call after a failed split");
-}
-
-#[test]
-fn flag_like_pane_id_from_split_is_rejected() {
-    // Option injection: a split result whose pane_id looks like a flag is refused.
-    let mut cli = FakeCli::new(r#"{"result":{"pane":{"pane_id":"--evil"}}}"#);
-    let r = open_pane(&PathBuf::from("/w/f"), OsStr::new("vim"), "p0", &mut cli);
-    assert!(r.is_err());
-    assert_eq!(cli.calls.len(), 1, "no run call with an unsafe new pane id");
-}
-
-#[test]
-fn flag_like_current_pane_id_is_rejected_before_any_call() {
-    let mut cli = FakeCli::new("{}");
-    let r = open_pane(
-        &PathBuf::from("/w/f"),
-        OsStr::new("vim"),
-        "--evil",
-        &mut cli,
-    );
-    assert!(r.is_err());
-    assert!(
-        cli.calls.is_empty(),
-        "no split with an unsafe current pane id"
-    );
+    assert_eq!(ctx.base_branch, None);
 }


### PR DESCRIPTION
Audit-driven cleanup (over-engineering / YAGNI theme). **No production behavior change** — all removed code was unreachable or uncalled.

## What & why
1. **Remove the dead new-pane editor hand-off seam.** The `e` key only ever uses the local-spawn path (`$EDITOR`). The new-herdr-pane editor path was fully built and tested but **unreachable**: `ProcessSpawner::open_pane` always errored, and nothing called `host::open_pane`. Removed:
   - `editor.rs`: the `Target` enum + `Spawner::open_pane`; `open()` now just spawns.
   - `host.rs`: `open_pane`, `current_pane_id`, `HerdrCli`, the `SplitResult` structs, `is_safe_pane_id`, `shell_quote_path` — leaving only context parsing.
   - `app.rs`: the always-erroring `ProcessSpawner::open_pane` stub.
   - This also kills the **divergent second pane-id validator** (`host::is_safe_pane_id`); the live launcher keeps `launch::is_flag_safe`.
2. **Remove dead `LaunchContext.worktree_root` / `is_worktree`** — parsed from host JSON but never read by `root::resolve` (which computes its own worktree detection).
3. **Remove dead `TreeModel::toggle` / `root`** — no callers.
4. **Fix a stale `render.rs` comment** that said AC-27 work was "in later tasks" (it's implemented).

Tests for the dead paths are removed; the live editor + context-parse tests stay.

## Not included (deliberately)
The dead `ViewState.width` threading (a low-severity audit nit) is **kept** — it's documented vestigial session-state guarded by a deliberate regression test; removing it would delete a useful guard for marginal gain.

## Verification
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --check` clean
- `cargo test` — all green

Going through the full review-gate since this removes trust-boundary code (shell-quoting / pane-id validation).