### PR TITLE
feat: update-available notification (v1.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2026-06-22
+
+### Added
+- **Update-available notification** — the viewer checks for a newer release (at most once per
+  day, off the UI thread, over a read-only `git ls-remote`) and, when you're behind, shows a
+  dismissable bottom status-line banner with the one-line update command. Press `u` to dismiss
+  it for the session. Opt out entirely with `HERDR_FILE_VIEWER_NO_UPDATE_CHECK=1`. No new
+  dependencies, no telemetry.
+
+### Docs
+- Clarified updating: re-running `herdr plugin install …` pulls the latest; `--ref` only pins a
+  specific version and is no longer presented as part of the normal install.
+
 ## [1.0.0] - 2026-06-22
 
 First public release: a git-aware, read-only file viewer that runs as a herdr plugin pane.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -574,7 +574,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "herdr-file-viewer"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "ansi-to-tui",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "herdr-file-viewer"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2024"
 rust-version = "1.96"
 description = "A git-aware, read-only file viewer that runs as a herdr TUI pane"

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ the launcher's open/focus/toggle behavior, the full key map, and the `--remote` 
 | `w` | Toggle line wrapping for the content pane |
 | `z` | Zoom — hide the tree so the content pane fills the frame; press again (or `q`/`Esc`) to restore the two-column layout |
 | `r` | Refresh git state — pick up changes made outside the viewer (a merge / pull / commit elsewhere) |
+| `u` | Dismiss the "update available" banner for this session |
 | `q` / `Esc` | Back out of zoom if zoomed; otherwise close the viewer and return to the prior pane |
 
 `Tab` to the content pane, then the arrow keys (or `h`/`j`/`k`/`l`) scroll it in all four
@@ -159,9 +160,9 @@ Requirements: **Rust 1.96+** (edition 2024) and Cargo; **herdr 0.7.0+**, on **Li
 which the viewer pane launches:
 
 ```bash
-# install from this GitHub repo (latest main):
+# install (and update — re-run any time to get the latest):
 herdr plugin install smarzban/herdr-file-viewer
-# …or pin a specific release for reproducibility:
+# …optional: pin a specific older version for reproducibility:
 herdr plugin install smarzban/herdr-file-viewer --ref v1.0.0
 
 # or, for local development, link this checkout in place:
@@ -169,11 +170,34 @@ cargo build --release            # plugin link does NOT run the [[build]] step, 
 herdr plugin link /path/to/herdr-file-viewer
 ```
 
+> You don't need `--ref` to stay current — a bare install pulls the latest. See
+> [Updating](#updating).
+
 Confirm it registered with `herdr plugin list`. To build manually outside herdr:
 
 ```bash
 cargo build --release
 ```
+
+## Updating
+
+herdr has no plugin auto-update, so the viewer tells you when a new release exists: open it
+(`prefix+f`) and, if you're behind, a status line appears at the bottom naming the new version
+and the command to update. Press `u` to dismiss it for the session.
+
+To update, just re-run the install — it pulls the latest:
+
+```bash
+herdr plugin install smarzban/herdr-file-viewer
+```
+
+- You **don't** need `--ref` to stay current; it only *pins* a specific version (and a pin stays
+  pinned until you change it).
+- Want a heads-up the moment a release ships? On GitHub, **Watch → Custom → Releases**.
+- Prefer no network check? Set `HERDR_FILE_VIEWER_NO_UPDATE_CHECK=1` in the pane's environment —
+  the check (and banner) are disabled entirely. The check otherwise runs at most once per 24h,
+  off the UI thread, over a read-only `git ls-remote`, and never blocks or fails the viewer when
+  offline.
 
 ## Optional runtime dependencies (external renderers)
 

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -6,7 +6,7 @@
 
 id = "herdr-file-viewer"
 name = "herdr-file-viewer"
-version = "1.0.0"
+version = "1.1.0"
 description = "A git-aware, read-only file viewer: a keyboard-driven TUI in a herdr split pane."
 min_herdr_version = "0.7.0"
 platforms = ["linux", "macos"]

--- a/src/app.rs
+++ b/src/app.rs
@@ -72,6 +72,9 @@ pub fn run() -> io::Result<()> {
             editor,
         },
     );
+    // Kick off the once-a-day update check (off the UI thread; disabled by
+    // HERDR_FILE_VIEWER_NO_UPDATE_CHECK). The banner, if any, appears on a later draw.
+    controller.set_update(crate::update::start_default());
 
     let mut terminal = ratatui::try_init()?;
     // Mouse is additive to the keyboard-first design (AC-18): herdr forwards mouse events to a

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -20,6 +20,7 @@ use crate::git::{Baseline, Status};
 use crate::intent::Intent;
 use crate::presenter::{Focus, PaneGeometry, ViewState};
 use crate::tree::{Node, NodeKind, TreeModel};
+use crate::update::{self, UpdateState, Version};
 use crate::view_policy::{FileDescriptor, ViewMode, applicable_modes, default_mode};
 use crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 use ratatui::layout::Position;
@@ -185,6 +186,14 @@ pub struct Controller {
     /// True while the left button is held after pressing on the divider (a resize drag), so the
     /// release is treated as the end of the drag, not a click.
     dragging_divider: bool,
+    /// The newer version to advertise, if any (set from the cached value at startup and
+    /// refreshed by the background check). `None` ⇒ up-to-date / unknown.
+    update_available: Option<Version>,
+    /// Hides the banner for the rest of this session (the `u` key). Not persisted — it returns
+    /// next launch while still behind.
+    update_dismissed: bool,
+    /// One-shot receiver for the background update check's result (`None` when no check ran).
+    update_rx: Option<mpsc::Receiver<Option<Version>>>,
 }
 
 impl Controller {
@@ -274,6 +283,9 @@ impl Controller {
             geom: PaneGeometry::default(),
             last_click: None,
             dragging_divider: false,
+            update_available: None,
+            update_dismissed: false,
+            update_rx: None,
         };
         ctrl.refresh_git_state();
         ctrl.dispatch_render();
@@ -330,6 +342,14 @@ impl Controller {
         self.width = width;
     }
 
+    /// Install the update-check result: the initial (cached) banner value plus the receiver the
+    /// background probe will deliver a refreshed result on. Called once by the run loop after
+    /// construction; absent ⇒ no banner (so existing call sites/tests are unaffected).
+    pub fn set_update(&mut self, state: UpdateState) {
+        self.update_available = state.initial;
+        self.update_rx = state.rx;
+    }
+
     /// Record the content viewport `(width, height)` the Presenter last drew into, so content
     /// scrolling can be clamped to it. Called by the run loop after each draw.
     pub fn set_content_viewport(&mut self, width: u16, height: u16) {
@@ -377,6 +397,7 @@ impl Controller {
             wrap,
             split_pct: self.split_pct,
             zoomed: self.zoomed,
+            update_banner: self.update_banner(),
         }
     }
 
@@ -421,6 +442,7 @@ impl Controller {
             Intent::ToggleWrap => self.toggle_wrap(),
             Intent::ToggleZoom => self.toggle_zoom(),
             Intent::Refresh => self.refresh(),
+            Intent::DismissUpdate => self.dismiss_update(),
             Intent::Close => self.close_or_unzoom(),
         }
     }
@@ -864,6 +886,24 @@ impl Controller {
         Effects::redraw()
     }
 
+    /// Hide the update banner for this session (the `u` key). Inert when no banner is showing,
+    /// so the key does nothing (no wasted repaint) until an update is actually available.
+    fn dismiss_update(&mut self) -> Effects {
+        if self.update_available.is_some() && !self.update_dismissed {
+            self.update_dismissed = true;
+            return Effects::redraw();
+        }
+        Effects::noop()
+    }
+
+    /// The update-banner text to display, or `None` when up-to-date, dismissed, or unknown.
+    fn update_banner(&self) -> Option<String> {
+        if self.update_dismissed {
+            return None;
+        }
+        self.update_available.as_ref().map(update::banner_text)
+    }
+
     /// The pane regained focus (the run loop forwards herdr's focus events): re-read git state
     /// so external changes show in the tree. No-op without a repo (AC-26) — so an external
     /// change to a non-git directory costs nothing. In **changed-only** mode the refresh
@@ -950,6 +990,16 @@ impl Controller {
                 applied = true;
             }
             // else: a superseded selection's render — drop it.
+        }
+        // A finished background update check (one-shot): adopt its verdict and drop the
+        // receiver. `Some(v)` shows/refreshes the banner; `None` (a successful check that found
+        // nothing newer) clears a now-stale cached banner.
+        if let Some(rx) = &self.update_rx
+            && let Ok(version) = rx.try_recv()
+        {
+            self.update_available = version;
+            self.update_rx = None;
+            applied = true;
         }
         applied.then(Effects::redraw)
     }

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -991,15 +991,20 @@ impl Controller {
             }
             // else: a superseded selection's render — drop it.
         }
-        // A finished background update check (one-shot): adopt its verdict and drop the
-        // receiver. `Some(v)` shows/refreshes the banner; `None` (a successful check that found
-        // nothing newer) clears a now-stale cached banner.
-        if let Some(rx) = &self.update_rx
-            && let Ok(version) = rx.try_recv()
-        {
-            self.update_available = version;
-            self.update_rx = None;
-            applied = true;
+        // A finished background update check (one-shot): adopt its verdict and drop the receiver.
+        // `Some(v)` shows/refreshes the banner; `None` (a successful check that found nothing
+        // newer) clears a now-stale cached banner. A *disconnected* channel means the probe failed
+        // and sent nothing — drop the receiver too, so we stop polling a dead channel every tick.
+        if let Some(rx) = &self.update_rx {
+            match rx.try_recv() {
+                Ok(version) => {
+                    self.update_available = version;
+                    self.update_rx = None;
+                    applied = true;
+                }
+                Err(mpsc::TryRecvError::Disconnected) => self.update_rx = None,
+                Err(mpsc::TryRecvError::Empty) => {}
+            }
         }
         applied.then(Effects::redraw)
     }

