### PR TITLE
fix: prebuilt install gate uses a published COMMIT marker (v1.2.1 hotfix)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,12 @@ jobs:
           # Flatten the per-target binaries and concatenate their checksum lines into one file.
           find artifacts -type f -name 'herdr-file-viewer-*' ! -name '*.sha256' -exec cp {} release/ \;
           cat artifacts/*/*.sha256 > release/SHA256SUMS
-          echo "Publishing:"; ls -l release; echo "---"; cat release/SHA256SUMS
+          # Record the exact commit this release was built from. The install step compares its
+          # checkout's HEAD to this so the prebuilt is used only when the source IS the released
+          # commit (herdr's install checkout lacks local tags, so HEAD vs. this marker is how the
+          # script verifies the match without resolving a tag).
+          printf '%s\n' "$GITHUB_SHA" > release/COMMIT
+          echo "Publishing:"; ls -l release; echo "--- SHA256SUMS ---"; cat release/SHA256SUMS; echo "--- COMMIT ---"; cat release/COMMIT
 
       - name: Create-or-update the release and upload assets
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2026-06-23
+
+### Fixed
+- Prebuilt install path now works for a normal `herdr plugin install`. v1.2.0 gated the prebuilt on
+  a local `v<version>` tag ref, but herdr's install checkout clones the commit *without* tags, so the
+  gate always fell back to a source build (failing when Rust was absent). The gate now compares the
+  checkout's `HEAD` to a `COMMIT` marker published in the release — so the prebuilt is used whenever
+  the source is exactly the released commit, while a `main` ahead of the tag still builds from source.
+
 ## [1.2.0] - 2026-06-23
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -574,7 +574,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "herdr-file-viewer"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "ansi-to-tui",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "herdr-file-viewer"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2024"
 rust-version = "1.96"
 description = "A git-aware, read-only file viewer that runs as a herdr TUI pane"

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -6,7 +6,7 @@
 
 id = "herdr-file-viewer"
 name = "herdr-file-viewer"
-version = "1.2.0"
+version = "1.2.1"
 description = "A git-aware, read-only file viewer: a keyboard-driven TUI in a herdr split pane."
 min_herdr_version = "0.7.0"
 platforms = ["linux", "macos"]

--- a/scripts/fetch-or-build.sh
+++ b/scripts/fetch-or-build.sh
@@ -3,13 +3,13 @@
 #
 # Fast path: download the prebuilt binary that matches THIS source's version + platform from the
 # GitHub release, verify its SHA-256, and install it at target/release/herdr-file-viewer.
-# Fallback: on ANY miss (no asset for this version, network/download error, checksum mismatch,
-# unmapped platform, no curl/wget) print a clear notice and build from source with cargo —
-# identical to the pre-prebuilt behavior, so installing never gets harder than before.
+# Fallback: on ANY miss (source is not the released commit, no asset for this version,
+# network/download error, checksum mismatch, unmapped platform, no curl/wget) print a clear notice
+# and build from source with cargo — identical to the pre-prebuilt behavior, so installing never
+# gets harder than before.
 #
-# Paths and the release base URL are overridable via env (FV_CARGO_TOML / FV_OUT / FV_BASE_URL) so
-# the logic is exercised by a hermetic test with stubbed uname/curl/cargo. Defaults resolve
-# relative to this script, matching how herdr runs the build from the plugin root.
+# Paths and the release base URL are overridable via env (FV_REPO_ROOT / FV_CARGO_TOML / FV_OUT /
+# FV_BASE_URL) so the logic is exercised by a hermetic test with stubbed uname/curl/cargo/git.
 set -u
 
 repo="smarzban/herdr-file-viewer"
@@ -40,6 +40,26 @@ fallback() {
   build_from_source
 }
 
+download() { # download <url> <dest>
+  if have curl; then
+    curl -fsSL -o "$2" "$1"
+  elif have wget; then
+    wget -q -O "$2" "$1"
+  else
+    return 127
+  fi
+}
+
+sha256_of() { # prints the hex digest of file $1
+  if have sha256sum; then
+    sha256sum "$1" | awk '{print $1}'
+  elif have shasum; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  else
+    return 127
+  fi
+}
+
 # --- resolve the target triple from the platform ------------------------------------------
 os=$(uname -s 2>/dev/null || echo unknown)
 arch=$(uname -m 2>/dev/null || echo unknown)
@@ -63,42 +83,31 @@ esac
 version=$(grep -E '^version *= *"' "$cargo_toml" 2>/dev/null | head -n 1 | sed -E 's/^version *= *"([^"]+)".*/\1/')
 [ -n "$version" ] || fallback "could not read version from $cargo_toml"
 
