### PR TITLE
feat: prebuilt-binary install path (no Rust toolchain needed) — v1.2.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     tags: ["v*"]
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,94 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: build ${{ matrix.triple }}
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - os: macos-latest
+            triple: aarch64-apple-darwin
+          - os: macos-latest
+            triple: x86_64-apple-darwin
+          - os: ubuntu-latest
+            triple: x86_64-unknown-linux-musl
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      # Fail fast if the pushed tag disagrees with the crate version, so we never publish a release
+      # whose assets don't match the source the install step clones.
+      - name: Verify tag matches Cargo.toml version
+        shell: bash
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          crate="$(grep -E '^version *= *"' Cargo.toml | head -n1 | sed -E 's/^version *= *"([^"]+)".*/\1/')"
+          if [ "$tag" != "$crate" ]; then
+            echo "tag $GITHUB_REF_NAME ($tag) != Cargo.toml version ($crate)" >&2
+            exit 1
+          fi
+
+      - uses: dtolnay/rust-toolchain@1.96.0
+        with:
+          targets: ${{ matrix.triple }}
+
+      - name: Install musl tools
+        if: matrix.triple == 'x86_64-unknown-linux-musl'
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
+
+      - name: Build
+        run: cargo build --release --target ${{ matrix.triple }}
+
+      - name: Stage asset + checksum
+        shell: bash
+        run: |
+          mkdir -p dist
+          asset="herdr-file-viewer-${{ matrix.triple }}"
+          cp "target/${{ matrix.triple }}/release/herdr-file-viewer" "dist/$asset"
+          cd dist
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum "$asset" > "$asset.sha256"
+          else
+            shasum -a 256 "$asset" > "$asset.sha256"
+          fi
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.triple }}
+          path: dist/*
+
+  publish:
+    name: publish release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Assemble release assets + SHA256SUMS
+        shell: bash
+        run: |
+          mkdir -p release
+          # Flatten the per-target binaries and concatenate their checksum lines into one file.
+          find artifacts -type f -name 'herdr-file-viewer-*' ! -name '*.sha256' -exec cp {} release/ \;
+          cat artifacts/*/*.sha256 > release/SHA256SUMS
+          echo "Publishing:"; ls -l release; echo "---"; cat release/SHA256SUMS
+
+      - name: Create-or-update the release and upload assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 \
+            || gh release create "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --title "$GITHUB_REF_NAME" --generate-notes
+          gh release upload "$GITHUB_REF_NAME" release/* --clobber --repo "$GITHUB_REPOSITORY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2026-06-23
+
+### Added
+- Prebuilt-binary install path: tagged releases now ship SHA-256-verified binaries for macOS
+  (arm64 + x86_64) and Linux x86_64 (static/musl). The install step downloads the binary matching
+  the source's version + platform and falls back to a `cargo` source build on any miss, so no Rust
+  toolchain is needed for supported platforms. The install command is unchanged.
+
 ## [1.1.0] - 2026-06-22
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -574,7 +574,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "herdr-file-viewer"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "ansi-to-tui",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "herdr-file-viewer"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2024"
 rust-version = "1.96"
 description = "A git-aware, read-only file viewer that runs as a herdr TUI pane"

--- a/README.md
+++ b/README.md
@@ -54,13 +54,8 @@ right into the tree. It opens beside whatever you're doing and never touches you
 
 ## Quick start
 
-> **Prerequisite: [Rust](https://rustup.rs) 1.96+.** The plugin compiles from source at install
-> time, so `cargo` must be on your PATH. No Rust yet?
-> `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh` (or `brew install rust`).
-> If it's missing, the install fails with a message telling you exactly this.
-
 ```bash
-# 1. Install the plugin (herdr builds it from source at install time):
+# 1. Install the plugin (tagged releases download a prebuilt binary; otherwise builds from source):
 herdr plugin install smarzban/herdr-file-viewer
 
 # 2. (recommended) install the renderers, so markdown / diffs / code are styled, not plain text:
@@ -152,11 +147,16 @@ file itself.
 
 ## Install
 
-Requirements: **Rust 1.96+** (edition 2024) and Cargo; **herdr 0.7.0+**, on **Linux** or
-**macOS**.
+Requirements: **herdr 0.7.0+**, on **Linux** or **macOS**.
 
-**Install through herdr** — herdr runs the manifest's `[[build]]` step
-(`cargo build --release`) at install time, producing `./target/release/herdr-file-viewer`,
+> **No Rust toolchain needed for tagged releases.** `herdr plugin install smarzban/herdr-file-viewer`
+> downloads a prebuilt, SHA-256-verified binary for your platform (macOS arm64/x86_64, Linux x86_64).
+> If no matching prebuilt is available — an unsupported platform, or installing from a `main` that is
+> ahead of the latest release — it automatically builds from source with `cargo` instead (Rust 1.96+).
+> The install command is the same either way.
+
+**Install through herdr** — herdr runs the manifest's `[[build]]` step at install time, either
+downloading a prebuilt binary or compiling from source, producing `./target/release/herdr-file-viewer`,
 which the viewer pane launches:
 
 ```bash

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -6,7 +6,7 @@
 
 id = "herdr-file-viewer"
 name = "herdr-file-viewer"
-version = "1.1.0"
+version = "1.2.0"
 description = "A git-aware, read-only file viewer: a keyboard-driven TUI in a herdr split pane."
 min_herdr_version = "0.7.0"
 platforms = ["linux", "macos"]

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -11,13 +11,13 @@ description = "A git-aware, read-only file viewer: a keyboard-driven TUI in a he
 min_herdr_version = "0.7.0"
 platforms = ["linux", "macos"]
 
-# Build step herdr runs at install time to produce the binary the pane launches. Wrapped in a
-# shell that (1) sources ~/.cargo/env if present, so the build finds `cargo` even when herdr was
-# launched without ~/.cargo/bin on PATH (e.g. a GUI / login-less launch) — the `[ -f ]` guard
-# means a missing env file can't abort the build; and (2) if `cargo` still isn't found, prints a
-# clear "install Rust" message and exits, instead of a cryptic failure.
+# Build step herdr runs at install time. Fast path: scripts/fetch-or-build.sh downloads the
+# prebuilt binary matching this source's version + platform and verifies its SHA-256. On ANY miss
+# (no matching release, download/checksum failure, unsupported platform) it falls back to building
+# from source with cargo — so installing never gets harder than before, and no Rust toolchain is
+# needed when a matching prebuilt release exists.
 [[build]]
-command = ["/bin/sh", "-c", "[ -f \"$HOME/.cargo/env\" ] && . \"$HOME/.cargo/env\"; command -v cargo >/dev/null 2>&1 || { echo 'herdr-file-viewer needs Rust 1.96+ to build, but cargo was not found. Install Rust from https://rustup.rs then re-run: herdr plugin install smarzban/herdr-file-viewer' >&2; exit 1; }; exec cargo build --release"]
+command = ["/bin/sh", "scripts/fetch-or-build.sh"]
 
 # The viewer pane. herdr performs the split placement on launch (AC-17); no runtime
 # command is issued to open the viewer — declaring placement = "split" is what opens

--- a/scripts/fetch-or-build.sh
+++ b/scripts/fetch-or-build.sh
@@ -96,7 +96,7 @@ download "$bin_url" "$tmpbin"   || fallback "prebuilt binary not available for v
 download "$sums_url" "$tmpsums" || fallback "checksums not available for v$version"
 
 # Expected hash = the SHA256SUMS line for our asset filename.
-expected=$(grep " $asset\$" "$tmpsums" 2>/dev/null | awk '{print $1}' | head -n 1)
+expected=$(grep -E "^[0-9a-f]{64}  $asset\$" "$tmpsums" 2>/dev/null | awk '{print $1}' | head -n 1)
 [ -n "$expected" ] || fallback "no checksum listed for $asset"
 
 actual=$(sha256_of "$tmpbin") || fallback "no sha-256 tool (sha256sum/shasum) available"

--- a/scripts/fetch-or-build.sh
+++ b/scripts/fetch-or-build.sh
@@ -1,0 +1,112 @@
+#!/bin/sh
+# fetch-or-build.sh — herdr [[build]] step for herdr-file-viewer.
+#
+# Fast path: download the prebuilt binary that matches THIS source's version + platform from the
+# GitHub release, verify its SHA-256, and install it at target/release/herdr-file-viewer.
+# Fallback: on ANY miss (no asset for this version, network/download error, checksum mismatch,
+# unmapped platform, no curl/wget) print a clear notice and build from source with cargo —
+# identical to the pre-prebuilt behavior, so installing never gets harder than before.
+#
+# Paths and the release base URL are overridable via env (FV_CARGO_TOML / FV_OUT / FV_BASE_URL) so
+# the logic is exercised by a hermetic test with stubbed uname/curl/cargo. Defaults resolve
+# relative to this script, matching how herdr runs the build from the plugin root.
+set -u
+
+repo="smarzban/herdr-file-viewer"
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+repo_root="$script_dir/.."
+cargo_toml="${FV_CARGO_TOML:-$repo_root/Cargo.toml}"
+out="${FV_OUT:-$repo_root/target/release/herdr-file-viewer}"
+base_url="${FV_BASE_URL:-https://github.com/$repo/releases/download}"
+
+have() { command -v "$1" >/dev/null 2>&1; }
+
+# Build from source — the original, unconditional behavior. Source ~/.cargo/env so cargo is found
+# even when herdr was launched without ~/.cargo/bin on PATH (e.g. a GUI / login-less launch); the
+# `[ -f ]` guard means a missing env file can't abort the build. Clear message if cargo is absent.
+build_from_source() {
+  [ -f "$HOME/.cargo/env" ] && . "$HOME/.cargo/env"
+  if ! have cargo; then
+    echo "herdr-file-viewer needs Rust 1.96+ to build, but cargo was not found. Install Rust from https://rustup.rs then re-run: herdr plugin install $repo" >&2
+    exit 1
+  fi
+  exec cargo build --release
+}
+
+fallback() {
+  echo "herdr-file-viewer: $1 — building from source instead." >&2
+  [ -n "${tmpdir:-}" ] && rm -rf "$tmpdir"
+  build_from_source
+}
+
+# --- resolve the target triple from the platform ------------------------------------------
+os=$(uname -s 2>/dev/null || echo unknown)
+arch=$(uname -m 2>/dev/null || echo unknown)
+triple=""
+case "$os" in
+  Darwin)
+    case "$arch" in
+      arm64|aarch64) triple="aarch64-apple-darwin" ;;
+      x86_64|amd64)  triple="x86_64-apple-darwin" ;;
+    esac
+    ;;
+  Linux)
+    case "$arch" in
+      x86_64|amd64)  triple="x86_64-unknown-linux-musl" ;;
+    esac
+    ;;
+esac
+[ -n "$triple" ] || fallback "no prebuilt binary for $os/$arch"
+
+# --- read the version this source declares ------------------------------------------------
+version=$(grep -E '^version *= *"' "$cargo_toml" 2>/dev/null | head -n 1 | sed -E 's/^version *= *"([^"]+)".*/\1/')
+[ -n "$version" ] || fallback "could not read version from $cargo_toml"
+
+asset="herdr-file-viewer-$triple"
+bin_url="$base_url/v$version/$asset"
+sums_url="$base_url/v$version/SHA256SUMS"
+
+download() { # download <url> <dest>
+  if have curl; then
+    curl -fsSL -o "$2" "$1"
+  elif have wget; then
+    wget -q -O "$2" "$1"
+  else
+    return 127
+  fi
+}
+
+sha256_of() { # prints the hex digest of file $1
+  if have sha256sum; then
+    sha256sum "$1" | awk '{print $1}'
+  elif have shasum; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  else
+    return 127
+  fi
+}
+
+tmpdir=$(mktemp -d 2>/dev/null) || fallback "could not create a temp dir"
+trap 'rm -rf "$tmpdir"' EXIT
+tmpbin="$tmpdir/$asset"
+tmpsums="$tmpdir/SHA256SUMS"
+
+download "$bin_url" "$tmpbin"   || fallback "prebuilt binary not available for v$version ($asset)"
+download "$sums_url" "$tmpsums" || fallback "checksums not available for v$version"
+
+# Expected hash = the SHA256SUMS line for our asset filename.
+expected=$(grep " $asset\$" "$tmpsums" 2>/dev/null | awk '{print $1}' | head -n 1)
+[ -n "$expected" ] || fallback "no checksum listed for $asset"
+
+actual=$(sha256_of "$tmpbin") || fallback "no sha-256 tool (sha256sum/shasum) available"
+if [ "$actual" != "$expected" ]; then
+  fallback "checksum mismatch for $asset (expected $expected, got $actual)"
+fi
+
+# Verified — make it executable and move it into place.
+chmod +x "$tmpbin"
+mkdir -p "$(dirname "$out")"
+mv -f "$tmpbin" "$out" || fallback "could not install the verified binary to $out"
+echo "herdr-file-viewer: installed prebuilt v$version ($triple), verified SHA-256."
+exit 0