--- a/src/input.rs
+++ b/src/input.rs
@@ -34,6 +34,7 @@ pub fn map_key(key: KeyEvent) -> Option<Intent> {
         KeyCode::Char('w') => Some(Intent::ToggleWrap),
         KeyCode::Char('z') => Some(Intent::ToggleZoom),
         KeyCode::Char('r') => Some(Intent::Refresh),
+        KeyCode::Char('u') => Some(Intent::DismissUpdate),
         KeyCode::Char('q') | KeyCode::Esc => Some(Intent::Close),
         _ => None,
     }
@@ -70,6 +71,7 @@ mod tests {
         (KeyCode::Char('w'), Intent::ToggleWrap),
         (KeyCode::Char('z'), Intent::ToggleZoom),
         (KeyCode::Char('r'), Intent::Refresh),
+        (KeyCode::Char('u'), Intent::DismissUpdate),
         (KeyCode::Char('q'), Intent::Close),
         (KeyCode::Esc, Intent::Close),
     ];

--- a/src/intent.rs
+++ b/src/intent.rs
@@ -45,6 +45,9 @@ pub enum Intent {
     /// Re-read git state (working-tree status + changed-set) and re-render, so the viewer picks
     /// up changes made outside it — a merge, pull, or commit in another pane. Read-only.
     Refresh,
+    /// Dismiss the "update available" banner for this session (it returns next launch while
+    /// still behind). Read-only — touches only in-memory UI state.
+    DismissUpdate,
     /// Close the viewer and return control to the prior pane (AC-20).
     Close,
 }
