### PR TITLE
chore: release essentials — LICENSE, CI, metadata, docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-D warnings"
+
+jobs:
+  lint:
+    name: rustfmt + clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.96.0
+        with:
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+      - name: rustfmt
+        run: cargo fmt --all --check
+      - name: clippy
+        run: cargo clippy --all-targets -- -D warnings
+
+  test:
+    name: test (${{ matrix.os }}, ${{ matrix.rust }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        rust: ["1.96.0", "stable"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+      - uses: Swatinem/rust-cache@v2
+      # The unit / integration / e2e (pty) tests are hermetic: they stub the editor via
+      # $EDITOR and run in temp dirs, so they need neither glow/delta/bat nor a live herdr.
+      - name: test
+        run: cargo test
+
+  audit:
+    name: cargo-audit (advisories)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo install cargo-audit --locked
+      - run: cargo audit

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,86 @@
+# Architecture
+
+A high-level map of how `herdr-file-viewer` is built, for contributors and for anyone
+reviewing the implementation. It's a small crate (~3.5k lines of source), so this stays brief.
+
+## The shape: one in-process TUI owning both columns
+
+The viewer is a **single process** that draws *both* the directory tree (left) and the content
+pane (right) inside one [ratatui](https://ratatui.rs) frame. It is **not** composed of multiple
+herdr panes — herdr opens it as one split pane and the viewer owns the whole rectangle. This
+keeps focus, layout, and keyboard routing entirely in-process (no cross-pane IPC for the core
+UX), at the cost of drawing the two-column layout ourselves.
+
+The crate is a **library + a thin binary**: `src/main.rs` is a few lines that either prints a
+launcher decision (for the shell launch scripts) or calls `lib::run()`; everything testable
+lives in the library modules.
+
+## Components
+
+Each module has one responsibility; the side-effecting ones sit behind traits so the controller
+is unit-testable with stubs.
+
+| Module | Responsibility |
+| --- | --- |
+| `host` | The herdr boundary — parse the injected `HERDR_PLUGIN_CONTEXT_JSON` launch context, degrading to `{ cwd }` on anything malformed (never panics). |
+| `context` | The normalized `LaunchContext` the host hands to the resolver. |
+| `root` | Resolve the tree root (git worktree top-level, else cwd) and git-presence. |
+| `git` | Read-only git queries: status, baseline selection, changed-set, per-file diff. The **only** module that shells out to `git`, and only with read-only subcommands. |
+| `tree` | The rooted, `.gitignore`-aware file tree: filters, cursor, expansion, status markers. |
+| `view_policy` | A pure decision: which view mode a file gets (changed → diff, markdown → rendered, else → syntax content) and the cycle order. |
+| `render` | Produce the content-pane text: classify the file, delegate styling to an external CLI, and **neutralize escape sequences** before display. |
+| `presenter` | Draw the two-column (or zoomed / narrow) layout with ratatui; report the content viewport + pane geometry back. |
+| `input` | Map crossterm key events → intents. |
+| `intent` | The closed set of user intents (one exhaustive enum). |
+| `controller` | Orchestrate intents → state changes; hold the ephemeral session state; dispatch renders to the worker. |
+| `editor` | Hand a file off to `$EDITOR` (launch only — never reads or writes the file). |
+| `launch` | The "launch-or-focus-or-toggle" decision behind the shell launch scripts (pure, hermetically testable). |
+
+## Data flow
+
+```
+herdr → env (HERDR_PLUGIN_CONTEXT_JSON)
+          │
+   host::from_env → root::resolve → git::default_baseline
+          │
+   Controller::new  ── wires live GitService / ContentProvider / EditorHandoff behind traits
+          │
+   event loop (app::run):  draw → poll input → handle(intent) → drain finished renders → repeat
+```
+
+**Rendering is off the input thread.** Selecting a file *dispatches* a render job to a worker
+thread (`std::thread` + `mpsc`); `handle()` returns immediately so input never blocks on a slow
+external renderer. The finished text arrives later and is drained by `Controller::poll()` each
+tick. Jobs carry a monotonic sequence so a stale render for a file the user has left is dropped.
+A renderer panic is contained (`catch_unwind`) so the worker survives. No `tokio`.
+
+## Load-bearing decisions
+
+- **Read-only.** The viewer never mutates a file or the git repository. The editor path is a
+  hand-off to an external process. Every `git` invocation uses read-only subcommands.
+- **Delegate rendering.** Markdown, diffs, and syntax highlighting are produced by best-in-class
+  external CLIs (`glow`, `delta`, `bat`) — the viewer builds only the shell and ingests their
+  ANSI output. Each renderer is optional; a missing one degrades to plain text + a notice.
+- **Git is first-class**, woven through the tree (status markers, colors, changed-only filter,
+  baseline toggle) and the content pane (diff view) — not a separate mode.
+- **In-memory, ephemeral state only.** No persistent store; the filesystem and git repo are the
+  read-only source of truth.
+
+## Trust boundaries
+
+Three untrusted inputs are handled defensively (see [SECURITY.md](SECURITY.md)):
+
+1. **File content** is untrusted — fed to renderers on **stdin** (never as an argument), and the
+   renderer output is re-sanitized so no escape sequence can drive the terminal.
+2. **The git repository** may be untrusted (an agent's worktree, a clone) — every `git`
+   invocation is hardened against repo-controlled code execution (no external diff/textconv,
+   neutralized `core.fsmonitor`/`core.hooksPath`, scrubbed repo-redirecting env). This hardening
+   lives in **one** shared builder so it cannot drift between callers.
+3. **The herdr-injected context** is parsed defensively and degrades to a minimal default.
+
+## Tests
+
+`cargo test` runs unit tests, integration tests, and end-to-end tests that drive the real binary
+over a pseudo-terminal (`expectrl`), plus ratatui `TestBackend` snapshot tests (`insta`). The e2e
+tests stub the editor via `$EDITOR` and run in temp directories, so they need neither the
+external renderers nor a live herdr.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All notable changes to this project are documented here. The format is based on
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - 2026-06-22
+
+First public release: a git-aware, read-only file viewer that runs as a herdr plugin pane.
+
+### Added
+- **Tree, scoped to your work** — rooted at the git worktree top-level (else the launch
+  directory), honoring `.gitignore` with a toggle to reveal ignored files.
+- **Git woven in** — per-file status markers (`M`/`A`/`D`/`?`) with color, a changed-files-only
+  filter, and a baseline you can toggle between your branch's merge-base and `HEAD`.
+- **The right view per file** — a changed file shows its diff; markdown renders; everything else
+  is syntax-highlighted with line numbers. Cycle the view (`v`), including a **full-file diff**
+  (whole file + line numbers + inline change).
+- **Navigable content** — scroll all four directions, toggle line wrapping (`w`), resize the
+  split (`<` / `>`), and **zoom** (`z`) to hide the tree for a full-screen read.
+- **Activate** (`Enter` / double-click) — expand a folder, or open a file in zoom mode.
+- **Open in `$EDITOR`** (`e`) — a read-only hand-off; the viewer never edits the file itself.
+- **Keyboard-first**, with additive mouse support (click, double-click, wheel, divider drag).
+- **Two ways to summon it** — a split-pane action and an idempotent tab action
+  (open-or-switch-or-toggle).
+- **Delegated rendering** to `glow` / `delta` / `bat`, each optional with graceful plain-text
+  fallback and a notice when a renderer is absent.
+- **Refresh** (`r`) and automatic git re-read on focus-gain, so external changes (a merge, pull,
+  or commit elsewhere) show up.
+
+### Security
+- Read-only by construction; untrusted file content is escape-neutralized and fed to renderers
+  on stdin; every `git` invocation is hardened for untrusted repositories. See
+  [SECURITY.md](SECURITY.md).
+
+[1.0.0]: https://github.com/smarzban/herdr-plugin-file-viewer/releases/tag/v1.0.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -574,7 +574,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "herdr-file-viewer"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "ansi-to-tui",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,16 @@
 [package]
 name = "herdr-file-viewer"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2024"
 rust-version = "1.96"
 description = "A git-aware, read-only file viewer that runs as a herdr TUI pane"
 license = "MIT"
+authors = ["Saeed Marzban <git@smarzban.com>"]
+repository = "https://github.com/smarzban/herdr-plugin-file-viewer"
+homepage = "https://github.com/smarzban/herdr-plugin-file-viewer"
+readme = "README.md"
+keywords = ["herdr", "tui", "git", "viewer", "ratatui"]
+categories = ["command-line-utilities", "development-tools"]
 
 [lib]
 name = "herdr_file_viewer"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Saeed Marzban
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,49 @@
+# Security
+
+`herdr-file-viewer` is a **read-only** viewer that routinely opens **untrusted** content: the
+files and git repositories it browses may be an agent's worktree, a fresh clone, or anything a
+collaborator handed you. Its security posture is built around that.
+
+## Threat model & mitigations
+
+- **Read-only by construction.** The viewer never writes a file or mutates the git repository.
+  Every `git` call uses read-only subcommands; opening a file in an editor is a hand-off to an
+  external process, not an in-app edit.
+
+- **Untrusted file content → terminal-control neutralization.** All file bytes are treated as
+  hostile. Content is fed to the external renderers on **stdin** (never as a command argument, so
+  a file name can't inject), and the result is run through an escape-sequence neutralizer before
+  display: cursor-movement, screen-control, OSC, C1, and other control sequences are stripped;
+  only SGR (color/style) is kept and mapped to ratatui styles. A malicious file therefore cannot
+  move the cursor, clear the screen, set the window title, or otherwise drive the terminal — it
+  can only paint text inside the viewer's own region.
+
+- **Untrusted repository → hardened git invocations.** Because the opened repo may be hostile,
+  every `git` command is hardened against repo-controlled code execution: `--no-ext-diff` /
+  `--no-textconv` refuse repo-configured diff/textconv programs, `--attr-source` reads attributes
+  from the empty tree (so a planted `.gitattributes` can't designate a filter/diff driver),
+  `core.fsmonitor` and `core.hooksPath` are neutralized, `GIT_OPTIONAL_LOCKS=0` prevents index
+  writes, and repo-redirecting environment variables (`GIT_DIR`, `GIT_WORK_TREE`, …) are scrubbed.
+  This hardening lives in a single shared builder so it cannot drift between callers.
+
+- **Injection guards.** Host-supplied pane ids are validated before they reach an argv (so a
+  flag-like id can't option-inject the herdr CLI). Paths are passed to `git` as raw `OsStr`
+  arguments after a within-root check (no traversal above the root, no arbitrary reads).
+
+- **Resource bounds.** File reads and captured renderer/diff output are size-capped, and external
+  renderers run under a wall-clock timeout, so a huge or slow input degrades gracefully rather
+  than hanging or exhausting memory.
+
+- **Crash containment.** A renderer failure (including a panic on the render worker) is contained
+  and surfaced as a non-fatal notice/placeholder; the viewer never crashes on bad input.
+
+## Reporting a vulnerability
+
+Please report suspected vulnerabilities privately rather than opening a public issue:
+
+- Open a **GitHub private security advisory** ("Security" → "Report a vulnerability") on this
+  repository, **or**
+- Email **git@smarzban.com** with details and reproduction steps.
+
+You'll get an acknowledgement, and a fix or mitigation plan once the report is triaged. Thank you
+for helping keep the viewer safe.

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -6,7 +6,7 @@
 
 id = "herdr-file-viewer"
 name = "herdr-file-viewer"
-version = "0.1.0"
+version = "1.0.0"
 description = "A git-aware, read-only file viewer: a keyboard-driven TUI in a herdr split pane."
 min_herdr_version = "0.7.0"
 platforms = ["linux", "macos"]

--- a/scripts/install-renderers.sh
+++ b/scripts/install-renderers.sh
@@ -58,16 +58,33 @@ install_one() {
   fi
   local pkg; pkg="$(pkg_name "$tool")"
   if [ -n "$PM" ] && [ -n "$pkg" ] && pm_install "$pkg"; then
-    echo "✓ installed $tool via $PM ($pkg)"
-    return 0
+    # On Debian/Ubuntu the bat package installs its binary as `batcat`, not `bat` (the name
+    # the viewer looks for). Bridge it via a symlink in ~/.local/bin.
+    if [ "$tool" = "bat" ] && ! have bat && have batcat; then
+      mkdir -p "$HOME/.local/bin"
+      ln -sf "$(command -v batcat)" "$HOME/.local/bin/bat"
+      if have bat; then
+        echo "✓ installed bat via $PM (bridged 'batcat' → ~/.local/bin/bat)"
+      else
+        echo "✓ installed bat via $PM as 'batcat', symlinked to ~/.local/bin/bat — add ~/.local/bin to PATH to use it"
+      fi
+      return 0
+    fi
+    # Confirm the binary is actually on PATH before claiming success (a package can install
+    # under a different name, as bat does above).
+    if have "$bin"; then
+      echo "✓ installed $tool via $PM ($pkg)"
+      return 0
+    fi
+    echo "… '$pkg' installed via $PM but '$bin' is not on PATH; trying alternatives"
   fi
   # Fall back to cargo where possible.
   local cp; cp="$(cargo_pkg "$tool")"
   if [ -n "$cp" ] && have cargo; then
-    echo "… $tool not available via ${PM:-a system package manager}; trying cargo install $cp"
-    if cargo install "$cp"; then echo "✓ installed $tool via cargo ($cp)"; return 0; fi
+    echo "… trying cargo install $cp"
+    if cargo install "$cp" && have "$bin"; then echo "✓ installed $tool via cargo ($cp)"; return 0; fi
   fi
-  echo "✗ could not auto-install $tool — install it manually:"
+  echo "✗ could not put '$bin' on PATH for $tool — install it manually:"
   case "$tool" in
     glow)  echo "    https://github.com/charmbracelet/glow#installation" ;;
     delta) echo "    https://github.com/dandavison/delta#installation  (or: cargo install git-delta)" ;;

--- a/scripts/install-renderers.sh
+++ b/scripts/install-renderers.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Install the viewer's OPTIONAL external renderers — glow (markdown), delta (diffs),
+# bat (syntax) — using whatever package manager this machine has.
+#
+# These are runtime, install-time dependencies, NOT Cargo deps. The viewer works without
+# them (it falls back to plain text + a notice), so this script is a convenience, never a
+# requirement. It is idempotent: already-installed renderers are skipped. It never uses sudo
+# implicitly — system package managers are invoked with sudo only where they need it, and you
+# can read exactly what runs below.
+set -u
+
+have() { command -v "$1" >/dev/null 2>&1; }
+
+# --- detect a package manager (first match wins) ------------------------------------------
+PM=""
+if have brew; then PM="brew"
+elif have apt-get; then PM="apt"
+elif have dnf; then PM="dnf"
+elif have pacman; then PM="pacman"
+fi
+
+# Map a renderer to its package name for the detected manager. Empty = "not packaged here".
+pkg_name() {
+  local tool="$1"
+  case "$PM:$tool" in
+    brew:glow|apt:glow|dnf:glow|pacman:glow) echo "glow" ;;
+    brew:delta|apt:delta|dnf:delta|pacman:delta) echo "git-delta" ;;
+    brew:bat|apt:bat|dnf:bat|pacman:bat) echo "bat" ;;
+    *) echo "" ;;
+  esac
+}
+
+pm_install() {
+  local pkg="$1"
+  case "$PM" in
+    brew)   brew install "$pkg" ;;
+    apt)    sudo apt-get update -qq && sudo apt-get install -y "$pkg" ;;
+    dnf)    sudo dnf install -y "$pkg" ;;
+    pacman) sudo pacman -S --noconfirm "$pkg" ;;
+    *) return 1 ;;
+  esac
+}
+
+# cargo fallback for the two renderers that ship as crates (glow is Go — no cargo install).
+cargo_pkg() {
+  case "$1" in
+    delta) echo "git-delta" ;;
+    bat)   echo "bat" ;;
+    *)     echo "" ;;
+  esac
+}
+
+install_one() {
+  local tool="$1" bin="$2"   # bin = the command name to test for (delta/bat/glow)
+  if have "$bin"; then
+    echo "✓ $tool already installed ($(command -v "$bin"))"
+    return 0
+  fi
+  local pkg; pkg="$(pkg_name "$tool")"
+  if [ -n "$PM" ] && [ -n "$pkg" ] && pm_install "$pkg"; then
+    echo "✓ installed $tool via $PM ($pkg)"
+    return 0
+  fi
+  # Fall back to cargo where possible.
+  local cp; cp="$(cargo_pkg "$tool")"
+  if [ -n "$cp" ] && have cargo; then
+    echo "… $tool not available via ${PM:-a system package manager}; trying cargo install $cp"
+    if cargo install "$cp"; then echo "✓ installed $tool via cargo ($cp)"; return 0; fi
+  fi
+  echo "✗ could not auto-install $tool — install it manually:"
+  case "$tool" in
+    glow)  echo "    https://github.com/charmbracelet/glow#installation" ;;
+    delta) echo "    https://github.com/dandavison/delta#installation  (or: cargo install git-delta)" ;;
+    bat)   echo "    https://github.com/sharkdp/bat#installation  (or: cargo install bat)" ;;
+  esac
+  return 1
+}
+
+echo "herdr-file-viewer — optional renderers"
+if [ -n "$PM" ]; then echo "package manager: $PM"; else echo "no supported package manager found (brew/apt/dnf/pacman) — will try cargo where possible"; fi
+echo
+
+rc=0
+install_one glow  glow  || rc=1
+install_one delta delta || rc=1
+install_one bat   bat   || rc=1
+
+echo
+if [ "$rc" -eq 0 ]; then
+  echo "All renderers available — you'll get rendered markdown, syntax-highlighted diffs, and code."
+else
+  echo "Some renderers are missing; the viewer still works (plain text + a notice for those views)."
+fi
+exit 0


