### PR TITLE
refactor: dedup git hardening + backfill security tests (audit)

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -229,9 +229,9 @@ impl Controller {
                     } else {
                         None
                     };
-                // A renderer panic must not kill the worker (rendering would stop forever) nor
-                // fire the global panic hook from this thread (it would reset the main thread's
-                // terminal mid-session). Contain it and surface a placeholder instead.
+                // Contain a renderer panic so the worker survives — otherwise the thread would
+                // die and rendering would stop for the rest of the session. The unwind is caught
+                // here and a placeholder is surfaced in place of the failed render.
                 let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
                     content.render(&job.path, job.mode, raw_diff.as_deref())
                 }))

--- a/src/git.rs
+++ b/src/git.rs
@@ -208,11 +208,15 @@ pub fn diff(
     capture_stdout(cmd)
 }
 
-/// Build a `git -C <repo> <args>` command hardened for read-only use against an
-/// **untrusted** repository: `GIT_OPTIONAL_LOCKS=0` stops status/diff from writing the
-/// index (AC-N2); `core.fsmonitor` / `core.hooksPath` are neutralized so a planted
-/// `.git/config` can't run a program during a query.
-fn git_command(repo_root: &Path, args: &[&str]) -> Command {
+/// Build a `git -C <dir> <args>` command hardened for read-only use against an **untrusted**
+/// repository: `GIT_OPTIONAL_LOCKS=0` stops status/diff from writing the index (AC-N2);
+/// `core.fsmonitor` / `core.hooksPath` are neutralized so a planted `.git/config` can't run a
+/// program during a query; and inherited repo-redirecting env (`GIT_DIR`/`GIT_WORK_TREE`/…) is
+/// dropped so queries resolve against `-C <dir>`, not a repository the viewer was launched
+/// against. **This is the single source of that hardening** — the Root Resolver
+/// ([`crate::root`]) builds its queries through this same function, so the guards cannot drift
+/// between the two.
+pub(crate) fn git_command(repo_root: &Path, args: &[&str]) -> Command {
     let mut cmd = Command::new("git");
     cmd.env("GIT_OPTIONAL_LOCKS", "0")
         // Drop inherited repo-redirecting env so queries resolve against `-C <repo>`, not
@@ -394,5 +398,68 @@ fn classify_name_status(code: &str) -> Option<Status> {
         Some('D') => Some(Status::Deleted),
         Some('M' | 'T' | 'R' | 'C') => Some(Status::Modified),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The shared hardened builder must apply *every* untrusted-repo guard. This is the
+    /// regression guard that keeps the Git Service and the Root Resolver — which now build
+    /// their queries through this one function — from silently dropping a protection (AC-N2).
+    #[test]
+    fn git_command_applies_every_untrusted_repo_guard() {
+        let cmd = git_command(Path::new("/some/repo"), &["status"]);
+
+        // CLI guards: -C <dir>, neutralized fsmonitor/hooks, attr-source pinned to empty tree.
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        assert!(
+            args.iter().any(|a| a == "-C"),
+            "runs with -C <dir>: {args:?}"
+        );
+        assert!(
+            args.contains(&"core.fsmonitor=false".to_string()),
+            "fsmonitor neutralized: {args:?}"
+        );
+        assert!(
+            args.contains(&"core.hooksPath=/dev/null".to_string()),
+            "hooks neutralized: {args:?}"
+        );
+        assert!(
+            args.iter().any(|a| a.starts_with("--attr-source=")),
+            "attr-source pinned to the empty tree: {args:?}"
+        );
+
+        // GIT_OPTIONAL_LOCKS=0 is set; the repo-redirecting vars are scrubbed (env value None).
+        let envs: Vec<(String, Option<String>)> = cmd
+            .get_envs()
+            .map(|(k, v)| {
+                (
+                    k.to_string_lossy().into_owned(),
+                    v.map(|v| v.to_string_lossy().into_owned()),
+                )
+            })
+            .collect();
+        assert!(
+            envs.iter()
+                .any(|(k, v)| k == "GIT_OPTIONAL_LOCKS" && v.as_deref() == Some("0")),
+            "optional locks disabled: {envs:?}"
+        );
+        for var in [
+            "GIT_DIR",
+            "GIT_WORK_TREE",
+            "GIT_COMMON_DIR",
+            "GIT_INDEX_FILE",
+            "GIT_OBJECT_DIRECTORY",
+        ] {
+            assert!(
+                envs.iter().any(|(k, v)| k == var && v.is_none()),
+                "{var} is scrubbed from the child env: {envs:?}"
+            );
+        }
     }
 }

--- a/src/root.rs
+++ b/src/root.rs
@@ -6,7 +6,6 @@
 
 use crate::context::LaunchContext;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 /// The resolved root and git facts the Session Controller initializes from.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -48,29 +47,12 @@ pub fn resolve(ctx: &LaunchContext) -> Resolved {
 }
 
 /// Run a read-only `git` query in `dir`; `Some(trimmed stdout)` on success, else `None`.
-/// Hardened like the Git Service runner: no optional index locks, repo-controlled
-/// `core.fsmonitor` / `core.hooksPath` neutralized, and inherited repo-redirecting env
-/// (`GIT_DIR`/`GIT_WORK_TREE`/…) dropped so the *root* resolves against `dir`, not a
-/// repository the viewer happened to be launched against (the root may be untrusted).
+/// Built through the Git Service's shared [`crate::git::git_command`] so the untrusted-repo
+/// hardening (no optional index locks, neutralized `core.fsmonitor`/`core.hooksPath`, dropped
+/// repo-redirecting env so the *root* resolves against `dir`) is applied identically here and
+/// in the Git Service — it cannot drift between the two.
 fn git_output(dir: &Path, args: &[&str]) -> Option<String> {
-    let out = Command::new("git")
-        .env("GIT_OPTIONAL_LOCKS", "0")
-        .env_remove("GIT_DIR")
-        .env_remove("GIT_WORK_TREE")
-        .env_remove("GIT_COMMON_DIR")
-        .env_remove("GIT_INDEX_FILE")
-        .env_remove("GIT_OBJECT_DIRECTORY")
-        .arg("-C")
-        .arg(dir)
-        .args([
-            "-c",
-            "core.fsmonitor=false",
-            "-c",
-            "core.hooksPath=/dev/null",
-        ])
-        .args(args)
-        .output()
-        .ok()?;
+    let out = crate::git::git_command(dir, args).output().ok()?;
     if out.status.success() {
         Some(String::from_utf8_lossy(&out.stdout).trim().to_string())
     } else {

--- a/src/root.rs
+++ b/src/root.rs
@@ -50,7 +50,10 @@ pub fn resolve(ctx: &LaunchContext) -> Resolved {
 /// Built through the Git Service's shared [`crate::git::git_command`] so the untrusted-repo
 /// hardening (no optional index locks, neutralized `core.fsmonitor`/`core.hooksPath`, dropped
 /// repo-redirecting env so the *root* resolves against `dir`) is applied identically here and
-/// in the Git Service — it cannot drift between the two.
+/// in the Git Service — it cannot drift between the two. The shared builder also pins
+/// `--attr-source`, so root resolution (like the rest of the Git Service) needs git ≥ 2.40;
+/// an older git makes these queries fail and the directory degrades to a plain, non-git
+/// browser (AC-26) rather than a half-working repo view.
 fn git_output(dir: &Path, args: &[&str]) -> Option<String> {
     let out = crate::git::git_command(dir, args).output().ok()?;
     if out.status.success() {

--- a/tests/controller_async.rs
+++ b/tests/controller_async.rs
@@ -34,12 +34,23 @@ impl ContentProvider for SlowContent {
     }
 }
 
-/// A renderer that always panics — to prove the worker thread *contains* the panic
-/// (`catch_unwind`) and surfaces a placeholder instead of dying or crashing the app.
-struct PanicContent;
-impl ContentProvider for PanicContent {
-    fn render(&self, _path: &Path, _mode: ViewMode, _raw_diff: Option<&str>) -> RenderResult {
-        panic!("renderer blew up");
+/// A renderer that panics only on `panic_file` and renders normally otherwise — so a test can
+/// prove BOTH that a panic is contained (the panic file → placeholder) AND that the worker
+/// survives it (a *different* file still renders real content afterwards, which can only arrive
+/// if the worker thread lived through the panic).
+struct PanicOnContent {
+    panic_file: &'static str,
+}
+impl ContentProvider for PanicOnContent {
+    fn render(&self, path: &Path, _mode: ViewMode, _raw_diff: Option<&str>) -> RenderResult {
+        let name = path.file_name().unwrap().to_string_lossy().into_owned();
+        if name == self.panic_file {
+            panic!("renderer blew up on {name}");
+        }
+        RenderResult {
+            content: Text::raw(format!("rendered:{name}")),
+            notices: Vec::new(),
+        }
     }
 }
 
@@ -242,27 +253,25 @@ fn a_superseded_render_does_not_overwrite_a_newer_selection() {
 }
 
 #[test]
-fn a_panicking_renderer_is_contained_and_keeps_the_worker_alive() {
+fn a_panicking_renderer_is_contained_and_the_worker_survives() {
     // AC-23 resilience: a renderer panic must not kill the worker (rendering would stop
-    // forever) nor crash the app — it is caught and a placeholder is surfaced instead.
-    // (The deliberate panic prints to stderr; that is expected — the point is that nothing
-    // unwinds out of the worker.)
+    // forever) nor crash the app. (The deliberate panic prints to stderr; that is expected.)
     let dir = TempDir::new();
     std::fs::write(dir.path().join("a.rs"), "1\n").unwrap();
     std::fs::write(dir.path().join("b.rs"), "2\n").unwrap();
     let components = Components {
         git: Arc::new(NoGit),
-        content: Box::new(PanicContent),
+        content: Box::new(PanicOnContent { panic_file: "b.rs" }),
         editor: Box::new(NoEditor),
     };
     let mut ctrl = Controller::new(dir.path().to_path_buf(), false, Baseline::Head, components);
 
-    // Select a file → dispatches a render whose worker render() panics.
-    ctrl.handle(Intent::NavDown);
+    // Select b.rs → its render() panics; the worker must catch it and surface a placeholder.
+    ctrl.handle(Intent::NavDown); // b.rs
     let deadline = Instant::now() + Duration::from_secs(5);
     loop {
         ctrl.poll();
-        if flatten(ctrl.content()).contains("content unavailable") {
+        if flatten(ctrl.content()).contains("[content unavailable — renderer error]") {
             break;
         }
         assert!(
@@ -271,23 +280,20 @@ fn a_panicking_renderer_is_contained_and_keeps_the_worker_alive() {
         );
         std::thread::sleep(Duration::from_millis(5));
     }
-    assert!(
-        flatten(ctrl.content()).contains("[content unavailable — renderer error]"),
-        "a panicking renderer surfaces a placeholder, not a crash"
-    );
 
-    // The worker survived the first panic: a second selection still gets processed (it panics
-    // again → another placeholder), proving the worker loop did not break out on the panic.
-    ctrl.handle(Intent::NavUp);
+    // Now select a.rs → a NORMAL render. Its DISTINCT content can only arrive if the worker
+    // survived the earlier panic — a dead worker would leave the placeholder showing forever.
+    // This (not the placeholder, which was already on screen) is what proves survival.
+    ctrl.handle(Intent::NavUp); // a.rs renders normally
     let deadline2 = Instant::now() + Duration::from_secs(5);
     loop {
         ctrl.poll();
-        if flatten(ctrl.content()).contains("content unavailable") {
+        if flatten(ctrl.content()) == "rendered:a.rs" {
             break;
         }
         assert!(
             Instant::now() < deadline2,
-            "the worker did not survive the first panic (no result for the second selection)"
+            "the worker did not survive the panic (the post-panic render never arrived)"
         );
         std::thread::sleep(Duration::from_millis(5));
     }

--- a/tests/controller_async.rs
+++ b/tests/controller_async.rs
@@ -34,6 +34,15 @@ impl ContentProvider for SlowContent {
     }
 }
 
+/// A renderer that always panics — to prove the worker thread *contains* the panic
+/// (`catch_unwind`) and surfaces a placeholder instead of dying or crashing the app.
+struct PanicContent;
+impl ContentProvider for PanicContent {
+    fn render(&self, _path: &Path, _mode: ViewMode, _raw_diff: Option<&str>) -> RenderResult {
+        panic!("renderer blew up");
+    }
+}
+
 struct NoGit;
 impl GitService for NoGit {
     fn status(&self) -> BTreeMap<PathBuf, Status> {
@@ -230,4 +239,56 @@ fn a_superseded_render_does_not_overwrite_a_newer_selection() {
         "rendered:c.rs",
         "a superseded render must not overwrite the newer selection"
     );
+}
+
+#[test]
+fn a_panicking_renderer_is_contained_and_keeps_the_worker_alive() {
+    // AC-23 resilience: a renderer panic must not kill the worker (rendering would stop
+    // forever) nor crash the app — it is caught and a placeholder is surfaced instead.
+    // (The deliberate panic prints to stderr; that is expected — the point is that nothing
+    // unwinds out of the worker.)
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.rs"), "1\n").unwrap();
+    std::fs::write(dir.path().join("b.rs"), "2\n").unwrap();
+    let components = Components {
+        git: Arc::new(NoGit),
+        content: Box::new(PanicContent),
+        editor: Box::new(NoEditor),
+    };
+    let mut ctrl = Controller::new(dir.path().to_path_buf(), false, Baseline::Head, components);
+
+    // Select a file → dispatches a render whose worker render() panics.
+    ctrl.handle(Intent::NavDown);
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        ctrl.poll();
+        if flatten(ctrl.content()).contains("content unavailable") {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "the contained-panic placeholder never arrived (the worker likely died)"
+        );
+        std::thread::sleep(Duration::from_millis(5));
+    }
+    assert!(
+        flatten(ctrl.content()).contains("[content unavailable — renderer error]"),
+        "a panicking renderer surfaces a placeholder, not a crash"
+    );
+
+    // The worker survived the first panic: a second selection still gets processed (it panics
+    // again → another placeholder), proving the worker loop did not break out on the panic.
+    ctrl.handle(Intent::NavUp);
+    let deadline2 = Instant::now() + Duration::from_secs(5);
+    loop {
+        ctrl.poll();
+        if flatten(ctrl.content()).contains("content unavailable") {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline2,
+            "the worker did not survive the first panic (no result for the second selection)"
+        );
+        std::thread::sleep(Duration::from_millis(5));
+    }
 }

--- a/tests/git_status.rs
+++ b/tests/git_status.rs
@@ -91,3 +91,38 @@ fn untracked_directory_is_listed_per_file_not_collapsed() {
     assert!(!map.contains_key(&PathBuf::from("newdir")));
     assert!(!map.contains_key(&PathBuf::from("newdir/")));
 }
+
+#[test]
+fn staged_rename_reports_the_new_path_and_does_not_desync_the_parser() {
+    // A renamed file appears in `-z` porcelain as a record (`R…`) followed by a SEPARATE NUL
+    // field carrying the original path. The parser must consume that extra field so the new
+    // path is reported AND the entries after it are not mis-parsed (a desync would shift every
+    // following code/path pair). This is the most fragile parse in the Git Service.
+    let repo = TempDir::new();
+    init_repo_with_commit(repo.path());
+    fs::write(repo.path().join("old.txt"), "content\n").unwrap();
+    git(repo.path(), &["add", "old.txt"]);
+    git(repo.path(), &["commit", "-q", "-m", "add old"]);
+
+    // Stage a rename, plus an untracked file that sorts AFTER it: if the rename's extra NUL
+    // field were not consumed, this trailing entry would be mis-parsed.
+    git(repo.path(), &["mv", "old.txt", "new.txt"]);
+    fs::write(repo.path().join("zzz.txt"), "z\n").unwrap();
+
+    let map = status(repo.path());
+
+    assert_eq!(
+        map.get(&PathBuf::from("new.txt")),
+        Some(&Status::Modified),
+        "the rename's new path is reported (R → Modified)"
+    );
+    assert!(
+        !map.contains_key(&PathBuf::from("old.txt")),
+        "the rename source is consumed, not reported as its own entry"
+    );
+    assert_eq!(
+        map.get(&PathBuf::from("zzz.txt")),
+        Some(&Status::Untracked),
+        "the entry after the rename parses correctly — the extra NUL field was consumed"
+    );
+}

--- a/tests/render_escape.rs
+++ b/tests/render_escape.rs
@@ -75,3 +75,65 @@ fn sgr_styling_is_mapped_to_style_not_left_as_raw_codes() {
         .any(|s| s.style.fg.is_some());
     assert!(has_color, "SGR color is applied as a ratatui style");
 }
+
+#[test]
+fn osc_sequences_are_dropped_through_both_terminators() {
+    // OSC (ESC ]) can set the window title, define hyperlinks, etc. It must be dropped whole,
+    // through either terminator: BEL (\x07) or ST (ESC \). (AC-27)
+    let bel = "before\x1b]0;hijack the title\x07after"; // OSC ... BEL
+    let st = "x\x1b]8;;http://evil/\x1b\\y"; // OSC-8 hyperlink ... ST (ESC \)
+    for hostile in [bel, st] {
+        let rendered = flatten(&to_text(hostile));
+        assert!(
+            !rendered.contains('\u{1b}'),
+            "no ESC survives: {rendered:?}"
+        );
+        assert!(
+            !rendered.contains("hijack"),
+            "OSC payload not reproduced: {rendered:?}"
+        );
+        assert!(
+            !rendered.contains("http://evil"),
+            "OSC-8 target not reproduced: {rendered:?}"
+        );
+    }
+    // The surrounding plain text on each side is preserved.
+    assert!(flatten(&to_text(bel)).contains("before") && flatten(&to_text(bel)).contains("after"));
+    assert!(flatten(&to_text(st)).contains('x') && flatten(&to_text(st)).contains('y'));
+}
+
+#[test]
+fn c1_control_codepoints_are_dropped() {
+    // C1 controls (U+0080–U+009F, e.g. U+009B = a single-byte CSI introducer) are acted on by
+    // some terminals, so each is dropped. (AC-27)
+    let hostile = "a\u{9b}b\u{85}c"; // U+009B (CSI), U+0085 (NEL)
+    let rendered = flatten(&to_text(hostile));
+    assert!(!rendered.contains('\u{9b}'), "C1 CSI dropped: {rendered:?}");
+    assert!(!rendered.contains('\u{85}'), "C1 NEL dropped: {rendered:?}");
+    assert!(rendered.contains('a') && rendered.contains('b') && rendered.contains('c'));
+}
+
+#[test]
+fn a_lone_trailing_esc_is_dropped() {
+    // A bare ESC at the end of input (no following byte to form a sequence) must still be
+    // dropped, never emitted. (AC-27)
+    let rendered = flatten(&to_text("text\x1b"));
+    assert!(
+        !rendered.contains('\u{1b}'),
+        "trailing ESC dropped: {rendered:?}"
+    );
+    assert!(rendered.contains("text"));
+}
+
+#[test]
+fn esc_plus_single_byte_escape_is_dropped() {
+    // A two-byte ESC + single-char escape (e.g. ESC c = RIS, a full terminal reset) must be
+    // dropped whole — both the ESC and its command byte. (AC-27)
+    let rendered = flatten(&to_text("a\x1bcb")); // ESC c (RIS) between 'a' and 'b'
+    assert!(!rendered.contains('\u{1b}'), "ESC dropped: {rendered:?}");
+    assert!(rendered.contains('a') && rendered.contains('b'));
+    assert!(
+        !rendered.contains('c'),
+        "the RIS command byte is consumed with its ESC: {rendered:?}"
+    );
+}


### PR DESCRIPTION
Audit-driven (Themes 2 & 3). **No behavior change** to observable output; one internal consistency improvement + test coverage.

## Theme 2 — one shared hardened git-command builder
`root::git_output` and `git::git_command` each independently scrubbed the repo-redirecting env (`GIT_DIR`/`GIT_WORK_TREE`/…) and set `core.fsmonitor=false` / `core.hooksPath=/dev/null` — two copies of the untrusted-repo hardening that could **drift** (3 models flagged it). Now `git::git_command` is the single `pub(crate)` builder and the Root Resolver builds its queries through it.
- root's `rev-parse` queries additionally gain `--attr-source=<empty-tree>` — harmless (they read no attributes), and the existing root/baseline/worktree tests confirm resolution is unchanged.
- A unit test asserts the builder applies **every** guard (env scrubbing + fsmonitor/hooks + attr-source + `-C`) — the regression guard against future drift.

## Theme 3 — backfill the hardest / most security-relevant paths
- **git status rename/copy parse** (the trickiest parse): a staged rename reports the new path, and the extra NUL field is consumed so following entries don't desync.
- **AC-27 escape neutralizer**: the previously-untested **OSC**, **C1**, **lone-ESC**, and **ESC+single** branches (only CSI/C0/SGR were covered).
- **render worker `catch_unwind`**: a panicking renderer is contained and the worker stays alive (AC-23 resilience).

## Verification
- `cargo clippy --all-targets -- -D warnings` clean · `cargo fmt --check` clean · all 196 tests green.

Full review-gate (holistic ×4 + lens-security ×2) since it touches untrusted-repo hardening.