### PR TITLE
fix(install): make the build step find cargo (source ~/.cargo/env)

### DIFF
--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -11,9 +11,12 @@ description = "A git-aware, read-only file viewer: a keyboard-driven TUI in a he
 min_herdr_version = "0.7.0"
 platforms = ["linux", "macos"]
 
-# Build step herdr runs at install time to produce the binary the pane launches.
+# Build step herdr runs at install time to produce the binary the pane launches. It is wrapped
+# in a shell that sources ~/.cargo/env first, so the build finds `cargo` even when herdr was
+# launched from a context that doesn't have ~/.cargo/bin on PATH (e.g. a GUI / login-less
+# launch) — otherwise `cargo build` fails to start with "No such file or directory".
 [[build]]
-command = ["cargo", "build", "--release"]
+command = ["/bin/sh", "-c", ". \"$HOME/.cargo/env\" 2>/dev/null; cargo build --release"]
 
 # The viewer pane. herdr performs the split placement on launch (AC-17); no runtime
 # command is issued to open the viewer — declaring placement = "split" is what opens

--- a/tests/manifest.rs
+++ b/tests/manifest.rs
@@ -92,7 +92,7 @@ fn declares_a_release_build_command() {
         "manifest must declare a [[build]] step"
     );
     assert!(
-        m.contains(r#"command = ["cargo", "build", "--release"]"#),
+        m.contains("cargo build --release"),
         "the build step must run `cargo build --release`"
     );
 }


### PR DESCRIPTION
**Real install failure hit on first macOS install:** `herdr plugin install` died with `failed to start: No such file or directory (os error 2)` running `cargo build --release` — herdr's PATH didn't include `~/.cargo/bin` (common when herdr is launched outside a shell that sourced `~/.cargo/env`, e.g. a GUI launch). The install preview was correct; it couldn't *launch* cargo.

**Fix:** wrap the build step in `/bin/sh -c '. "$HOME/.cargo/env" 2>/dev/null; cargo build --release'` so it sources rustup's env and finds `cargo` regardless of how herdr was launched. Harmless where cargo is already on PATH; helps every rustup user.

Verified locally: the command builds (exit 0), `herdr plugin link` still parses the manifest, manifest test updated to a substring assertion, fmt/clippy clean.