### PR DESCRIPTION
Prepares the repo for a public **v1.0.0** release. No source-behavior change.

## Added
- **LICENSE** — MIT text (Cargo.toml declared `license = "MIT"` but shipped no file).
- **Cargo.toml + herdr-plugin.toml** — bump to `1.0.0`; add `repository`, `homepage`, `readme`, `authors`, `keywords`, `categories`.
- **.github/workflows/ci.yml** — `rustfmt --check` + `clippy -D warnings` + a test matrix (ubuntu & macOS × {1.96 MSRV, stable}) + `cargo-audit`.
- **ARCHITECTURE.md** — design rationale + component map (recovers what the now-local-only specs/ADRs covered, for public readers).
- **SECURITY.md** — the read-only / escape-neutralization / untrusted-repo-hardening posture + how to report.
- **CHANGELOG.md** — the 1.0.0 entry (Keep a Changelog).
- **scripts/install-renderers.sh** — optional, best-effort installer for glow/delta/bat (brew/apt/dnf/pacman + cargo fallback; idempotent; never required).

## Verification
- `cargo metadata` parses; `cargo build` green; all 23 test binaries pass; `fmt --check` + `clippy -D warnings` clean; `bash -n` on the script clean.
- The repository URL points at the post-rename name (`herdr-plugin-file-viewer`), which becomes valid when the repo is renamed before going public.

Reviewed by opus per the lightweight-change rule (docs/config/CI, no source behavior).