--- a/scripts/fetch-or-build.sh
+++ b/scripts/fetch-or-build.sh
@@ -15,7 +15,7 @@ set -u
 repo="smarzban/herdr-file-viewer"
 
 script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
-repo_root="$script_dir/.."
+repo_root="${FV_REPO_ROOT:-$script_dir/..}"
 cargo_toml="${FV_CARGO_TOML:-$repo_root/Cargo.toml}"
 out="${FV_OUT:-$repo_root/target/release/herdr-file-viewer}"
 base_url="${FV_BASE_URL:-https://github.com/$repo/releases/download}"
@@ -62,6 +62,16 @@ esac
 # --- read the version this source declares ------------------------------------------------
 version=$(grep -E '^version *= *"' "$cargo_toml" 2>/dev/null | head -n 1 | sed -E 's/^version *= *"([^"]+)".*/\1/')
 [ -n "$version" ] || fallback "could not read version from $cargo_toml"
+
+# Trust the prebuilt only when this checkout is EXACTLY the v$version release commit. Between
+# releases main carries the last released version in Cargo.toml while its HEAD has moved past the
+# tag; without this check we'd install the older tagged binary for newer source. When the checkout
+# is not a git work tree (e.g. an unpacked tarball) we can't verify, so we proceed on the version.
+if have git && git -C "$repo_root" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  head_rev=$(git -C "$repo_root" rev-parse HEAD 2>/dev/null || echo nohead)
+  tag_rev=$(git -C "$repo_root" rev-parse -q --verify "refs/tags/v$version^{commit}" 2>/dev/null || echo notag)
+  [ "$head_rev" = "$tag_rev" ] || fallback "checkout is not the v$version release tag (source may be ahead) — building from source"
+fi
 
 asset="herdr-file-viewer-$triple"
 bin_url="$base_url/v$version/$asset"