-# Trust the prebuilt only when this checkout is EXACTLY the v$version release commit. Between
-# releases main carries the last released version in Cargo.toml while its HEAD has moved past the
-# tag; without this check we'd install the older tagged binary for newer source. When the checkout
-# is not a git work tree (e.g. an unpacked tarball) we can't verify, so we proceed on the version.
-if have git && git -C "$repo_root" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-  head_rev=$(git -C "$repo_root" rev-parse HEAD 2>/dev/null || echo nohead)
-  tag_rev=$(git -C "$repo_root" rev-parse -q --verify "refs/tags/v$version^{commit}" 2>/dev/null || echo notag)
-  [ "$head_rev" = "$tag_rev" ] || fallback "checkout is not the v$version release tag (source may be ahead) — building from source"
-fi
-
 asset="herdr-file-viewer-$triple"
-bin_url="$base_url/v$version/$asset"
-sums_url="$base_url/v$version/SHA256SUMS"
-
-download() { # download <url> <dest>
-  if have curl; then
-    curl -fsSL -o "$2" "$1"
-  elif have wget; then
-    wget -q -O "$2" "$1"
-  else
-    return 127
-  fi
-}
-
-sha256_of() { # prints the hex digest of file $1
-  if have sha256sum; then
-    sha256sum "$1" | awk '{print $1}'
-  elif have shasum; then
-    shasum -a 256 "$1" | awk '{print $1}'
-  else
-    return 127
-  fi
-}
 
 tmpdir=$(mktemp -d 2>/dev/null) || fallback "could not create a temp dir"
 trap 'rm -rf "$tmpdir"' EXIT
+
+# --- gate: this checkout must be EXACTLY the commit the v$version release was built from ----
+# `herdr plugin install` clones a git work tree at the chosen commit but usually WITHOUT local tags,
+# so we cannot resolve the release tag locally. Instead we compare the checkout's HEAD to the commit
+# recorded in the release's COMMIT asset (a plain HTTPS download; `git rev-parse HEAD` is a safe
+# local ref read — no remote, no config-driven command execution). Between releases this repo's main
+# sits at the last released version while its HEAD has advanced past the tag; this check makes the
+# prebuilt fire only when the source IS the released commit, otherwise we build from source. When the
+# checkout is not a git work tree (e.g. an unpacked tarball) ahead-ness is undefined, so we proceed
+# on the version as before.
+if have git && git -C "$repo_root" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  head_rev=$(git -C "$repo_root" rev-parse HEAD 2>/dev/null || echo nohead)
+  download "$base_url/v$version/COMMIT" "$tmpdir/COMMIT" || fallback "release commit marker not available for v$version"
+  release_commit=$(tr -d '[:space:]' < "$tmpdir/COMMIT" 2>/dev/null)
+  if [ -z "$release_commit" ] || [ "$head_rev" != "$release_commit" ]; then
+    fallback "checkout ($head_rev) is not the v$version release commit ($release_commit) — building from source"
+  fi
+fi
+
+bin_url="$base_url/v$version/$asset"
+sums_url="$base_url/v$version/SHA256SUMS"
 tmpbin="$tmpdir/$asset"
 tmpsums="$tmpdir/SHA256SUMS"
 

