### PR TITLE
fix(viewer): root the tree at the invoking pane's dir, not the plugin's

### DIFF
--- a/src/host.rs
+++ b/src/host.rs
@@ -36,10 +36,13 @@ pub fn parse_context(json: Option<&str>, fallback_cwd: PathBuf) -> LaunchContext
     let raw: RawContext = json
         .and_then(|s| serde_json::from_str(s).ok())
         .unwrap_or_default();
+    // Ignore empty-string fields (a malformed host value) so they fall through to the next
+    // candidate / the process-cwd fallback rather than rooting at an empty path.
     let cwd = raw
         .focused_pane_cwd
-        .or(raw.workspace_cwd)
-        .or(raw.cwd)
+        .filter(|s| !s.is_empty())
+        .or(raw.workspace_cwd.filter(|s| !s.is_empty()))
+        .or(raw.cwd.filter(|s| !s.is_empty()))
         .map(PathBuf::from)
         .unwrap_or(fallback_cwd);
     LaunchContext {

--- a/src/host.rs
+++ b/src/host.rs
@@ -11,6 +11,13 @@ use std::path::PathBuf;
 /// object degrades gracefully rather than failing to parse; unknown fields are ignored.
 #[derive(Deserialize, Default)]
 struct RawContext {
+    /// herdr 0.7.0 reports the invoking pane's directory as `focused_pane_cwd` and the
+    /// workspace root as `workspace_cwd`; a plain `cwd` is accepted as a fallback. The viewer
+    /// roots at the most specific of these so the tree shows the directory the user is in — not
+    /// the plugin's own install dir, where the pane process is actually started (the pane
+    /// command is a relative path, so herdr launches it from the plugin root).
+    focused_pane_cwd: Option<String>,
+    workspace_cwd: Option<String>,
     cwd: Option<String>,
     base_branch: Option<String>,
 }
@@ -29,8 +36,14 @@ pub fn parse_context(json: Option<&str>, fallback_cwd: PathBuf) -> LaunchContext
     let raw: RawContext = json
         .and_then(|s| serde_json::from_str(s).ok())
         .unwrap_or_default();
+    let cwd = raw
+        .focused_pane_cwd
+        .or(raw.workspace_cwd)
+        .or(raw.cwd)
+        .map(PathBuf::from)
+        .unwrap_or(fallback_cwd);
     LaunchContext {
-        cwd: raw.cwd.map(PathBuf::from).unwrap_or(fallback_cwd),
+        cwd,
         base_branch: raw.base_branch,
     }
 }

--- a/tests/host_context.rs
+++ b/tests/host_context.rs
@@ -62,3 +62,23 @@ fn workspace_cwd_is_the_fallback_when_no_focused_pane_cwd() {
     );
     assert_eq!(ctx.cwd, PathBuf::from("/ws"));
 }
+
+#[test]
+fn focused_pane_cwd_wins_over_a_co_present_legacy_cwd() {
+    // Precedence is the whole point of the change: the invoking pane's dir beats a bare `cwd`.
+    let ctx = parse_context(
+        Some(r#"{"focused_pane_cwd":"/a","cwd":"/b"}"#),
+        PathBuf::from("/fallback"),
+    );
+    assert_eq!(ctx.cwd, PathBuf::from("/a"));
+}
+
+#[test]
+fn an_empty_cwd_field_is_ignored_in_favor_of_the_fallback() {
+    // A malformed host value (empty string) must not root at an empty path.
+    let ctx = parse_context(
+        Some(r#"{"focused_pane_cwd":""}"#),
+        PathBuf::from("/fallback"),
+    );
+    assert_eq!(ctx.cwd, PathBuf::from("/fallback"));
+}

--- a/tests/host_context.rs
+++ b/tests/host_context.rs
@@ -42,3 +42,23 @@ fn from_env_without_context_is_cwd_only() {
     assert_eq!(ctx.cwd, std::env::current_dir().unwrap());
     assert_eq!(ctx.base_branch, None);
 }
+
+#[test]
+fn focused_pane_cwd_is_used_as_the_root() {
+    // herdr 0.7.0's real context shape names the invoking pane's directory `focused_pane_cwd`
+    // (not `cwd`). The viewer must root there — not at its own process cwd (the fallback),
+    // which is the plugin's install dir. Regression test for the "tree shows the plugin's own
+    // files" bug.
+    let json = r#"{"workspace_cwd":"/ws","focused_pane_cwd":"/work/project","tab_id":"wE:tD"}"#;
+    let ctx = parse_context(Some(json), PathBuf::from("/plugin-dir"));
+    assert_eq!(ctx.cwd, PathBuf::from("/work/project"));
+}
+
+#[test]
+fn workspace_cwd_is_the_fallback_when_no_focused_pane_cwd() {
+    let ctx = parse_context(
+        Some(r#"{"workspace_cwd":"/ws"}"#),
+        PathBuf::from("/plugin-dir"),
+    );
+    assert_eq!(ctx.cwd, PathBuf::from("/ws"));
+}


### PR DESCRIPTION
**Bug (hit on first real use):** the file tree showed the viewer's *own* install directory instead of the directory the user invoked it from.

**Cause:** herdr starts the pane from the plugin root (the `[[panes]]` command is a relative path `./target/release/…`), so the viewer's process cwd is the plugin dir. It fell back to that because it looked for a `cwd` field in `HERDR_PLUGIN_CONTEXT_JSON` — but **herdr 0.7.0 actually provides the invoking pane's directory as `focused_pane_cwd`** (and the workspace root as `workspace_cwd`). Confirmed by dumping the real injected context.

**Fix:** read `focused_pane_cwd` → `workspace_cwd` → `cwd` → process cwd (most specific wins). One-field change in the host-context parser; no launcher change needed (herdr already injects the right info).

**Verified live in herdr:** opened the viewer next to a pane in a marker dir → the tree shows that dir's files (`PROJECT_MARKER.txt`, `notes.md`, `src/`), not the plugin's. Plus unit tests for the real 0.7.0 context shape. fmt/clippy clean, all tests green.