--- a/tests/fetch_or_build.rs
+++ b/tests/fetch_or_build.rs
@@ -64,7 +64,14 @@ impl Outcome {
 /// Run the script with stubbed uname/curl/cargo.
 /// - `serve_binary == false` → fake curl fails the binary fetch (simulates a 404 / missing asset).
 /// - `corrupt_sums == true`  → the published SHA256SUMS holds a wrong hash (checksum mismatch).
-fn run(os: &str, arch: &str, version: &str, serve_binary: bool, corrupt_sums: bool) -> Outcome {
+fn run_impl(
+    os: &str,
+    arch: &str,
+    version: &str,
+    serve_binary: bool,
+    corrupt_sums: bool,
+    repo_root: Option<&Path>,
+) -> Outcome {
     let root = tmp("root");
     let stub = root.join("bin");
     let server = root.join("server");
@@ -129,11 +136,16 @@ fn run(os: &str, arch: &str, version: &str, serve_binary: bool, corrupt_sums: bo
         "#!/bin/sh\necho FAKE_CARGO_BUILD \"$@\"\nexit 0\n",
     );
 
+    // The release-tag gate inspects FV_REPO_ROOT as a git work tree. By default point it at the
+    // (non-git) temp root so the gate is skipped and the platform/download/verify logic is what's
+    // under test; the gate's own tests pass a real git repo here.
+    let fv_repo_root: &Path = repo_root.unwrap_or(root.as_path());
     let path = format!("{}:{}", stub.display(), std::env::var("PATH").unwrap());
     let output = Command::new("sh")
         .arg(script_path())
         .env("PATH", path)
         .env("HOME", &root) // no ~/.cargo/env here, so the fallback uses the stubbed cargo
+        .env("FV_REPO_ROOT", fv_repo_root)
         .env("FV_CARGO_TOML", &cargo_toml)
         .env("FV_OUT", &out)
         .env("FV_BASE_URL", "https://example.invalid/releases/download")
@@ -154,6 +166,47 @@ fn run(os: &str, arch: &str, version: &str, serve_binary: bool, corrupt_sums: bo
     };
     let _ = fs::remove_dir_all(&root);
     o
+}
+
+/// Default runner: no git work tree at FV_REPO_ROOT, so the release-tag gate is skipped and the
+/// platform/download/verify path is exercised directly.
+fn run(os: &str, arch: &str, version: &str, serve_binary: bool, corrupt_sums: bool) -> Outcome {
+    run_impl(os, arch, version, serve_binary, corrupt_sums, None)
+}
+
+/// Throwaway git repo at `dir`: one commit tagged `v<version>`, plus (if `head_ahead`) a second
+/// commit so HEAD is past the tag. Drives the release-tag gate.
+fn make_git_repo(dir: &Path, version: &str, head_ahead: bool) {
+    fs::create_dir_all(dir).unwrap();
+    let g = |args: &[&str]| {
+        let o = Command::new("git")
+            .arg("-C")
+            .arg(dir)
+            .args(args)
+            .env("GIT_CONFIG_GLOBAL", "/dev/null")
+            .env("GIT_CONFIG_SYSTEM", "/dev/null")
+            .env("GIT_AUTHOR_NAME", "t")
+            .env("GIT_AUTHOR_EMAIL", "t@e")
+            .env("GIT_COMMITTER_NAME", "t")
+            .env("GIT_COMMITTER_EMAIL", "t@e")
+            .output()
+            .unwrap();
+        assert!(
+            o.status.success(),
+            "git {args:?}: {}",
+            String::from_utf8_lossy(&o.stderr)
+        );
+    };
+    g(&["init", "-q"]);
+    fs::write(dir.join("f.txt"), "1").unwrap();
+    g(&["add", "-A"]);
+    g(&["commit", "-q", "-m", "release"]);
+    g(&["tag", &format!("v{version}")]);
+    if head_ahead {
+        fs::write(dir.join("f.txt"), "2").unwrap();
+        g(&["add", "-A"]);
+        g(&["commit", "-q", "-m", "post-release"]);
+    }
 }
 
 #[test]
@@ -260,4 +313,45 @@ fn script_preserves_the_cargo_source_build_fallback() {
         s.contains(".cargo/env"),
         "fallback must source ~/.cargo/env like the original build step"
     );
+}
+
+#[test]
+fn gate_uses_prebuilt_when_checkout_is_exactly_the_release_tag() {
+    let gitdir = tmp("gitrepo-attag");
+    make_git_repo(&gitdir, "1.2.0", false); // HEAD == v1.2.0 tag
+    let o = run_impl("Linux", "x86_64", "1.2.0", true, false, Some(&gitdir));
+    assert!(
+        o.installed_prebuilt(),
+        "at the release tag the prebuilt should be used\nstdout:{}\nstderr:{}",
+        o.stdout,
+        o.stderr
+    );
+    assert!(
+        !o.fell_back(),
+        "must not build from source at the exact release commit"
+    );
+    let _ = fs::remove_dir_all(&gitdir);
+}
+
+#[test]
+fn gate_falls_back_when_checkout_is_ahead_of_the_release_tag() {
+    let gitdir = tmp("gitrepo-ahead");
+    make_git_repo(&gitdir, "1.2.0", true); // HEAD one commit past v1.2.0
+    let o = run_impl("Linux", "x86_64", "1.2.0", true, false, Some(&gitdir));
+    assert!(
+        o.fell_back(),
+        "source ahead of the tag must build from source\nstdout:{}\nstderr:{}",
+        o.stdout,
+        o.stderr
+    );
+    assert!(
+        o.placed.is_none(),
+        "must not install the stale tagged binary"
+    );
+    assert!(
+        o.urls.is_empty(),
+        "the gate must fire before any download; urls: {:?}",
+        o.urls
+    );
+    let _ = fs::remove_dir_all(&gitdir);
 }

--- a/tests/fetch_or_build.rs
+++ b/tests/fetch_or_build.rs
@@ -1,0 +1,263 @@
+//! Hermetic test for scripts/fetch-or-build.sh — the install-time [[build]] step.
+//! Stubs uname/curl/cargo via PATH and serves a local fixture "release"; uses the real
+//! sha256sum/shasum, mktemp, grep, etc. No network, no real cargo build, no new deps.
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static N: AtomicU64 = AtomicU64::new(0);
+
+fn script_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("scripts/fetch-or-build.sh")
+}
+
+fn tmp(label: &str) -> PathBuf {
+    let n = N.fetch_add(1, Ordering::Relaxed);
+    let p = std::env::temp_dir().join(format!("fv-fob-{}-{}-{}", std::process::id(), label, n));
+    fs::create_dir_all(&p).unwrap();
+    p
+}
+
+fn write_exec(path: &Path, body: &str) {
+    fs::write(path, body).unwrap();
+    let mut perm = fs::metadata(path).unwrap().permissions();
+    perm.set_mode(0o755);
+    fs::set_permissions(path, perm).unwrap();
+}
+
+/// Hex sha-256 of a file using whatever tool exists (matches the script's preference order).
+fn sha256_of(file: &Path) -> String {
+    if let Ok(out) = Command::new("sha256sum").arg(file).output()
+        && out.status.success()
+    {
+        let s = String::from_utf8_lossy(&out.stdout);
+        return s.split_whitespace().next().unwrap().to_string();
+    }
+    let out = Command::new("shasum")
+        .args(["-a", "256"])
+        .arg(file)
+        .output()
+        .expect("need sha256sum or shasum to run this test");
+    let s = String::from_utf8_lossy(&out.stdout);
+    s.split_whitespace().next().unwrap().to_string()
+}
+
+struct Outcome {
+    stdout: String,
+    stderr: String,
+    placed: Option<Vec<u8>>,
+    urls: Vec<String>,
+}
+
+impl Outcome {
+    fn installed_prebuilt(&self) -> bool {
+        self.stdout.contains("installed prebuilt")
+    }
+    fn fell_back(&self) -> bool {
+        self.stdout.contains("FAKE_CARGO_BUILD")
+    }
+}
+
+/// Run the script with stubbed uname/curl/cargo.
+/// - `serve_binary == false` → fake curl fails the binary fetch (simulates a 404 / missing asset).
+/// - `corrupt_sums == true`  → the published SHA256SUMS holds a wrong hash (checksum mismatch).
+fn run(os: &str, arch: &str, version: &str, serve_binary: bool, corrupt_sums: bool) -> Outcome {
+    let root = tmp("root");
+    let stub = root.join("bin");
+    let server = root.join("server");
+    let out = root.join("target/release/herdr-file-viewer");
+    let urllog = root.join("urls.log");
+    fs::create_dir_all(&stub).unwrap();
+    fs::create_dir_all(&server).unwrap();
+
+    let cargo_toml = root.join("Cargo.toml");
+    fs::write(
+        &cargo_toml,
+        format!("[package]\nname = \"herdr-file-viewer\"\nversion = \"{version}\"\n"),
+    )
+    .unwrap();
+
+    // The triple the script will resolve — kept in lockstep with the script's mapping.
+    let triple = match (os, arch) {
+        ("Darwin", "arm64") | ("Darwin", "aarch64") => "aarch64-apple-darwin",
+        ("Darwin", "x86_64") => "x86_64-apple-darwin",
+        ("Linux", "x86_64") => "x86_64-unknown-linux-musl",
+        _ => "",
+    };
+
+    let bin_blob: &[u8] = b"#!/bin/sh\necho prebuilt-viewer\n";
+    fs::write(server.join("bin"), bin_blob).unwrap();
+    if !triple.is_empty() {
+        let real = sha256_of(&server.join("bin"));
+        let hash = if corrupt_sums { "0".repeat(64) } else { real };
+        fs::write(
+            server.join("SHA256SUMS"),
+            format!("{hash}  herdr-file-viewer-{triple}\n"),
+        )
+        .unwrap();
+    }
+
+    write_exec(
+        &stub.join("uname"),
+        &format!(
+            "#!/bin/sh\ncase \"$1\" in\n  -s) echo {os} ;;\n  -m) echo {arch} ;;\n  *) echo {os} ;;\nesac\n"
+        ),
+    );
+
+    let bin_rule = if serve_binary {
+        format!("cp \"{}/bin\" \"$dest\"", server.display())
+    } else {
+        "exit 22".to_string() // curl -f exits 22 on HTTP >= 400
+    };
+    write_exec(
+        &stub.join("curl"),
+        &format!(
+            "#!/bin/sh\ndest=\"\"; url=\"\"\n\
+             while [ $# -gt 0 ]; do case \"$1\" in -o) dest=\"$2\"; shift 2 ;; -*) shift ;; *) url=\"$1\"; shift ;; esac; done\n\
+             echo \"$url\" >> \"{log}\"\n\
+             case \"$url\" in\n  */SHA256SUMS) cp \"{srv}/SHA256SUMS\" \"$dest\" ;;\n  *) {bin_rule} ;;\nesac\n",
+            log = urllog.display(),
+            srv = server.display(),
+        ),
+    );
+
+    write_exec(
+        &stub.join("cargo"),
+        "#!/bin/sh\necho FAKE_CARGO_BUILD \"$@\"\nexit 0\n",
+    );
+
+    let path = format!("{}:{}", stub.display(), std::env::var("PATH").unwrap());
+    let output = Command::new("sh")
+        .arg(script_path())
+        .env("PATH", path)
+        .env("HOME", &root) // no ~/.cargo/env here, so the fallback uses the stubbed cargo
+        .env("FV_CARGO_TOML", &cargo_toml)
+        .env("FV_OUT", &out)
+        .env("FV_BASE_URL", "https://example.invalid/releases/download")
+        .output()
+        .expect("run fetch-or-build.sh");
+
+    let urls = fs::read_to_string(&urllog)
+        .unwrap_or_default()
+        .lines()
+        .map(|s| s.to_string())
+        .collect();
+    let placed = fs::read(&out).ok();
+    let o = Outcome {
+        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+        stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+        placed,
+        urls,
+    };
+    let _ = fs::remove_dir_all(&root);
+    o
+}
+
+#[test]
+fn fast_path_installs_verified_binary_on_apple_silicon() {
+    let o = run("Darwin", "arm64", "1.2.0", true, false);
+    assert!(
+        o.installed_prebuilt(),
+        "stdout: {}\nstderr: {}",
+        o.stdout,
+        o.stderr
+    );
+    assert!(
+        !o.fell_back(),
+        "must not build from source on the fast path"
+    );
+    assert_eq!(
+        o.placed.as_deref(),
+        Some(&b"#!/bin/sh\necho prebuilt-viewer\n"[..])
+    );
+    assert!(
+        o.urls
+            .iter()
+            .any(|u| u.ends_with("/v1.2.0/herdr-file-viewer-aarch64-apple-darwin")),
+        "fetched exactly the version+triple asset, never 'latest'; urls: {:?}",
+        o.urls
+    );
+    assert!(
+        o.urls.iter().any(|u| u.ends_with("/v1.2.0/SHA256SUMS")),
+        "urls: {:?}",
+        o.urls
+    );
+}
+
+#[test]
+fn maps_intel_mac_to_x86_64_apple_darwin() {
+    let o = run("Darwin", "x86_64", "1.2.0", true, false);
+    assert!(o.installed_prebuilt(), "{}", o.stderr);
+    assert!(
+        o.urls
+            .iter()
+            .any(|u| u.ends_with("/v1.2.0/herdr-file-viewer-x86_64-apple-darwin")),
+        "urls: {:?}",
+        o.urls
+    );
+}
+
+#[test]
+fn maps_linux_to_static_musl_triple() {
+    let o = run("Linux", "x86_64", "1.2.0", true, false);
+    assert!(o.installed_prebuilt(), "{}", o.stderr);
+    assert!(
+        o.urls
+            .iter()
+            .any(|u| u.ends_with("/v1.2.0/herdr-file-viewer-x86_64-unknown-linux-musl")),
+        "urls: {:?}",
+        o.urls
+    );
+}
+
+#[test]
+fn checksum_mismatch_falls_back_and_installs_nothing() {
+    let o = run("Linux", "x86_64", "1.2.0", true, true);
+    assert!(o.fell_back(), "stdout: {}", o.stdout);
+    assert!(o.placed.is_none(), "must not install an unverified binary");
+    assert!(
+        o.stderr.contains("checksum mismatch"),
+        "stderr: {}",
+        o.stderr
+    );
+}
+
+#[test]
+fn missing_release_asset_falls_back_to_source_build() {
+    let o = run("Linux", "x86_64", "9.9.9", false, false);
+    assert!(o.fell_back(), "stdout: {}", o.stdout);
+    assert!(o.placed.is_none());
+    assert!(o.stderr.contains("not available"), "stderr: {}", o.stderr);
+}
+
+#[test]
+fn unmapped_platform_falls_back_without_downloading() {
+    let o = run("Linux", "riscv64", "1.2.0", true, false);
+    assert!(o.fell_back(), "stdout: {}", o.stdout);
+    assert!(
+        o.urls.is_empty(),
+        "must not download for an unsupported platform; urls: {:?}",
+        o.urls
+    );
+    assert!(
+        o.stderr.contains("no prebuilt binary"),
+        "stderr: {}",
+        o.stderr
+    );
+}
+
+#[test]
+fn script_preserves_the_cargo_source_build_fallback() {
+    let s = fs::read_to_string(script_path()).unwrap();
+    assert!(
+        s.contains("cargo build --release"),
+        "fallback must still build from source"
+    );
+    assert!(
+        s.contains(".cargo/env"),
+        "fallback must source ~/.cargo/env like the original build step"
+    );
+}