@@ -52,7 +55,7 @@ pub enum Intent {
 impl Intent {
     /// Every intent variant — lets the dispatcher and tests enumerate the closed set so
     /// keyboard-completeness (AC-18) and the no-edit invariant (AC-N3) stay checkable.
-    pub const ALL: [Intent; 17] = [
+    pub const ALL: [Intent; 18] = [
         Intent::NavUp,
         Intent::NavDown,
         Intent::Expand,
@@ -69,6 +72,7 @@ impl Intent {
         Intent::ToggleWrap,
         Intent::ToggleZoom,
         Intent::Refresh,
+        Intent::DismissUpdate,
         Intent::Close,
     ];
 }
@@ -102,6 +106,7 @@ mod tests {
                 | Intent::ToggleWrap
                 | Intent::ToggleZoom
                 | Intent::Refresh
+                | Intent::DismissUpdate
                 | Intent::Close => false,
             };
             assert!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod presenter;
 pub mod render;
 pub mod root;
 pub mod tree;
+pub mod update;
 pub mod view_policy;
 
 /// Entry point invoked by the binary. Wires the components and runs the event loop.

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -56,6 +56,9 @@ pub struct ViewState {
     /// Hide the tree and let the content pane fill the whole frame (the `z` zoom toggle).
     /// Overrides the split — and the narrow-layout focus rule — to draw content only.
     pub zoomed: bool,
+    /// When `Some`, a one-row "update available" status line is drawn across the bottom of the
+    /// frame (the columns take the remaining rows). `None` ⇒ no footer, layout unchanged.
+    pub update_banner: Option<String>,
 }
 
 /// The single-character git-status marker shown beside a tree row (AC-7).
@@ -191,6 +194,31 @@ fn draw_content(frame: &mut Frame, area: Rect, state: &ViewState) -> (u16, u16) 
     (parts[1].width, parts[1].height)
 }
 
+/// Split the frame into the body (the two columns) and an optional one-row footer. The footer
+/// is present exactly when an update banner is to be shown (and the frame is tall enough to
+/// spare a row). Shared by [`draw`] and [`geometry`] so the drawn layout and the hit-test
+/// geometry carve the same body rect — a mouse click is never mapped against stale geometry.
+fn body_and_footer(area: Rect, state: &ViewState) -> (Rect, Option<Rect>) {
+    if state.update_banner.is_none() || area.height < 2 {
+        return (area, None);
+    }
+    let parts = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(area);
+    (parts[0], Some(parts[1]))
+}
+
+/// Draw the one-row "update available" status line. Reversed-ish (dark-on-cyan) so it reads as
+/// a status bar; sanitized (defense-in-depth, AC-27) and clipped to its row by ratatui.
+fn draw_update_footer(frame: &mut Frame, area: Rect, banner: &str) {
+    let line = Line::styled(
+        sanitize_label(banner),
+        Style::new()
+            .fg(Color::Black)
+            .bg(Color::Cyan)
+            .add_modifier(Modifier::BOLD),
+    );
+    frame.render_widget(Paragraph::new(line), area);
+}
+
 /// Below this pane width the viewer drops to a single, focused column (AC-21).
 const NARROW_SPLIT: u16 = 80;
 
@@ -237,11 +265,12 @@ pub struct PaneGeometry {
 /// renders, so a click is never mapped against stale geometry. The interior of a bordered
 /// block is its area inset by one cell on each side (the title does not change it).
 pub fn geometry(area: Rect, state: &ViewState) -> PaneGeometry {
-    let (tree, content, divider_x) = columns(area, state);
+    let (body, _footer) = body_and_footer(area, state);
+    let (tree, content, divider_x) = columns(body, state);
     let inner = |r: Rect| Block::bordered().inner(r);
     PaneGeometry {
-        area_x: area.x,
-        area_width: area.width,
+        area_x: body.x,
+        area_width: body.width,
         tree_inner: tree.map(inner),
         content_inner: content.map(inner),
         divider_x,
@@ -257,7 +286,11 @@ pub fn geometry(area: Rect, state: &ViewState) -> PaneGeometry {
 /// taken from the **live frame width** (via [`columns`]), so it can never disagree with the
 /// geometry it is drawn into (a stale `state.width` cannot desync the layout).
 pub fn draw(frame: &mut Frame, state: &ViewState) -> (u16, u16) {
-    let (tree, content, _divider) = columns(frame.area(), state);
+    let (body, footer) = body_and_footer(frame.area(), state);
+    if let (Some(area), Some(banner)) = (footer, state.update_banner.as_deref()) {
+        draw_update_footer(frame, area, banner);
+    }
+    let (tree, content, _divider) = columns(body, state);
     if let Some(area) = tree {
         draw_tree(frame, area, state);
     }

--- a/src/update/cache.rs
+++ b/src/update/cache.rs
@@ -82,13 +82,22 @@ mod tests {
     #[test]
     fn should_check_respects_the_24h_window() {
         let day = CHECK_INTERVAL_SECS;
-        assert!(should_check(1_000 + day, 1_000), "exactly 24h later → check");
+        assert!(
+            should_check(1_000 + day, 1_000),
+            "exactly 24h later → check"
+        );
         assert!(should_check(1_000 + day + 1, 1_000), "past 24h → check");
         assert!(!should_check(1_000 + day - 1, 1_000), "within 24h → skip");
-        assert!(!should_check(0, 0), "zero elapsed → skip (not a check trigger)");
+        assert!(
+            !should_check(0, 0),
+            "zero elapsed → skip (not a check trigger)"
+        );
         // First run carries no cache, so `decide` checks against last=0 with the real (large)
         // clock — which is well past the window.
-        assert!(should_check(1_700_000_000, 0), "real clock vs last=0 → check");
+        assert!(
+            should_check(1_700_000_000, 0),
+            "real clock vs last=0 → check"
+        );
         assert!(
             should_check(100, 9_999),
             "clock went backwards → check, never overflow"

--- a/src/update/cache.rs
+++ b/src/update/cache.rs
@@ -1,0 +1,168 @@
+//! The throttle cache: the timestamp of the last check + the latest version then seen. Lets
+//! the banner show immediately from a prior result while bounding the network to once per 24h.
+//! Stores nothing about the user — only a unix time and a version string.
+
+use crate::update::version::Version;
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+/// Minimum gap between network checks: 24h.
+pub const CHECK_INTERVAL_SECS: u64 = 24 * 60 * 60;
+
+/// The cache file name within the cache dir.
+const CACHE_FILE: &str = "update-check.json";
+
+/// The on-disk cache. Both fields tolerate absence (a fresh/upgraded cache).
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+pub struct Cache {
+    pub last_check_unix: u64,
+    #[serde(default)]
+    pub latest_seen: Option<String>,
+}
+
+/// Whether enough time has elapsed since `last_check_unix` to hit the network again. A
+/// `last_check_unix` in the future (corrupted cache / clock skew) is treated as "check now",
+/// consistent with treating any unreadable cache as a reason to re-check.
+pub fn should_check(now_unix: u64, last_check_unix: u64) -> bool {
+    last_check_unix > now_unix || now_unix - last_check_unix >= CHECK_INTERVAL_SECS
+}
+
+/// The cache to persist after a check attempt. The timestamp always advances (so the 24h
+/// throttle holds even when the network is down); `latest_seen` records the probed version on
+/// success and otherwise preserves whatever was last seen.
+pub fn next_cache(
+    now_unix: u64,
+    previous: &Option<Cache>,
+    probe_succeeded: bool,
+    latest: Option<Version>,
+) -> Cache {
+    let latest_seen = if probe_succeeded {
+        latest.map(|v| v.to_string())
+    } else {
+        previous.as_ref().and_then(|c| c.latest_seen.clone())
+    };
+    Cache {
+        last_check_unix: now_unix,
+        latest_seen,
+    }
+}
+
+/// The plugin's cache directory: `$XDG_CACHE_HOME/herdr-file-viewer`, else
+/// `$HOME/.cache/herdr-file-viewer`. `None` when neither is set (then we check without
+/// persisting — a rare headless case).
+pub fn cache_dir() -> Option<PathBuf> {
+    let base = std::env::var_os("XDG_CACHE_HOME")
+        .map(PathBuf::from)
+        .filter(|p| !p.as_os_str().is_empty())
+        .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".cache")))?;
+    Some(base.join("herdr-file-viewer"))
+}
+
+/// Read and parse the cache; `None` (→ "check now") on any absence/error.
+pub fn load(dir: &Path) -> Option<Cache> {
+    let raw = std::fs::read_to_string(dir.join(CACHE_FILE)).ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
+/// Best-effort persist; creates `dir` if needed. Any error is ignored — a cache we cannot
+/// write just means we check again next launch.
+pub fn store(dir: &Path, cache: &Cache) {
+    let _ = std::fs::create_dir_all(dir);
+    if let Ok(json) = serde_json::to_string(cache) {
+        let _ = std::fs::write(dir.join(CACHE_FILE), json);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::update::version::Version;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    #[test]
+    fn should_check_respects_the_24h_window() {
+        let day = CHECK_INTERVAL_SECS;
+        assert!(should_check(1_000 + day, 1_000), "exactly 24h later → check");
+        assert!(should_check(1_000 + day + 1, 1_000), "past 24h → check");
+        assert!(!should_check(1_000 + day - 1, 1_000), "within 24h → skip");
+        assert!(!should_check(0, 0), "zero elapsed → skip (not a check trigger)");
+        // First run carries no cache, so `decide` checks against last=0 with the real (large)
+        // clock — which is well past the window.
+        assert!(should_check(1_700_000_000, 0), "real clock vs last=0 → check");
+        assert!(
+            should_check(100, 9_999),
+            "clock went backwards → check, never overflow"
+        );
+    }
+
+    #[test]
+    fn next_cache_always_advances_the_timestamp() {
+        let prev = Some(Cache {
+            last_check_unix: 1,
+            latest_seen: Some("1.1.0".into()),
+        });
+        // success with a new version → record it
+        let c = next_cache(500, &prev, true, Version::parse("1.2.0"));
+        assert_eq!(
+            c,
+            Cache {
+                last_check_unix: 500,
+                latest_seen: Some("1.2.0".into())
+            }
+        );
+        // success with no tags → latest_seen cleared
+        let c = next_cache(500, &prev, true, None);
+        assert_eq!(c.latest_seen, None);
+        // probe failure → timestamp advances (throttle holds) but the prior seen value is kept
+        let c = next_cache(500, &prev, false, None);
+        assert_eq!(
+            c,
+            Cache {
+                last_check_unix: 500,
+                latest_seen: Some("1.1.0".into())
+            }
+        );
+        // failure with no prior cache → empty seen
+        let c = next_cache(500, &None, false, None);
+        assert_eq!(
+            c,
+            Cache {
+                last_check_unix: 500,
+                latest_seen: None
+            }
+        );
+    }
+
+    static N: AtomicU64 = AtomicU64::new(0);
+    fn tmp() -> PathBuf {
+        let d = std::env::temp_dir().join(format!(
+            "hfv-cache-{}-{}",
+            std::process::id(),
+            N.fetch_add(1, Ordering::Relaxed)
+        ));
+        let _ = std::fs::remove_dir_all(&d);
+        d
+    }
+
+    #[test]
+    fn store_then_load_round_trips() {
+        let dir = tmp(); // does not exist yet — store must create it
+        let c = Cache {
+            last_check_unix: 42,
+            latest_seen: Some("1.1.0".into()),
+        };
+        store(&dir, &c);
+        assert_eq!(load(&dir), Some(c));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn load_is_none_for_missing_or_corrupt_cache() {
+        let dir = tmp();
+        assert_eq!(load(&dir), None, "missing dir → None (check now)");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join(CACHE_FILE), "{ not json").unwrap();
+        assert_eq!(load(&dir), None, "corrupt → None, never a panic");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/src/update/cache.rs
+++ b/src/update/cache.rs
@@ -27,23 +27,14 @@ pub fn should_check(now_unix: u64, last_check_unix: u64) -> bool {
     last_check_unix > now_unix || now_unix - last_check_unix >= CHECK_INTERVAL_SECS
 }
 
-/// The cache to persist after a check attempt. The timestamp always advances (so the 24h
-/// throttle holds even when the network is down); `latest_seen` records the probed version on
-/// success and otherwise preserves whatever was last seen.
-pub fn next_cache(
-    now_unix: u64,
-    previous: &Option<Cache>,
-    probe_succeeded: bool,
-    latest: Option<Version>,
-) -> Cache {
-    let latest_seen = if probe_succeeded {
-        latest.map(|v| v.to_string())
-    } else {
-        previous.as_ref().and_then(|c| c.latest_seen.clone())
-    };
+/// The cache to persist after a **successful** probe: the check time plus the latest version
+/// seen (`None` when the repo has no stable tags — which clears any stale cached banner). A
+/// *failed* probe must not call this: the cache is left untouched so the check retries next
+/// launch rather than being suppressed for 24h by a transient network blip.
+pub fn next_cache(now_unix: u64, latest: Option<Version>) -> Cache {
     Cache {
         last_check_unix: now_unix,
-        latest_seen,
+        latest_seen: latest.map(|v| v.to_string()),
     }
 }
 
@@ -66,10 +57,18 @@ pub fn load(dir: &Path) -> Option<Cache> {
 
 /// Best-effort persist; creates `dir` if needed. Any error is ignored — a cache we cannot
 /// write just means we check again next launch.
+///
+/// Atomic publish: write a per-process temp file in the same dir, then `rename` it over the
+/// target. herdr is multi-pane, so two viewer instances can write concurrently — a plain
+/// truncating write could be read torn; with rename each reader sees either the old or the new
+/// complete file (last writer wins, never a partial one).
 pub fn store(dir: &Path, cache: &Cache) {
     let _ = std::fs::create_dir_all(dir);
     if let Ok(json) = serde_json::to_string(cache) {
-        let _ = std::fs::write(dir.join(CACHE_FILE), json);
+        let tmp = dir.join(format!("{CACHE_FILE}.{}.tmp", std::process::id()));
+        if std::fs::write(&tmp, json).is_ok() {
+            let _ = std::fs::rename(&tmp, dir.join(CACHE_FILE));
+        }
     }
 }
 
@@ -105,13 +104,9 @@ mod tests {
     }
 
     #[test]
-    fn next_cache_always_advances_the_timestamp() {
-        let prev = Some(Cache {
-            last_check_unix: 1,
-            latest_seen: Some("1.1.0".into()),
-        });
-        // success with a new version → record it
-        let c = next_cache(500, &prev, true, Version::parse("1.2.0"));
+    fn next_cache_records_the_check_time_and_version() {
+        // A successful probe with a version → record the time and the version.
+        let c = next_cache(500, Version::parse("1.2.0"));
         assert_eq!(
             c,
             Cache {
@@ -119,20 +114,9 @@ mod tests {
                 latest_seen: Some("1.2.0".into())
             }
         );
-        // success with no tags → latest_seen cleared
-        let c = next_cache(500, &prev, true, None);
-        assert_eq!(c.latest_seen, None);
-        // probe failure → timestamp advances (throttle holds) but the prior seen value is kept
-        let c = next_cache(500, &prev, false, None);
-        assert_eq!(
-            c,
-            Cache {
-                last_check_unix: 500,
-                latest_seen: Some("1.1.0".into())
-            }
-        );
-        // failure with no prior cache → empty seen
-        let c = next_cache(500, &None, false, None);
+        // A successful probe that found no stable tag → latest_seen cleared (clears a stale
+        // cached banner). (A *failed* probe never reaches here — the caller leaves the cache.)
+        let c = next_cache(500, None);
         assert_eq!(
             c,
             Cache {

--- a/src/update/mod.rs
+++ b/src/update/mod.rs
@@ -12,7 +12,7 @@ pub use version::Version;
 
 use cache::{Cache, next_cache, should_check};
 use std::io::{self, Read};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::mpsc;
 use std::time::Duration;
@@ -55,31 +55,36 @@ pub fn banner_text(v: &Version) -> String {
     )
 }
 
-/// Build the hardened `git ls-remote --tags <url>` command. Constructed separately from
-/// [`run_git_ls_remote`] so the security boundary is unit-testable without shelling out.
+/// Apply the security boundary for invoking `git` against an untrusted environment.
 ///
-/// The viewed repository is **untrusted**, and a `git` process reads the repo-local `.git/config`
-/// of whatever working directory it discovers (URL `insteadOf` rewrites, credential helpers, …) —
-/// so an attacker-planted `.git/config` could otherwise redirect or hijack this once-a-day probe.
-/// We close that hole the way the rest of the viewer treats the repo as untrusted:
-/// - run from a **neutral, non-repo directory** and set `GIT_CEILING_DIRECTORIES` so git never
-///   walks up to *discover* a repo — no repo-local config is read, regardless of where herdr
-///   launched the pane;
-/// - pin the transport to `https` via `GIT_ALLOW_PROTOCOL`, so even a (user-global) URL rewrite
+/// The viewed repository is **untrusted**, and `git` reads the repo-local `.git/config` of
+/// whatever working directory it is in (URL `insteadOf` rewrites, credential helpers, …) — so an
+/// attacker-planted `.git/config` could otherwise redirect or hijack this once-a-day probe. We:
+/// - run in `run_dir`, which the caller guarantees is a **freshly-created private empty dir**
+///   (so it cannot itself contain a `.git/config`), and ceiling discovery to it
+///   (`GIT_CEILING_DIRECTORIES`) so git never walks up to find one — no repo-local config is read,
+///   regardless of where herdr launched the pane;
+/// - pin the transport to `https` (`GIT_ALLOW_PROTOCOL`), so even a (user-global) URL rewrite
 ///   can't redirect to a command-capable transport like `ext::` or `file://`;
-/// - `GIT_TERMINAL_PROMPT=0` so a credential prompt can never block.
+/// - never prompt (`GIT_TERMINAL_PROMPT=0`).
 ///
 /// The user's own global/system config is intentionally kept — it carries legitimate proxy / CA
 /// settings and is in the user's own trust domain (only the *viewed repo* is untrusted).
-fn ls_remote_command(repo_url: &str) -> Command {
-    let neutral = std::env::temp_dir();
-    let mut cmd = Command::new("git");
-    cmd.args(["ls-remote", "--tags", repo_url])
-        .current_dir(&neutral)
-        .env("GIT_CEILING_DIRECTORIES", &neutral)
+fn harden_git(cmd: &mut Command, run_dir: &Path) {
+    cmd.current_dir(run_dir)
+        .env("GIT_CEILING_DIRECTORIES", run_dir)
         .env("GIT_ALLOW_PROTOCOL", "https")
-        .env("GIT_TERMINAL_PROMPT", "0")
-        .env("GIT_HTTP_LOW_SPEED_LIMIT", "1000")
+        .env("GIT_TERMINAL_PROMPT", "0");
+}
+
+/// Build the hardened `git ls-remote --tags <url>` command, run from `run_dir` (see
+/// [`harden_git`]). Constructed separately from [`run_git_ls_remote`] so the security boundary is
+/// unit-testable without shelling out.
+fn ls_remote_command(repo_url: &str, run_dir: &Path) -> Command {
+    let mut cmd = Command::new("git");
+    cmd.args(["ls-remote", "--tags", repo_url]);
+    harden_git(&mut cmd, run_dir);
+    cmd.env("GIT_HTTP_LOW_SPEED_LIMIT", "1000")
         .env("GIT_HTTP_LOW_SPEED_TIME", PROBE_LOW_SPEED_TIME)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
@@ -87,11 +92,23 @@ fn ls_remote_command(repo_url: &str) -> Command {
     cmd
 }
 
-/// Production probe runner: run the hardened [`ls_remote_command`] and return its stdout, bounded
-/// by [`PROBE_TIMEOUT`] so a connect/DNS hang can't wedge or orphan the `git` child. `Err` on
-/// spawn failure, non-zero exit, or timeout — all of which degrade to "no banner".
+/// Production probe runner. Runs the hardened `git ls-remote` from a **freshly-created private,
+/// empty directory** — git reads a `.git/config` in its own cwd, so even the system temp dir
+/// could (in principle) carry one; a directory we just made cannot. The directory is removed
+/// afterwards. The whole invocation is bounded by [`PROBE_TIMEOUT`] so a connect/DNS hang can't
+/// wedge or orphan the `git` child. `Err` on any failure — all of which degrade to "no banner".
 pub fn run_git_ls_remote(repo_url: &str) -> io::Result<String> {
-    let mut child = ls_remote_command(repo_url).spawn()?;
+    let probe_dir = std::env::temp_dir().join(format!("herdr-fv-probe-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&probe_dir); // clear any stale dir from a prior crashed run
+    std::fs::create_dir_all(&probe_dir)?; // no clean dir → abort the probe (no banner)
+    let result = run_ls_remote_in(repo_url, &probe_dir);
+    let _ = std::fs::remove_dir_all(&probe_dir);
+    result
+}
+
+/// Spawn the hardened `ls-remote` in `run_dir` and read its stdout, bounded by [`PROBE_TIMEOUT`].
+fn run_ls_remote_in(repo_url: &str, run_dir: &Path) -> io::Result<String> {
+    let mut child = ls_remote_command(repo_url, run_dir).spawn()?;
     // Read stdout on a worker thread so the wait can be bounded (a hung connect never writes).
     let stdout = child.stdout.take();
     let (tx, rx) = mpsc::channel();
@@ -283,25 +300,26 @@ mod tests {
     #[test]
     fn ls_remote_command_is_hardened_against_untrusted_repo_config() {
         // Security regression: the probe must not let the (untrusted) viewed repo's git config
-        // influence it. It runs from a neutral non-repo dir with repo discovery ceilinged, pins
-        // the transport to https, and never prompts — so no repo-local `.git/config` is read.
+        // influence it. It runs from the given private run-dir with repo discovery ceilinged to
+        // it, pins the transport to https, and never prompts — so no repo-local `.git/config` is
+        // read (and the run-dir itself is a fresh empty dir, so it can't carry one either).
         use std::ffi::OsStr;
-        let cmd = ls_remote_command(repo_url());
+        let run_dir = std::path::Path::new("/some/private/probe-dir");
+        let cmd = ls_remote_command(repo_url(), run_dir);
         let env: std::collections::HashMap<_, _> = cmd
             .get_envs()
             .filter_map(|(k, v)| v.map(|v| (k.to_owned(), v.to_owned())))
             .collect();
-        let neutral = std::env::temp_dir();
         assert_eq!(
             cmd.get_current_dir(),
-            Some(neutral.as_path()),
-            "probe runs from a neutral non-repo directory, never the viewed repo"
+            Some(run_dir),
+            "probe runs from its private run-dir, never the viewed repo / process cwd"
         );
         assert_eq!(
             env.get(OsStr::new("GIT_CEILING_DIRECTORIES"))
                 .map(|v| v.as_os_str()),
-            Some(neutral.as_os_str()),
-            "git must not walk up to discover (and read the config of) any repo"
+            Some(run_dir.as_os_str()),
+            "git must not walk up out of the run-dir to discover (and read) any repo's config"
         );
         assert_eq!(
             env.get(OsStr::new("GIT_ALLOW_PROTOCOL"))
@@ -315,6 +333,66 @@ mod tests {
             Some("0"),
             "a credential prompt must never block the probe"
         );
+    }
+
+    #[test]
+    fn hardened_git_ignores_a_malicious_repo_local_insteadof() {
+        // Round-2 regression: a malicious repo-local `url.*.insteadOf` must NOT rewrite the probe
+        // URL when git runs under `harden_git` (fresh private dir + ceiling). `git ls-remote
+        // --get-url` resolves the URL *without any network*, so this is hermetic.
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static N: AtomicU64 = AtomicU64::new(0);
+        let base = std::env::temp_dir().join(format!(
+            "hfv-insteadof-{}-{}",
+            std::process::id(),
+            N.fetch_add(1, Ordering::Relaxed)
+        ));
+        let _ = std::fs::remove_dir_all(&base);
+        let evil = base.join("evil-repo");
+        let clean = base.join("clean");
+        std::fs::create_dir_all(&evil).unwrap();
+        std::fs::create_dir_all(&clean).unwrap();
+
+        // Make `evil` a repo whose config rewrites our GitHub URL to an attacker host.
+        let init = Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(&evil)
+            .status();
+        if init.map(|s| !s.success()).unwrap_or(true) {
+            let _ = std::fs::remove_dir_all(&base);
+            return; // git unavailable → the construction test still covers the boundary
+        }
+        let _ = Command::new("git")
+            .args([
+                "config",
+                "url.https://evil.invalid/.insteadOf",
+                "https://github.com/",
+            ])
+            .current_dir(&evil)
+            .status();
+
+        let url = repo_url();
+        let get_url = |cmd: &mut Command| -> String {
+            cmd.args(["ls-remote", "--get-url", url]);
+            let out = cmd.output().expect("git --get-url");
+            String::from_utf8_lossy(&out.stdout).trim().to_string()
+        };
+        // Precondition: run *inside* the evil repo with no hardening → the rewrite DOES apply.
+        let mut unhardened = Command::new("git");
+        unhardened.current_dir(&evil);
+        assert!(
+            get_url(&mut unhardened).contains("evil.invalid"),
+            "precondition: the malicious repo-local insteadOf rewrites the URL"
+        );
+        // Hardened (fresh private dir): the rewrite must NOT apply — the URL is unchanged.
+        let mut hardened = Command::new("git");
+        harden_git(&mut hardened, &clean);
+        assert_eq!(
+            get_url(&mut hardened),
+            url,
+            "harden_git must ignore the repo-local insteadOf and keep the trusted URL"
+        );
+        let _ = std::fs::remove_dir_all(&base);
     }
 
     #[test]

--- a/src/update/mod.rs
+++ b/src/update/mod.rs
@@ -1,0 +1,8 @@
+//! Update-available check — tell the user when a newer release exists.
+//!
+//! A bounded, read-only, fail-silent feature: once per 24h it runs `git ls-remote` against
+//! our own repo (off the UI thread), compares the highest stable tag to the version compiled
+//! into this binary, and — if behind — surfaces a one-line banner. Disabled entirely by the
+//! `HERDR_FILE_VIEWER_NO_UPDATE_CHECK` env var. No new dependencies, no telemetry, no mutation.
+
+pub mod version;

--- a/src/update/mod.rs
+++ b/src/update/mod.rs
@@ -98,13 +98,45 @@ fn ls_remote_command(repo_url: &str, run_dir: &Path) -> Command {
 /// afterwards. The whole invocation is bounded by [`PROBE_TIMEOUT`] so a connect/DNS hang can't
 /// wedge or orphan the `git` child. `Err` on any failure — all of which degrade to "no banner".
 pub fn run_git_ls_remote(repo_url: &str) -> io::Result<String> {
-    let probe_dir = std::env::temp_dir().join(format!("herdr-fv-probe-{}", std::process::id()));
-    let _ = std::fs::remove_dir_all(&probe_dir); // clear any stale dir from a prior crashed run
-    std::fs::create_dir_all(&probe_dir)?; // no clean dir → abort the probe (no banner)
+    let probe_dir = make_private_dir()?; // fresh, exclusively-created, empty, owned by us
     let result = run_ls_remote_in(repo_url, &probe_dir);
     let _ = std::fs::remove_dir_all(&probe_dir);
     result
 }
+
+/// Create a fresh, private, empty directory under the system temp dir and return its path.
+///
+/// Uses **exclusive** creation (`create_dir`, which fails if the path already exists) with an
+/// unpredictable, never-reused name (pid + a nanosecond stamp + a probe counter), retrying on the
+/// rare collision. So the returned directory is guaranteed to be one we just created — never a
+/// pre-existing or attacker-planted path (which `create_dir_all` would silently reuse, letting a
+/// `.git/config` in it influence the probe). The caller removes it when done. `Err` (→ no banner)
+/// if no fresh directory can be made.
+fn make_private_dir() -> io::Result<PathBuf> {
+    let base = std::env::temp_dir();
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let seq = PROBE_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    for attempt in 0..1024 {
+        let dir = base.join(format!(
+            "herdr-fv-probe-{}-{nanos}-{seq}-{attempt}",
+            std::process::id()
+        ));
+        match std::fs::create_dir(&dir) {
+            Ok(()) => return Ok(dir),
+            Err(e) if e.kind() == io::ErrorKind::AlreadyExists => continue,
+            Err(e) => return Err(e),
+        }
+    }
+    Err(io::Error::other(
+        "could not create a private probe directory",
+    ))
+}
+
+/// Distinguishes successive private-probe-dir names within one process.
+static PROBE_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
 /// Spawn the hardened `ls-remote` in `run_dir` and read its stdout, bounded by [`PROBE_TIMEOUT`].
 fn run_ls_remote_in(repo_url: &str, run_dir: &Path) -> io::Result<String> {
@@ -333,6 +365,30 @@ mod tests {
             Some("0"),
             "a credential prompt must never block the probe"
         );
+    }
+
+    #[test]
+    fn make_private_dir_is_fresh_empty_and_unique() {
+        // The probe dir must be freshly created (exclusive), empty, and never the same path twice
+        // — so a pre-existing/planted directory can't be reused as the probe cwd.
+        let a = make_private_dir().expect("first private dir");
+        let b = make_private_dir().expect("second private dir");
+        assert_ne!(a, b, "successive calls return distinct, never-reused paths");
+        for d in [&a, &b] {
+            assert!(d.is_dir(), "exists as a directory: {d:?}");
+            assert_eq!(
+                std::fs::read_dir(d).unwrap().count(),
+                0,
+                "freshly created → empty (no planted .git): {d:?}"
+            );
+        }
+        // Exclusive creation: creating the same path again must fail, not silently reuse it.
+        assert_eq!(
+            std::fs::create_dir(&a).unwrap_err().kind(),
+            io::ErrorKind::AlreadyExists
+        );
+        let _ = std::fs::remove_dir_all(&a);
+        let _ = std::fs::remove_dir_all(&b);
     }
 
     #[test]

--- a/src/update/mod.rs
+++ b/src/update/mod.rs
@@ -7,3 +7,299 @@
 
 pub mod cache;
 pub mod version;
+
+pub use version::Version;
+
+use cache::{Cache, next_cache, should_check};
+use std::io;
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::mpsc;
+use version::{latest_stable, newer_than_current};
+
+/// Setting this env var (to anything) disables the update check and banner entirely.
+pub const DISABLE_ENV: &str = "HERDR_FILE_VIEWER_NO_UPDATE_CHECK";
+
+/// The injected probe runner: given the repo URL, returns `git ls-remote`-style stdout. Boxed
+/// + `Send` so the background thread owns it; a type alias keeps signatures readable.
+pub type ProbeRunner = Box<dyn Fn(&str) -> io::Result<String> + Send>;
+
+/// How long `git ls-remote` may stall on a dead network before it aborts (seconds), so a
+/// background probe can't leave a `git` child hanging indefinitely.
+const PROBE_LOW_SPEED_TIME: &str = "5";
+
+/// The repository URL the probe queries (and the source of [`repo_slug`]).
+pub fn repo_url() -> &'static str {
+    env!("CARGO_PKG_REPOSITORY")
+}
+
+/// The `owner/repo` slug for the install command, derived from [`repo_url`].
+pub fn repo_slug() -> &'static str {
+    repo_url()
+        .trim_end_matches('/')
+        .trim_start_matches("https://github.com/")
+        .trim_start_matches("http://github.com/")
+}
+
+/// The one-line footer shown when a newer release exists.
+pub fn banner_text(v: &Version) -> String {
+    format!(
+        "↑ v{v} available · herdr plugin install {} · u to dismiss",
+        repo_slug()
+    )
+}
+
+/// Run the injected probe and return its stdout, or `None` on any error. The runner is a seam
+/// so tests never shell out / hit the network.
+pub fn probe(run: impl Fn(&str) -> io::Result<String>, repo_url: &str) -> Option<String> {
+    run(repo_url).ok()
+}
+
+/// Production probe runner: `git ls-remote --tags <url>`, with git's low-speed abort set so a
+/// stalled network connection can't hang the background thread (and its child) forever. stderr
+/// is discarded; a non-zero exit is an error (→ no banner).
+pub fn run_git_ls_remote(repo_url: &str) -> io::Result<String> {
+    let out = Command::new("git")
+        .args(["ls-remote", "--tags", repo_url])
+        .env("GIT_TERMINAL_PROMPT", "0") // never block on a credential prompt
+        .env("GIT_HTTP_LOW_SPEED_LIMIT", "1000")
+        .env("GIT_HTTP_LOW_SPEED_TIME", PROBE_LOW_SPEED_TIME)
+        .stderr(std::process::Stdio::null())
+        .output()?;
+    if out.status.success() {
+        Ok(String::from_utf8_lossy(&out.stdout).into_owned())
+    } else {
+        Err(io::Error::other(format!(
+            "git ls-remote exited with {}",
+            out.status
+        )))
+    }
+}
+
+/// The startup decision: what to show immediately (from cache) and whether to hit the network.
+pub struct Decision {
+    pub initial: Option<Version>,
+    pub should_check: bool,
+}
+
+/// Pure startup decision. `initial` is the cached latest-seen version if it is newer than the
+/// running build (and the feature is enabled); `should_check` is whether the 24h window has
+/// elapsed (and the feature is enabled).
+pub fn decide(disabled: bool, now_unix: u64, cache: &Option<Cache>) -> Decision {
+    if disabled {
+        return Decision {
+            initial: None,
+            should_check: false,
+        };
+    }
+    let initial = cache
+        .as_ref()
+        .and_then(|c| c.latest_seen.as_deref())
+        .and_then(Version::parse)
+        .and_then(newer_than_current);
+    let last = cache.as_ref().map(|c| c.last_check_unix).unwrap_or(0);
+    Decision {
+        initial,
+        should_check: should_check(now_unix, last),
+    }
+}
+
+/// Initial banner state + a one-shot receiver for the background check's result.
+pub struct UpdateState {
+    pub initial: Option<Version>,
+    pub rx: Option<mpsc::Receiver<Option<Version>>>,
+}
+
+impl UpdateState {
+    pub fn disabled() -> Self {
+        UpdateState {
+            initial: None,
+            rx: None,
+        }
+    }
+}
+
+/// Injected dependencies for [`start_with`] — real values in [`start_default`], fakes in tests.
+pub struct StartDeps {
+    pub disabled: bool,
+    pub now_unix: u64,
+    pub cache: Option<Cache>,
+    pub cache_dir: Option<PathBuf>,
+    pub repo_url: String,
+    pub run: ProbeRunner,
+}
+
+/// Decide, then (if warranted) spawn the background probe. The thread probes, persists the
+/// throttle cache, and sends the "version to show" (`Some` when newer, `None` when a successful
+/// check found nothing) over the channel. On a probe *failure* it persists the advanced
+/// timestamp but sends nothing, leaving any cached banner in place.
+pub fn start_with(deps: StartDeps) -> UpdateState {
+    let StartDeps {
+        disabled,
+        now_unix,
+        cache,
+        cache_dir,
+        repo_url,
+        run,
+    } = deps;
+    let decision = decide(disabled, now_unix, &cache);
+    if !decision.should_check {
+        return UpdateState {
+            initial: decision.initial,
+            rx: None,
+        };
+    }
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let stdout = probe(|url| run(url), &repo_url);
+        let succeeded = stdout.is_some();
+        let latest = stdout.as_deref().and_then(latest_stable);
+        if let Some(dir) = &cache_dir {
+            cache::store(dir, &next_cache(now_unix, &cache, succeeded, latest));
+        }
+        if succeeded {
+            let _ = tx.send(latest.and_then(newer_than_current));
+        }
+    });
+    UpdateState {
+        initial: decision.initial,
+        rx: Some(rx),
+    }
+}
+
+/// The real entry point: read the env/clock/cache and use the `git` runner.
+pub fn start_default() -> UpdateState {
+    let disabled = std::env::var_os(DISABLE_ENV).is_some();
+    if disabled {
+        return UpdateState::disabled();
+    }
+    let cache_dir = cache::cache_dir();
+    let cache = cache_dir.as_deref().and_then(cache::load);
+    let now_unix = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    start_with(StartDeps {
+        disabled,
+        now_unix,
+        cache,
+        cache_dir,
+        repo_url: repo_url().to_string(),
+        run: Box::new(run_git_ls_remote),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cache::CHECK_INTERVAL_SECS;
+    use version::current;
+
+    #[test]
+    fn repo_slug_is_owner_repo() {
+        // Derived from CARGO_PKG_REPOSITORY so it stays correct if the repo moves.
+        assert_eq!(repo_slug(), "smarzban/herdr-file-viewer");
+    }
+
+    #[test]
+    fn banner_names_the_version_and_install_command() {
+        let v = Version {
+            major: 1,
+            minor: 1,
+            patch: 0,
+        };
+        let b = banner_text(&v);
+        assert!(b.contains("1.1.0"), "names the version: {b}");
+        assert!(
+            b.contains("herdr plugin install smarzban/herdr-file-viewer"),
+            "shows install cmd: {b}"
+        );
+        assert!(b.contains('u'), "mentions the dismiss key: {b}");
+    }
+
+    #[test]
+    fn probe_returns_stdout_on_success_and_none_on_error() {
+        let ok = probe(|_url| Ok("aaa\trefs/tags/v1.1.0\n".to_string()), "url");
+        assert_eq!(
+            latest_stable(ok.as_deref().unwrap_or("")),
+            Version::parse("1.1.0")
+        );
+        let err = probe(|_url| Err(io::Error::other("offline")), "url");
+        assert_eq!(err, None);
+    }
+
+    #[test]
+    fn decide_uses_cache_for_the_initial_banner_and_gates_the_check() {
+        let newer = format!("{}.{}.{}", current().major + 1, 0, 0);
+        let cache = Some(Cache {
+            last_check_unix: 1_000,
+            latest_seen: Some(newer.clone()),
+        });
+
+        // Fresh cache (within 24h), behind → show banner from cache, no network.
+        let d = decide(false, 1_000 + 10, &cache);
+        assert_eq!(d.initial, Version::parse(&newer));
+        assert!(!d.should_check, "fresh cache → no check");
+
+        // Stale cache (>24h) → still show cached banner, AND check.
+        let d = decide(false, 1_000 + CHECK_INTERVAL_SECS + 1, &cache);
+        assert_eq!(d.initial, Version::parse(&newer));
+        assert!(d.should_check, "stale → check");
+
+        // Disabled → never a banner, never a check, whatever the cache says.
+        let d = decide(true, 10_000_000, &cache);
+        assert_eq!(d.initial, None);
+        assert!(!d.should_check);
+
+        // No cache → no initial banner, but do check (real clock vs last=0).
+        let d = decide(false, 10_000_000, &None);
+        assert_eq!(d.initial, None);
+        assert!(d.should_check);
+
+        // Cache says we're up-to-date (current version) → no banner.
+        let same = current().to_string();
+        let upcache = Some(Cache {
+            last_check_unix: 0,
+            latest_seen: Some(same),
+        });
+        assert_eq!(decide(false, 0, &upcache).initial, None);
+    }
+
+    #[test]
+    fn start_with_delivers_a_newer_version_over_the_channel() {
+        // A fake probe reporting a newer tag → the receiver yields it; no real network.
+        let newer = current().major + 1;
+        let stdout = format!("aaa\trefs/tags/v{newer}.0.0\n");
+        let dir = std::env::temp_dir().join(format!("hfv-startwith-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let state = start_with(StartDeps {
+            disabled: false,
+            now_unix: CHECK_INTERVAL_SECS * 10, // force should_check
+            cache: None,
+            cache_dir: Some(dir.clone()),
+            repo_url: "fake-url".to_string(),
+            run: Box::new(move |_url| Ok(stdout.clone())),
+        });
+        let rx = state.rx.expect("a check was scheduled");
+        let got = rx
+            .recv_timeout(std::time::Duration::from_secs(5))
+            .expect("result arrives");
+        assert_eq!(got, Version::parse(&format!("{newer}.0.0")));
+        // And the cache was written so a re-run wouldn't re-probe.
+        assert!(cache::load(&dir).is_some());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn start_with_disabled_does_nothing() {
+        let state = start_with(StartDeps {
+            disabled: true,
+            now_unix: 0,
+            cache: None,
+            cache_dir: None,
+            repo_url: "x".into(),
+            run: Box::new(|_| panic!("must not probe when disabled")),
+        });
+        assert!(state.initial.is_none() && state.rx.is_none());
+    }
+}

--- a/src/update/mod.rs
+++ b/src/update/mod.rs
@@ -11,10 +11,11 @@ pub mod version;
 pub use version::Version;
 
 use cache::{Cache, next_cache, should_check};
-use std::io;
+use std::io::{self, Read};
 use std::path::PathBuf;
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::sync::mpsc;
+use std::time::Duration;
 use version::{latest_stable, newer_than_current};
 
 /// Setting this env var (to anything) disables the update check and banner entirely.
@@ -24,9 +25,14 @@ pub const DISABLE_ENV: &str = "HERDR_FILE_VIEWER_NO_UPDATE_CHECK";
 /// + `Send` so the background thread owns it; a type alias keeps signatures readable.
 pub type ProbeRunner = Box<dyn Fn(&str) -> io::Result<String> + Send>;
 
-/// How long `git ls-remote` may stall on a dead network before it aborts (seconds), so a
-/// background probe can't leave a `git` child hanging indefinitely.
+/// How long `git ls-remote` may stall mid-transfer before git itself aborts (seconds).
 const PROBE_LOW_SPEED_TIME: &str = "5";
+
+/// Hard wall-clock bound on the whole `git ls-remote` invocation. The low-speed settings only
+/// cover a stalled HTTP *transfer*, not TCP connect / DNS — so a black-holed network could
+/// otherwise hang (and orphan) the `git` child indefinitely. On overrun the child is killed and
+/// the probe fails (→ no banner), matching the fail-silent contract.
+const PROBE_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// The repository URL the probe queries (and the source of [`repo_slug`]).
 pub fn repo_url() -> &'static str {
@@ -49,30 +55,87 @@ pub fn banner_text(v: &Version) -> String {
     )
 }
 
-/// Run the injected probe and return its stdout, or `None` on any error. The runner is a seam
-/// so tests never shell out / hit the network.
-pub fn probe(run: impl Fn(&str) -> io::Result<String>, repo_url: &str) -> Option<String> {
-    run(repo_url).ok()
-}
-
-/// Production probe runner: `git ls-remote --tags <url>`, with git's low-speed abort set so a
-/// stalled network connection can't hang the background thread (and its child) forever. stderr
-/// is discarded; a non-zero exit is an error (→ no banner).
-pub fn run_git_ls_remote(repo_url: &str) -> io::Result<String> {
-    let out = Command::new("git")
-        .args(["ls-remote", "--tags", repo_url])
-        .env("GIT_TERMINAL_PROMPT", "0") // never block on a credential prompt
+/// Build the hardened `git ls-remote --tags <url>` command. Constructed separately from
+/// [`run_git_ls_remote`] so the security boundary is unit-testable without shelling out.
+///
+/// The viewed repository is **untrusted**, and a `git` process reads the repo-local `.git/config`
+/// of whatever working directory it discovers (URL `insteadOf` rewrites, credential helpers, …) —
+/// so an attacker-planted `.git/config` could otherwise redirect or hijack this once-a-day probe.
+/// We close that hole the way the rest of the viewer treats the repo as untrusted:
+/// - run from a **neutral, non-repo directory** and set `GIT_CEILING_DIRECTORIES` so git never
+///   walks up to *discover* a repo — no repo-local config is read, regardless of where herdr
+///   launched the pane;
+/// - pin the transport to `https` via `GIT_ALLOW_PROTOCOL`, so even a (user-global) URL rewrite
+///   can't redirect to a command-capable transport like `ext::` or `file://`;
+/// - `GIT_TERMINAL_PROMPT=0` so a credential prompt can never block.
+///
+/// The user's own global/system config is intentionally kept — it carries legitimate proxy / CA
+/// settings and is in the user's own trust domain (only the *viewed repo* is untrusted).
+fn ls_remote_command(repo_url: &str) -> Command {
+    let neutral = std::env::temp_dir();
+    let mut cmd = Command::new("git");
+    cmd.args(["ls-remote", "--tags", repo_url])
+        .current_dir(&neutral)
+        .env("GIT_CEILING_DIRECTORIES", &neutral)
+        .env("GIT_ALLOW_PROTOCOL", "https")
+        .env("GIT_TERMINAL_PROMPT", "0")
         .env("GIT_HTTP_LOW_SPEED_LIMIT", "1000")
         .env("GIT_HTTP_LOW_SPEED_TIME", PROBE_LOW_SPEED_TIME)
-        .stderr(std::process::Stdio::null())
-        .output()?;
-    if out.status.success() {
-        Ok(String::from_utf8_lossy(&out.stdout).into_owned())
-    } else {
-        Err(io::Error::other(format!(
-            "git ls-remote exited with {}",
-            out.status
-        )))
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+    cmd
+}
+
+/// Production probe runner: run the hardened [`ls_remote_command`] and return its stdout, bounded
+/// by [`PROBE_TIMEOUT`] so a connect/DNS hang can't wedge or orphan the `git` child. `Err` on
+/// spawn failure, non-zero exit, or timeout — all of which degrade to "no banner".
+pub fn run_git_ls_remote(repo_url: &str) -> io::Result<String> {
+    let mut child = ls_remote_command(repo_url).spawn()?;
+    // Read stdout on a worker thread so the wait can be bounded (a hung connect never writes).
+    let stdout = child.stdout.take();
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        if let Some(mut out) = stdout {
+            let _ = out.read_to_end(&mut buf);
+        }
+        let _ = tx.send(buf);
+    });
+    match rx.recv_timeout(PROBE_TIMEOUT) {
+        Ok(buf) => match wait_bounded(&mut child, PROBE_TIMEOUT) {
+            Some(status) if status.success() => Ok(String::from_utf8_lossy(&buf).into_owned()),
+            Some(status) => Err(io::Error::other(format!(
+                "git ls-remote exited with {status}"
+            ))),
+            None => Err(io::Error::other("git ls-remote did not exit")),
+        },
+        Err(_) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            Err(io::Error::other("git ls-remote timed out"))
+        }
+    }
+}
+
+/// Wait for a child to exit within `grace`, killing and reaping it if it overruns.
+fn wait_bounded(
+    child: &mut std::process::Child,
+    grace: Duration,
+) -> Option<std::process::ExitStatus> {
+    let deadline = std::time::Instant::now() + grace;
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => return Some(status),
+            Ok(None) if std::time::Instant::now() < deadline => {
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            _ => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return None;
+            }
+        }
     }
 }
 
@@ -129,10 +192,11 @@ pub struct StartDeps {
     pub run: ProbeRunner,
 }
 
-/// Decide, then (if warranted) spawn the background probe. The thread probes, persists the
-/// throttle cache, and sends the "version to show" (`Some` when newer, `None` when a successful
-/// check found nothing) over the channel. On a probe *failure* it persists the advanced
-/// timestamp but sends nothing, leaving any cached banner in place.
+/// Decide, then (if warranted) spawn the background probe. On a **successful** probe the thread
+/// persists the throttle cache (advancing the 24h window + the latest version seen) and sends the
+/// "version to show" (`Some` when newer, `None` when nothing newer) over the channel. On a probe
+/// **failure** it leaves the cache untouched — so the check simply retries next launch — and sends
+/// nothing (the receiver then disconnects, which `Controller::poll` cleans up).
 pub fn start_with(deps: StartDeps) -> UpdateState {
     let StartDeps {
         disabled,
@@ -151,13 +215,12 @@ pub fn start_with(deps: StartDeps) -> UpdateState {
     }
     let (tx, rx) = mpsc::channel();
     std::thread::spawn(move || {
-        let stdout = probe(|url| run(url), &repo_url);
-        let succeeded = stdout.is_some();
-        let latest = stdout.as_deref().and_then(latest_stable);
-        if let Some(dir) = &cache_dir {
-            cache::store(dir, &next_cache(now_unix, &cache, succeeded, latest));
-        }
-        if succeeded {
+        // A probe failure leaves the cache as-is (retry next launch) and sends nothing.
+        if let Ok(stdout) = run(&repo_url) {
+            let latest = latest_stable(&stdout);
+            if let Some(dir) = &cache_dir {
+                cache::store(dir, &next_cache(now_unix, latest));
+            }
             let _ = tx.send(latest.and_then(newer_than_current));
         }
     });
@@ -218,14 +281,68 @@ mod tests {
     }
 
     #[test]
-    fn probe_returns_stdout_on_success_and_none_on_error() {
-        let ok = probe(|_url| Ok("aaa\trefs/tags/v1.1.0\n".to_string()), "url");
+    fn ls_remote_command_is_hardened_against_untrusted_repo_config() {
+        // Security regression: the probe must not let the (untrusted) viewed repo's git config
+        // influence it. It runs from a neutral non-repo dir with repo discovery ceilinged, pins
+        // the transport to https, and never prompts — so no repo-local `.git/config` is read.
+        use std::ffi::OsStr;
+        let cmd = ls_remote_command(repo_url());
+        let env: std::collections::HashMap<_, _> = cmd
+            .get_envs()
+            .filter_map(|(k, v)| v.map(|v| (k.to_owned(), v.to_owned())))
+            .collect();
+        let neutral = std::env::temp_dir();
         assert_eq!(
-            latest_stable(ok.as_deref().unwrap_or("")),
-            Version::parse("1.1.0")
+            cmd.get_current_dir(),
+            Some(neutral.as_path()),
+            "probe runs from a neutral non-repo directory, never the viewed repo"
         );
-        let err = probe(|_url| Err(io::Error::other("offline")), "url");
-        assert_eq!(err, None);
+        assert_eq!(
+            env.get(OsStr::new("GIT_CEILING_DIRECTORIES"))
+                .map(|v| v.as_os_str()),
+            Some(neutral.as_os_str()),
+            "git must not walk up to discover (and read the config of) any repo"
+        );
+        assert_eq!(
+            env.get(OsStr::new("GIT_ALLOW_PROTOCOL"))
+                .map(|v| v.to_str().unwrap_or("")),
+            Some("https"),
+            "transport pinned to https so a URL rewrite can't reach ext::/file://"
+        );
+        assert_eq!(
+            env.get(OsStr::new("GIT_TERMINAL_PROMPT"))
+                .map(|v| v.to_str().unwrap_or("")),
+            Some("0"),
+            "a credential prompt must never block the probe"
+        );
+    }
+
+    #[test]
+    fn fresh_cache_shows_the_banner_without_probing() {
+        // AC-U4: a fresh cache (within 24h) shows the cached banner and performs NO network call —
+        // the probe runner must never be invoked, and no background check is scheduled.
+        let newer = format!("{}.0.0", current().major + 1);
+        let cache = Some(Cache {
+            last_check_unix: 1_000,
+            latest_seen: Some(newer.clone()),
+        });
+        let state = start_with(StartDeps {
+            disabled: false,
+            now_unix: 1_000 + 10, // well within the 24h window
+            cache,
+            cache_dir: None,
+            repo_url: "x".into(),
+            run: Box::new(|_| panic!("must not probe when the cache is fresh")),
+        });
+        assert_eq!(
+            state.initial,
+            Version::parse(&newer),
+            "banner shown from cache"
+        );
+        assert!(
+            state.rx.is_none(),
+            "fresh cache → no background check scheduled"
+        );
     }
 
     #[test]

--- a/src/update/mod.rs
+++ b/src/update/mod.rs
@@ -5,4 +5,5 @@
 //! into this binary, and — if behind — surfaces a one-line banner. Disabled entirely by the
 //! `HERDR_FILE_VIEWER_NO_UPDATE_CHECK` env var. No new dependencies, no telemetry, no mutation.
 
+pub mod cache;
 pub mod version;

--- a/src/update/version.rs
+++ b/src/update/version.rs
@@ -1,0 +1,173 @@
+//! Semantic version value + tag parsing for the update check. Hand-rolled (no `semver` crate):
+//! our tags are simple `vMAJOR.MINOR.PATCH`, and a pre-release suffix is treated as "not a
+//! stable release" rather than ordered.
+
+/// A `MAJOR.MINOR.PATCH` version. `Ord` is the natural field order, so comparison answers
+/// "is one release newer than another".
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Version {
+    pub major: u32,
+    pub minor: u32,
+    pub patch: u32,
+}
+
+impl Version {
+    /// Parse `MAJOR.MINOR.PATCH` with an optional leading `v`. Returns `None` for anything that
+    /// is not exactly three numeric components — including pre-release/build suffixes
+    /// (`1.2.3-rc1`), which must never count as a stable release.
+    pub fn parse(s: &str) -> Option<Version> {
+        let s = s.strip_prefix('v').unwrap_or(s);
+        let mut parts = s.split('.');
+        let major = parts.next()?.parse().ok()?;
+        let minor = parts.next()?.parse().ok()?;
+        let patch = parts.next()?.parse().ok()?;
+        if parts.next().is_some() {
+            return None; // more than three components
+        }
+        Some(Version {
+            major,
+            minor,
+            patch,
+        })
+    }
+}
+
+impl std::fmt::Display for Version {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
+    }
+}
+
+/// Parse one `git ls-remote --tags` output line into a stable [`Version`].
+///
+/// Each line is `<sha>\trefs/tags/<ref>`. We take the ref, drop the `refs/tags/` prefix, and
+/// parse it as a version — which rejects the `^{}` peel lines (annotated-tag dereferences),
+/// pre-release tags, and any non-`vX.Y.Z` ref. `None` for all of those.
+pub fn parse_tag_ref(line: &str) -> Option<Version> {
+    let (_sha, refname) = line.split_once('\t')?;
+    let tag = refname.strip_prefix("refs/tags/")?;
+    Version::parse(tag)
+}
+
+/// The highest stable version among all tag lines, or `None` if there are none.
+pub fn latest_stable(ls_remote_stdout: &str) -> Option<Version> {
+    ls_remote_stdout.lines().filter_map(parse_tag_ref).max()
+}
+
+/// The version compiled into this binary (Cargo's package version).
+pub fn current() -> Version {
+    // The package version is always a valid triple (CI/clippy would reject otherwise), so this
+    // parse cannot fail in a real build; fall back to 0.0.0 rather than panic, keeping the
+    // "never crash" invariant even for a hand-mangled version string.
+    Version::parse(env!("CARGO_PKG_VERSION")).unwrap_or(Version {
+        major: 0,
+        minor: 0,
+        patch: 0,
+    })
+}
+
+/// `Some(latest)` iff `latest` is strictly newer than the running build, else `None`.
+pub fn newer_than_current(latest: Version) -> Option<Version> {
+    (latest > current()).then_some(latest)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_plain_and_v_prefixed_triples() {
+        assert_eq!(
+            Version::parse("1.2.3"),
+            Some(Version {
+                major: 1,
+                minor: 2,
+                patch: 3
+            })
+        );
+        assert_eq!(
+            Version::parse("v1.0.0"),
+            Some(Version {
+                major: 1,
+                minor: 0,
+                patch: 0
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_non_triples_and_prereleases() {
+        assert_eq!(Version::parse("1.2"), None);
+        assert_eq!(Version::parse("1.2.3.4"), None);
+        assert_eq!(Version::parse("1.2.x"), None);
+        assert_eq!(Version::parse("1.2.3-rc1"), None);
+        assert_eq!(Version::parse(""), None);
+        assert_eq!(Version::parse("v"), None);
+    }
+
+    #[test]
+    fn orders_by_major_then_minor_then_patch() {
+        assert!(Version::parse("1.1.0").unwrap() > Version::parse("1.0.9").unwrap());
+        assert!(Version::parse("2.0.0").unwrap() > Version::parse("1.9.9").unwrap());
+        assert!(Version::parse("1.0.10").unwrap() > Version::parse("1.0.9").unwrap());
+        assert_eq!(
+            Version::parse("1.0.0").unwrap(),
+            Version::parse("v1.0.0").unwrap()
+        );
+    }
+
+    #[test]
+    fn displays_as_a_dotted_triple() {
+        assert_eq!(
+            Version {
+                major: 1,
+                minor: 2,
+                patch: 3
+            }
+            .to_string(),
+            "1.2.3"
+        );
+    }
+
+    const SAMPLE: &str = "\
+9bbba64\trefs/tags/v1.0.0
+ce1ddf8\trefs/tags/v1.0.0^{}
+aaa1111\trefs/tags/v1.1.0
+bbb2222\trefs/tags/v1.1.0^{}
+ccc3333\trefs/tags/v2.0.0-rc1
+ddd4444\trefs/tags/not-a-version
+";
+
+    #[test]
+    fn parse_tag_ref_reads_clean_tags_only() {
+        assert_eq!(
+            parse_tag_ref("9bbba64\trefs/tags/v1.0.0"),
+            Version::parse("1.0.0")
+        );
+        // peel lines, pre-releases, and junk refs are ignored
+        assert_eq!(parse_tag_ref("ce1ddf8\trefs/tags/v1.0.0^{}"), None);
+        assert_eq!(parse_tag_ref("ccc3333\trefs/tags/v2.0.0-rc1"), None);
+        assert_eq!(parse_tag_ref("ddd4444\trefs/tags/not-a-version"), None);
+        assert_eq!(parse_tag_ref(""), None);
+    }
+
+    #[test]
+    fn latest_stable_picks_the_highest_skipping_prereleases() {
+        // v2.0.0-rc1 is a pre-release → ignored; the highest stable is v1.1.0.
+        assert_eq!(latest_stable(SAMPLE), Version::parse("1.1.0"));
+        assert_eq!(latest_stable(""), None);
+        assert_eq!(latest_stable("garbage with no tags"), None);
+    }
+
+    #[test]
+    fn newer_than_current_compares_against_the_build_version() {
+        let cur = current();
+        // The current version is never "newer" than itself.
+        assert_eq!(newer_than_current(cur), None);
+        let higher = Version {
+            major: cur.major + 1,
+            ..cur
+        };
+        assert_eq!(newer_than_current(higher), Some(higher));
+    }
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -80,5 +80,8 @@ pub fn canon(p: &Path) -> PathBuf {
 pub fn viewer_command(dir: &Path) -> Command {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_herdr-file-viewer"));
     cmd.current_dir(dir);
+    // Tests must never reach the network: disable the once-a-day update check in every spawned
+    // viewer (it would otherwise run `git ls-remote` against the real repo).
+    cmd.env("HERDR_FILE_VIEWER_NO_UPDATE_CHECK", "1");
     cmd
 }

--- a/tests/presenter.rs
+++ b/tests/presenter.rs
@@ -509,11 +509,7 @@ fn update_banner_renders_as_a_bottom_status_line() {
         out.contains("fn main()"),
         "content still shows above the banner\n{out}"
     );
-    let last = out
-        .lines()
-        .filter(|l| !l.trim().is_empty())
-        .next_back()
-        .unwrap_or("");
+    let last = out.lines().rfind(|l| !l.trim().is_empty()).unwrap_or("");
     assert!(
         last.contains("u to dismiss"),
         "banner is the bottom line: {last:?}"

--- a/tests/presenter.rs
+++ b/tests/presenter.rs
@@ -70,6 +70,7 @@ fn sample_state() -> ViewState {
         wrap: false,
         split_pct: 40,
         zoomed: false,
+        update_banner: None,
     }
 }
 
@@ -486,5 +487,71 @@ fn geometry_is_single_column_when_narrow() {
     assert!(
         g.divider_x.is_none(),
         "no divider in a single-column layout"
+    );
+}
+
+#[test]
+fn update_banner_renders_as_a_bottom_status_line() {
+    // AC-U1: when behind, the bottom row carries the version + the install command.
+    let mut state = sample_state();
+    state.update_banner = Some(
+        "↑ v1.1.0 available · herdr plugin install smarzban/herdr-file-viewer · u to dismiss"
+            .to_string(),
+    );
+    let out = render(&state, 100, 24);
+    assert!(out.contains("v1.1.0 available"), "names the version\n{out}");
+    assert!(
+        out.contains("herdr plugin install smarzban/herdr-file-viewer"),
+        "shows the install command\n{out}"
+    );
+    // The banner sits on the last interior row; the tree/content are still drawn above it.
+    assert!(
+        out.contains("fn main()"),
+        "content still shows above the banner\n{out}"
+    );
+    let last = out
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .next_back()
+        .unwrap_or("");
+    assert!(
+        last.contains("u to dismiss"),
+        "banner is the bottom line: {last:?}"
+    );
+}
+
+#[test]
+fn no_banner_reserves_no_row_and_shows_nothing() {
+    // AC-U2: up-to-date users see no banner text at all.
+    let out = render(&sample_state(), 100, 24); // update_banner: None
+    assert!(
+        !out.contains("available"),
+        "no update text when up-to-date\n{out}"
+    );
+}
+
+#[test]
+fn banner_carves_exactly_one_row_off_the_columns() {
+    // AC-U2: showing the banner shrinks the content interior by exactly one row vs. no banner,
+    // so mouse hit-testing (which reads the same geometry) stays correct.
+    use herdr_file_viewer::presenter::geometry;
+    use ratatui::layout::Rect;
+    let area = Rect {
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 24,
+    };
+
+    let plain = sample_state();
+    let mut withbanner = sample_state();
+    withbanner.update_banner = Some("↑ v1.1.0 available · u to dismiss".to_string());
+
+    let h_plain = geometry(area, &plain).content_inner.unwrap().height;
+    let h_banner = geometry(area, &withbanner).content_inner.unwrap().height;
+    assert_eq!(
+        h_plain - h_banner,
+        1,
+        "the banner takes exactly one row from the body"
     );
 }

--- a/tests/presenter_narrow.rs
+++ b/tests/presenter_narrow.rs
@@ -38,6 +38,7 @@ fn state(width: u16, focus: Focus) -> ViewState {
         wrap: false,
         split_pct: 40,
         zoomed: false,
+        update_banner: None,
     }
 }
 

--- a/tests/update_banner.rs
+++ b/tests/update_banner.rs
@@ -1,0 +1,163 @@
+//! The update-available banner state on the Session Controller (AC-U1, AC-U2, AC-U7): shown
+//! from the initial (cached) value, refreshed from the background channel, and dismissable for
+//! the session. No real git / renderer / editor / network — the components are no-op stubs and
+//! the update result is injected directly.
+
+mod common;
+
+use common::TempDir;
+use herdr_file_viewer::controller::{
+    Components, ContentProvider, Controller, EditorHandoff, GitService, RenderResult,
+};
+use herdr_file_viewer::git::{Baseline, Status};
+use herdr_file_viewer::intent::Intent;
+use herdr_file_viewer::update::{UpdateState, Version};
+use herdr_file_viewer::view_policy::ViewMode;
+use ratatui::text::Text;
+use std::collections::BTreeMap;
+use std::io;
+use std::path::Path;
+use std::sync::{Arc, mpsc};
+
+// ---- minimal no-op stubs (the banner logic exercises none of these) -------------------
+
+struct Git;
+impl GitService for Git {
+    fn status(&self) -> BTreeMap<std::path::PathBuf, Status> {
+        BTreeMap::new()
+    }
+    fn changed_set(&self, _baseline: Baseline) -> BTreeMap<std::path::PathBuf, Status> {
+        BTreeMap::new()
+    }
+    fn diff(&self, _rel: &Path, _baseline: Baseline, _full: bool) -> String {
+        String::new()
+    }
+}
+
+struct Content;
+impl ContentProvider for Content {
+    fn render(&self, _path: &Path, _mode: ViewMode, _raw_diff: Option<&str>) -> RenderResult {
+        RenderResult {
+            content: Text::raw(""),
+            notices: Vec::new(),
+        }
+    }
+}
+
+struct Editor;
+impl EditorHandoff for Editor {
+    fn open(&mut self, _file: &Path) -> io::Result<bool> {
+        Ok(false)
+    }
+}
+
+fn controller_in(dir: &Path) -> Controller {
+    Controller::new(
+        dir.to_path_buf(),
+        false, // non-git: keeps the test focused on banner state
+        Baseline::Head,
+        Components {
+            git: Arc::new(Git),
+            content: Box::new(Content),
+            editor: Box::new(Editor),
+        },
+    )
+}
+
+fn v(major: u32, minor: u32, patch: u32) -> Version {
+    Version {
+        major,
+        minor,
+        patch,
+    }
+}
+
+#[test]
+fn initial_cached_version_shows_a_banner() {
+    let dir = TempDir::new();
+    let mut c = controller_in(dir.path());
+    c.set_update(UpdateState {
+        initial: Some(v(9, 9, 9)),
+        rx: None,
+    });
+    assert!(
+        c.view_state()
+            .update_banner
+            .is_some_and(|b| b.contains("9.9.9")),
+        "a cached newer version is advertised on the first frame"
+    );
+}
+
+#[test]
+fn no_update_means_no_banner() {
+    let dir = TempDir::new();
+    let mut c = controller_in(dir.path());
+    c.set_update(UpdateState {
+        initial: None,
+        rx: None,
+    });
+    assert!(c.view_state().update_banner.is_none());
+}
+
+#[test]
+fn background_result_turns_the_banner_on() {
+    let dir = TempDir::new();
+    let (tx, rx) = mpsc::channel();
+    let mut c = controller_in(dir.path());
+    c.set_update(UpdateState {
+        initial: None,
+        rx: Some(rx),
+    });
+    assert!(
+        c.view_state().update_banner.is_none(),
+        "nothing until the check returns"
+    );
+
+    tx.send(Some(v(2, 0, 0))).unwrap();
+    let fx = c.poll().expect("poll applies the background update result");
+    assert!(fx.redraw, "a fresh verdict triggers a repaint");
+    assert!(
+        c.view_state()
+            .update_banner
+            .is_some_and(|b| b.contains("2.0.0")),
+        "the banner now names the version the check found"
+    );
+}
+
+#[test]
+fn background_up_to_date_clears_a_stale_cached_banner() {
+    // A cached banner, then a successful check that finds nothing newer (`None`) → banner gone.
+    let dir = TempDir::new();
+    let (tx, rx) = mpsc::channel();
+    let mut c = controller_in(dir.path());
+    c.set_update(UpdateState {
+        initial: Some(v(9, 9, 9)),
+        rx: Some(rx),
+    });
+    assert!(c.view_state().update_banner.is_some());
+
+    tx.send(None).unwrap();
+    c.poll().expect("poll applies the result");
+    assert!(
+        c.view_state().update_banner.is_none(),
+        "a successful 'up-to-date' check clears the stale cached banner"
+    );
+}
+
+#[test]
+fn dismiss_hides_the_banner_for_the_session() {
+    let dir = TempDir::new();
+    let mut c = controller_in(dir.path());
+    c.set_update(UpdateState {
+        initial: Some(v(9, 9, 9)),
+        rx: None,
+    });
+    let fx = c.handle(Intent::DismissUpdate);
+    assert!(fx.redraw, "dismissing repaints to remove the banner");
+    assert!(
+        c.view_state().update_banner.is_none(),
+        "dismissed → hidden for the session"
+    );
+    // Dismiss again is inert (no banner to hide).
+    assert!(!c.handle(Intent::DismissUpdate).redraw);
+}


### PR DESCRIPTION
## What & why

herdr has no plugin auto-update and no new-release notification, so users have no way to learn that a newer release exists. This adds an unobtrusive, opt-out **update-available banner**: when the viewer launches and a newer release exists, a one-row bottom status line names the new version and the one-line update command.

## How

- **`src/update/`** (new module, no new dependencies):
  - `version.rs` — hand-rolled `Version` + `git ls-remote --tags` parsing (skips `^{}` peels and pre-releases), `current`/`latest_stable`/`newer_than_current`.
  - `cache.rs` — throttle cache (`should_check` 24h window, `next_cache`, XDG cache dir, best-effort load/store). Stores only a unix timestamp + version string.
  - `mod.rs` — `git ls-remote` probe (injected runner; git low-speed abort so it can't hang), banner text, `decide` (pure startup decision), and a background-thread `start_with`/`start_default` that mirrors the existing off-thread render pattern (`std::thread` + `mpsc`, drained by `Controller::poll`).
- **Controller** — banner state set from the cached value immediately, refreshed by the background result; `u` dismisses for the session (not persisted; returns next launch while still behind).
- **Presenter** — a one-row bottom status line, drawn only when behind; `draw`/`geometry` carve the same body so mouse hit-testing stays correct.
- **Opt-out** — `HERDR_FILE_VIEWER_NO_UPDATE_CHECK=1` disables the check and banner entirely; the e2e harness sets it so tests never hit the network.

## Properties

Read-only (only network action is `git ls-remote` against our own repo), non-blocking (off the UI thread), throttled (≤ once / 24h), fail-silent (offline / git-missing / no-tags → no banner, no error), zero new dependencies.

## Docs

README gains an **Updating** section and de-emphasizes `--ref` (a bare `herdr plugin install …` already pulls the latest; `--ref` only pins an older version). Bumps to **v1.1.0**.

All tests + clippy `-D warnings` + fmt green.