### PR TITLE
fix(install): clear 'install Rust' error + harden the build step

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ right into the tree. It opens beside whatever you're doing and never touches you
 
 ## Quick start
 
+> **Prerequisite: [Rust](https://rustup.rs) 1.96+.** The plugin compiles from source at install
+> time, so `cargo` must be on your PATH. No Rust yet?
+> `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh` (or `brew install rust`).
+> If it's missing, the install fails with a message telling you exactly this.
+
 ```bash
 # 1. Install the plugin (herdr builds it from source at install time):
 herdr plugin install smarzban/herdr-file-viewer

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -11,12 +11,13 @@ description = "A git-aware, read-only file viewer: a keyboard-driven TUI in a he
 min_herdr_version = "0.7.0"
 platforms = ["linux", "macos"]
 
-# Build step herdr runs at install time to produce the binary the pane launches. It is wrapped
-# in a shell that sources ~/.cargo/env first, so the build finds `cargo` even when herdr was
-# launched from a context that doesn't have ~/.cargo/bin on PATH (e.g. a GUI / login-less
-# launch) — otherwise `cargo build` fails to start with "No such file or directory".
+# Build step herdr runs at install time to produce the binary the pane launches. Wrapped in a
+# shell that (1) sources ~/.cargo/env if present, so the build finds `cargo` even when herdr was
+# launched without ~/.cargo/bin on PATH (e.g. a GUI / login-less launch) — the `[ -f ]` guard
+# means a missing env file can't abort the build; and (2) if `cargo` still isn't found, prints a
+# clear "install Rust" message and exits, instead of a cryptic failure.
 [[build]]
-command = ["/bin/sh", "-c", ". \"$HOME/.cargo/env\" 2>/dev/null; cargo build --release"]
+command = ["/bin/sh", "-c", "[ -f \"$HOME/.cargo/env\" ] && . \"$HOME/.cargo/env\"; command -v cargo >/dev/null 2>&1 || { echo 'herdr-file-viewer needs Rust 1.96+ to build, but cargo was not found. Install Rust from https://rustup.rs then re-run: herdr plugin install smarzban/herdr-file-viewer' >&2; exit 1; }; exec cargo build --release"]
 
 # The viewer pane. herdr performs the split placement on launch (AC-17); no runtime
 # command is issued to open the viewer — declaring placement = "split" is what opens

--- a/tests/manifest.rs
+++ b/tests/manifest.rs
@@ -95,6 +95,10 @@ fn declares_a_release_build_command() {
         m.contains("cargo build --release"),
         "the build step must run `cargo build --release`"
     );
+    assert!(
+        m.contains(".cargo/env"),
+        "the build step must source ~/.cargo/env so it finds cargo regardless of how herdr launched it"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Follow-up to the cargo-PATH fix, after seeing a real user hit a cryptic `exit status: 1` with no Rust installed.

- **Clear error when Rust is missing:** the build step now checks for `cargo` and, if absent, prints `herdr-file-viewer needs Rust 1.96+ … install from https://rustup.rs then reinstall` and exits — instead of a mystery failure.
- **Hardened the env source:** `[ -f "$HOME/.cargo/env" ] && . …` so a *missing* env file can't abort the build (helps non-rustup installs).
- **README:** Quick start now leads with the **Rust 1.96+ prerequisite** (the plugin compiles at install).

Verified locally: happy path builds; error path prints the message + exits 1; `herdr plugin link` still parses the manifest; manifest test now also guards the env-source; fmt/clippy clean.