### PR TITLE
chore(release): v1.2.2 (docs-only re-tag for prebuilt fast path)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.2] - 2026-06-23
+
+### Docs
+- Slimmed the README to the essentials (pitch, quick start, keys, links) and moved the longer
+  guides into dedicated files: `docs/install.md` (install & updating), `docs/renderers.md`
+  (the optional `glow`/`delta`/`bat` integrations), and `docs/usage.md` (summoning & keybindings).
+- Added a **Roadmap** section (in-app help overlay, settings, go-to-file) and an invitation to
+  open issues for bugs and feature requests.
+- Documented `$EDITOR` setup for the `e` key: the editor is read from the herdr **server's**
+  environment, so export it in the right shell startup file and restart the server
+  (`herdr server stop` + relaunch) — `reload-config` and quitting the client are not enough.
+- Added a rendered-markdown screenshot to the README; trimmed `SECURITY.md` to the GitHub private
+  advisory channel.
+
+This is a docs-only release; the binary is unchanged from 1.2.1 in behavior — it is re-tagged so a
+normal `herdr plugin install` uses the prebuilt fast path again instead of building from source.
+
 ## [1.2.1] - 2026-06-23
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -574,7 +574,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "herdr-file-viewer"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "ansi-to-tui",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "herdr-file-viewer"
-version = "1.2.1"
+version = "1.2.2"
 edition = "2024"
 rust-version = "1.96"
 description = "A git-aware, read-only file viewer that runs as a herdr TUI pane"

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -6,7 +6,7 @@
 
 id = "herdr-file-viewer"
 name = "herdr-file-viewer"
-version = "1.2.1"
+version = "1.2.2"
 description = "A git-aware, read-only file viewer: a keyboard-driven TUI in a herdr split pane."
 min_herdr_version = "0.7.0"
 platforms = ["linux", "macos"]


### PR DESCRIPTION
## What

Version bump **1.2.1 → 1.2.2** (Cargo.toml, herdr-plugin.toml, Cargo.lock) + CHANGELOG entry. Docs-only release.

## Why

`main` has been ahead of `v1.2.1` since the README restructure — all docs (README slim + `docs/` guides, Roadmap, markdown screenshot, SECURITY tidy, `$EDITOR`/`e`-key setup). Because the prebuilt-install gate requires `HEAD == the released commit`, a bare `herdr plugin install` has been falling back to a **source build** (needs Rust). Re-tagging `main` at HEAD as `v1.2.2` publishes binaries whose `COMMIT` marker matches `main`, so the prebuilt fast path works again.

The binary is **unchanged in behavior** from 1.2.1 — this only re-tags so the install doesn't need a toolchain.

## Release steps (after merge)

1. Merge this PR (main HEAD becomes the 1.2.2 commit).
2. Tag `v1.2.2` at main HEAD and push → `release.yml` cross-builds the 3 targets and publishes binaries + `SHA256SUMS` + `COMMIT`.
3. Live-verify a clean install uses the prebuilt (no source build).

No code changes; no review-gate (mechanical version bump).