--- a/tests/manifest.rs
+++ b/tests/manifest.rs
@@ -92,12 +92,8 @@ fn declares_a_release_build_command() {
         "manifest must declare a [[build]] step"
     );
     assert!(
-        m.contains("cargo build --release"),
-        "the build step must run `cargo build --release`"
-    );
-    assert!(
-        m.contains(".cargo/env"),
-        "the build step must source ~/.cargo/env so it finds cargo regardless of how herdr launched it"
+        m.contains("scripts/fetch-or-build.sh"),
+        "the build step must run the fetch-or-build script (prebuilt binary, cargo fallback)"
     );
 }
 

--- a/tests/release_workflow.rs
+++ b/tests/release_workflow.rs
@@ -1,0 +1,47 @@
+//! The release workflow's contract, asserted as text (mirrors tests/manifest.rs): it triggers on
+//! version tags, builds the three published targets, guards the tag against the crate version, and
+//! publishes a SHA256SUMS. These are the invariants scripts/fetch-or-build.sh relies on; GitHub
+//! Actions itself is exercised by cutting a real tag (a manual verification step).
+
+use std::fs;
+use std::path::PathBuf;
+
+fn workflow() -> String {
+    let p = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(".github/workflows/release.yml");
+    fs::read_to_string(&p).unwrap_or_else(|e| panic!("read {}: {e}", p.display()))
+}
+
+#[test]
+fn triggers_on_version_tags() {
+    let w = workflow();
+    assert!(w.contains("tags:"), "release must be tag-triggered");
+    assert!(w.contains("v*"), "release must trigger on v* tags");
+}
+
+#[test]
+fn builds_the_three_published_targets() {
+    let w = workflow();
+    for triple in [
+        "aarch64-apple-darwin",
+        "x86_64-apple-darwin",
+        "x86_64-unknown-linux-musl",
+    ] {
+        assert!(w.contains(triple), "release must build {triple}");
+    }
+}
+
+#[test]
+fn publishes_a_sha256sums_file() {
+    assert!(
+        workflow().contains("SHA256SUMS"),
+        "release must publish a SHA256SUMS for the binaries"
+    );
+}
+
+#[test]
+fn guards_the_tag_against_the_crate_version() {
+    assert!(
+        workflow().contains("Cargo.toml"),
+        "release must verify the pushed tag matches Cargo.toml's version"
+    );
+}