--- a/tests/fetch_or_build.rs
+++ b/tests/fetch_or_build.rs
@@ -71,6 +71,7 @@ fn run_impl(
     serve_binary: bool,
     corrupt_sums: bool,
     repo_root: Option<&Path>,
+    commit_marker: Option<&str>,
 ) -> Outcome {
     let root = tmp("root");
     let stub = root.join("bin");
@@ -107,6 +108,11 @@ fn run_impl(
         .unwrap();
     }
 
+    // The COMMIT marker the release publishes; the gate compares the checkout's HEAD to it.
+    if let Some(c) = commit_marker {
+        fs::write(server.join("COMMIT"), format!("{c}\n")).unwrap();
+    }
+
     write_exec(
         &stub.join("uname"),
         &format!(
@@ -125,7 +131,7 @@ fn run_impl(
             "#!/bin/sh\ndest=\"\"; url=\"\"\n\
              while [ $# -gt 0 ]; do case \"$1\" in -o) dest=\"$2\"; shift 2 ;; -*) shift ;; *) url=\"$1\"; shift ;; esac; done\n\
              echo \"$url\" >> \"{log}\"\n\
-             case \"$url\" in\n  */SHA256SUMS) cp \"{srv}/SHA256SUMS\" \"$dest\" ;;\n  *) {bin_rule} ;;\nesac\n",
+             case \"$url\" in\n  */COMMIT) cp \"{srv}/COMMIT\" \"$dest\" ;;\n  */SHA256SUMS) cp \"{srv}/SHA256SUMS\" \"$dest\" ;;\n  *) {bin_rule} ;;\nesac\n",
             log = urllog.display(),
             srv = server.display(),
         ),
@@ -171,14 +177,15 @@ fn run_impl(
 /// Default runner: no git work tree at FV_REPO_ROOT, so the release-tag gate is skipped and the
 /// platform/download/verify path is exercised directly.
 fn run(os: &str, arch: &str, version: &str, serve_binary: bool, corrupt_sums: bool) -> Outcome {
-    run_impl(os, arch, version, serve_binary, corrupt_sums, None)
+    run_impl(os, arch, version, serve_binary, corrupt_sums, None, None)
 }
 
-/// Throwaway git repo at `dir`: one commit tagged `v<version>`, plus (if `head_ahead`) a second
-/// commit so HEAD is past the tag. Drives the release-tag gate.
-fn make_git_repo(dir: &Path, version: &str, head_ahead: bool) {
+/// Throwaway git repo at `dir` with a single commit and NO tag — exactly like herdr's install
+/// checkout (a work tree at the cloned commit, without local tags). Returns the HEAD commit SHA,
+/// which the COMMIT-gate compares against the release's published marker.
+fn make_git_repo(dir: &Path) -> String {
     fs::create_dir_all(dir).unwrap();
-    let g = |args: &[&str]| {
+    let g = |args: &[&str]| -> std::process::Output {
         let o = Command::new("git")
             .arg("-C")
             .arg(dir)
@@ -196,17 +203,14 @@ fn make_git_repo(dir: &Path, version: &str, head_ahead: bool) {
             "git {args:?}: {}",
             String::from_utf8_lossy(&o.stderr)
         );
+        o
     };
     g(&["init", "-q"]);
     fs::write(dir.join("f.txt"), "1").unwrap();
     g(&["add", "-A"]);
     g(&["commit", "-q", "-m", "release"]);
-    g(&["tag", &format!("v{version}")]);
-    if head_ahead {
-        fs::write(dir.join("f.txt"), "2").unwrap();
-        g(&["add", "-A"]);
-        g(&["commit", "-q", "-m", "post-release"]);
-    }
+    let head = g(&["rev-parse", "HEAD"]);
+    String::from_utf8_lossy(&head.stdout).trim().to_string()
 }
 
 #[test]
@@ -315,42 +319,66 @@ fn script_preserves_the_cargo_source_build_fallback() {
     );
 }
 
+// Regression test for the v1.2.0 install failure: herdr's checkout is a git work tree at the
+// release commit but WITHOUT local tags. The gate must confirm the match via the published COMMIT
+// marker (HEAD == COMMIT), not a local tag ref, and use the prebuilt.
 #[test]
-fn gate_uses_prebuilt_when_checkout_is_exactly_the_release_tag() {
-    let gitdir = tmp("gitrepo-attag");
-    make_git_repo(&gitdir, "1.2.0", false); // HEAD == v1.2.0 tag
-    let o = run_impl("Linux", "x86_64", "1.2.0", true, false, Some(&gitdir));
+fn gate_uses_prebuilt_when_head_matches_the_release_commit() {
+    let gitdir = tmp("gitrepo-match");
+    let head = make_git_repo(&gitdir); // tagless work tree, like herdr's install checkout
+    let o = run_impl(
+        "Linux",
+        "x86_64",
+        "1.2.0",
+        true,
+        false,
+        Some(&gitdir),
+        Some(&head),
+    );
     assert!(
         o.installed_prebuilt(),
-        "at the release tag the prebuilt should be used\nstdout:{}\nstderr:{}",
+        "HEAD matches the release COMMIT → prebuilt must be used\nstdout:{}\nstderr:{}",
         o.stdout,
         o.stderr
     );
     assert!(
         !o.fell_back(),
-        "must not build from source at the exact release commit"
+        "must not build from source when HEAD is the released commit"
+    );
+    assert!(
+        o.urls.iter().any(|u| u.ends_with("/v1.2.0/COMMIT")),
+        "gate must fetch the COMMIT marker; urls: {:?}",
+        o.urls
     );
     let _ = fs::remove_dir_all(&gitdir);
 }
 
+// When the checkout's HEAD differs from the release commit (e.g. main has advanced past the tag),
+// the gate must fall back to a source build and never install the stale binary.
 #[test]
-fn gate_falls_back_when_checkout_is_ahead_of_the_release_tag() {
+fn gate_falls_back_when_head_differs_from_the_release_commit() {
     let gitdir = tmp("gitrepo-ahead");
-    make_git_repo(&gitdir, "1.2.0", true); // HEAD one commit past v1.2.0
-    let o = run_impl("Linux", "x86_64", "1.2.0", true, false, Some(&gitdir));
+    let _head = make_git_repo(&gitdir);
+    let other = "0000000000000000000000000000000000000000"; // a commit this checkout is NOT at
+    let o = run_impl(
+        "Linux",
+        "x86_64",
+        "1.2.0",
+        true,
+        false,
+        Some(&gitdir),
+        Some(other),
+    );
     assert!(
         o.fell_back(),
-        "source ahead of the tag must build from source\nstdout:{}\nstderr:{}",
+        "HEAD != release commit must build from source\nstdout:{}\nstderr:{}",
         o.stdout,
         o.stderr
     );
+    assert!(o.placed.is_none(), "must not install the stale binary");
     assert!(
-        o.placed.is_none(),
-        "must not install the stale tagged binary"
-    );
-    assert!(
-        o.urls.is_empty(),
-        "the gate must fire before any download; urls: {:?}",
+        !o.urls.iter().any(|u| u.contains("herdr-file-viewer-")),
+        "the gate must fire before the binary download; urls: {:?}",
         o.urls
     );
     let _ = fs::remove_dir_all(&gitdir);

--- a/tests/release_workflow.rs
+++ b/tests/release_workflow.rs
@@ -45,3 +45,14 @@ fn guards_the_tag_against_the_crate_version() {
         "release must verify the pushed tag matches Cargo.toml's version"
     );
 }
+
+#[test]
+fn publishes_a_commit_marker() {
+    let w = workflow();
+    // The install gate compares the checkout's HEAD to this marker (herdr's checkout lacks tags),
+    // so the release must publish the built commit as a COMMIT asset.
+    assert!(
+        w.contains("release/COMMIT") && w.contains("GITHUB_SHA"),
+        "release must publish a COMMIT marker (the GITHUB_SHA it was built from)"
+    );
+}


### PR DESCRIPTION
## Why
v1.2.0's prebuilt install path is **broken for a normal `herdr plugin install`**. The release-tag gate compared `git rev-parse HEAD` to a local `refs/tags/v$version` ref — but herdr clones the release commit **without fetching tags**, so the tag ref is absent, the gate always falls back to a source build, and the install fails when Rust isn't present:

```
herdr-file-viewer: checkout is not the v1.2.0 release tag (source may be ahead) — building from source
herdr-file-viewer needs Rust 1.96+ to build, but cargo was not found.
```

## Fix
Gate on a **published `COMMIT` marker** instead of a local tag:
- The release workflow writes the built commit (`$GITHUB_SHA`) to a `COMMIT` asset.
- `fetch-or-build.sh` compares the checkout's `HEAD` (a safe local ref read — no remote, no config-driven execution) to that marker. Prebuilt is used iff `HEAD == COMMIT`; a `main` ahead of the tag still falls back to source. Works with herdr's tagless checkout.

## Tests
- New regression test `gate_uses_prebuilt_when_head_matches_the_release_commit` models herdr's **tagless** checkout (a git work tree, no tag) → must use the prebuilt. Plus `gate_falls_back_when_head_differs_from_the_release_commit`.
- `release_workflow.rs` gains `publishes_a_commit_marker`.
- Full suite green; clippy `-D warnings` + fmt clean.

Ships as **v1.2.1**.