### PR DESCRIPTION
## What & why

Lets users install the plugin **without a Rust toolchain**. At install time herdr's `[[build]]` step now runs `scripts/fetch-or-build.sh`, which downloads a **SHA-256-verified prebuilt binary matching the source's version + platform** and falls back to `cargo build --release` on any miss. The install command is unchanged and never harder than before. Ships as **v1.2.0**.

## How it works

- **`scripts/fetch-or-build.sh`** (new `[[build]]` command): resolves the target triple from `uname`, reads the version from `Cargo.toml`, downloads `…/releases/download/v<version>/herdr-file-viewer-<triple>` + `SHA256SUMS` over HTTPS, **verifies the hash before `chmod +x`**, and installs to `target/release/herdr-file-viewer`. **Any** failure (unsupported platform, missing asset, network error, checksum mismatch, no curl/wget) prints a stderr notice and execs the original cargo build (preserving the `~/.cargo/env` sourcing + "install Rust 1.96+" message).
- **`.github/workflows/release.yml`** (new): on a `v*` tag push, cross-builds the three targets — `aarch64-apple-darwin` + `x86_64-apple-darwin` (one macOS runner) and `x86_64-unknown-linux-musl` (static, ubuntu) — guards that the tag matches `Cargo.toml`'s version, and publishes the binaries + `SHA256SUMS` to the release (create-or-update + `--clobber`).
- **Version-matching (load-bearing):** the script fetches the tag `v<Cargo.toml version>` **exactly, never "latest"** — so the binary always matches the cloned source. A tagged commit hits the fast path; a between-release `main` HEAD cleanly falls back to a source build.

## Tests

- `tests/fetch_or_build.rs` — 7 hermetic tests (PATH-stubbed `uname`/`curl`/`cargo`, real `sha256sum`/`shasum`, local fixture): per-platform triple mapping, checksum-verified install, and mismatch / missing-asset / unmapped-platform → fallback (asserts nothing unverified is ever installed).
- `tests/release_workflow.rs` — 4 string-contract tests (mirrors `tests/manifest.rs`): tag trigger, the three targets, `SHA256SUMS`, and the tag-vs-`Cargo.toml` guard. The YAML was also validated with a real `yaml.safe_load`.
- Full suite: 239 passing; clippy `-D warnings` and `cargo fmt --check` clean.

## Scope / notes

- **No new Cargo dependencies.** Read-only plugin — no runtime behavior change; crosses no constitution line (no ADR).
- **Out of scope (deferred):** signatures (layer on later with zero install-UX change), Windows, ARM-Linux, tar.gz packaging.
- **Follow-up logged (AUDIT.md):** GitHub Actions are pinned by version tag, not commit SHA — consistent with the existing `ci.yml`; a repo-wide SHA-pin is a deferred hardening pass (owner decision).

## Verification after merge

Cut `v1.2.0` (owner-gated) → the new workflow attaches the 3 binaries + `SHA256SUMS`; then confirm a Rust-less `herdr plugin install` reports `installed prebuilt v1.2.0 …`.
