### PR TITLE
feat: copy selected file's path to the clipboard (y / Y)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -43,7 +43,7 @@ herdr → env (HERDR_PLUGIN_CONTEXT_JSON)
           │
    host::from_env → root::resolve → git::default_baseline
           │
-   Controller::new  ── wires live GitService / ContentProvider / EditorHandoff behind traits
+   Controller::new  ── wires live GitService / ContentProvider / EditorHandoff / Clipboard behind traits
           │
    event loop (app::run):  draw → poll input → handle(intent) → drain finished renders → repeat
 ```
@@ -57,7 +57,8 @@ A renderer panic is contained (`catch_unwind`) so the worker survives. No `tokio
 ## Load-bearing decisions
 
 - **Read-only.** The viewer never mutates a file or the git repository. The editor path is a
-  hand-off to an external process. Every `git` invocation uses read-only subcommands.
+  hand-off to an external process; the path-copy keys (`y`/`Y`) only copy a path string to the
+  clipboard (via an OSC 52 escape). Every `git` invocation uses read-only subcommands.
 - **Delegate rendering.** Markdown, diffs, and syntax highlighting are produced by best-in-class
   external CLIs (`glow`, `delta`, `bat`) — the viewer builds only the shell and ingests their
   ANSI output. Each renderer is optional; a missing one degrades to plain text + a notice.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Copy a file's path to the clipboard.** `y` copies the selected file's repo-relative path
+  (e.g. `src/app.rs`); `Y` copies its absolute path. The copy uses the terminal's OSC 52
+  clipboard escape, so it travels through herdr and SSH to your real clipboard with no extra
+  tooling, and a confirmation shows in the notices strip. Read-only — like every other key, it
+  never touches the file's contents.
+
 ## [1.2.2] - 2026-06-23
 
 ### Docs

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ you only add the keybinding. The [keys](#keys) are below; deeper detail lives in
 | `b` | Toggle the diff baseline (base branch ⇄ `HEAD`) |
 | `v` | Cycle the content view mode |
 | `e` | Open the selected file in `$EDITOR` |
+| `y` | Copy the selected file's **repo-relative** path to the clipboard (e.g. `src/app.rs`) |
+| `Y` | Copy the selected file's **absolute** path to the clipboard |
 | `Tab` | Move focus between the tree and content columns |
 | `<` / `>` | Narrow / widen the tree column (move the divider) |
 | `w` | Toggle line wrapping for the content pane |
@@ -120,7 +122,14 @@ forces a full refresh on demand. (Focus-refresh updates the tree's status withou
 content scroll.)
 
 Character keys act only when no control chord is held (so terminal chords like `Ctrl+C` are
-never intercepted); `Shift` is permitted, for keys such as `<` and `>`.
+never intercepted); `Shift` is permitted, for keys such as `<` and `>` (and `y`/`Y`).
+
+**Copy a path (`y` / `Y`).** `y` copies the selected file's repo-relative path; `Y` copies its
+absolute path — handy for pasting into a prompt, a command, or an agent. The copy uses the
+terminal's **OSC 52** clipboard escape, so it travels through herdr (and SSH) to your real
+clipboard with no extra tooling. A confirmation appears in the notices strip. If nothing lands
+on your clipboard, your terminal likely needs OSC 52 / clipboard-write enabled (e.g. in tmux,
+`set -g set-clipboard on`).
 
 ### Mouse
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -7,7 +7,7 @@
 //! via the hook `ratatui::try_init` installs.
 
 use crate::controller::{
-    Components, ContentProvider, Controller, EditorHandoff, GitService, RenderResult,
+    Clipboard, Components, ContentProvider, Controller, EditorHandoff, GitService, RenderResult,
 };
 use crate::editor::{EditorLauncher, Spawner};
 use crate::git::{self, Baseline, Status};
@@ -27,6 +27,7 @@ use ratatui::DefaultTerminal;
 use std::collections::BTreeMap;
 use std::ffi::{OsStr, OsString};
 use std::io;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::Arc;
@@ -61,6 +62,7 @@ pub fn run() -> io::Result<()> {
     let editor: Box<dyn EditorHandoff> = Box::new(LiveEditor {
         editor: std::env::var_os("EDITOR"),
     });
+    let clipboard: Box<dyn Clipboard> = Box::new(Osc52Clipboard);
 
     let mut controller = Controller::new(
         resolved.root.clone(),
@@ -70,6 +72,7 @@ pub fn run() -> io::Result<()> {
             git,
             content,
             editor,
+            clipboard,
         },
     );
     // Kick off the once-a-day update check (off the UI thread; disabled by
@@ -256,6 +259,54 @@ impl EditorHandoff for LiveEditor {
         resumed?;
         Ok(true) // the editor drew over the screen → the run loop forces a full repaint
     }
+}
+
+/// The live Clipboard: copy via the OSC 52 terminal escape sequence. This is the portable,
+/// dependency-free way for a TUI in a pane to set the *host* terminal's clipboard — it travels
+/// through terminal multiplexers (herdr, tmux with passthrough) and SSH, unlike a native
+/// clipboard API bound to the local display. The sequence produces no visible output, so
+/// writing it mid-loop never disturbs the ratatui screen.
+struct Osc52Clipboard;
+
+impl Clipboard for Osc52Clipboard {
+    fn copy(&mut self, text: &str) -> io::Result<()> {
+        // OSC 52: ESC ] 52 ; c ; <base64 payload> BEL — `c` selects the clipboard. The payload is
+        // a path, which can include an untrusted, attacker-chosen file name (trust boundary #1).
+        // base64-encoding it confines the bytes to `[A-Za-z0-9+/=]`, so a name containing ESC/BEL
+        // or another OSC sequence cannot break out of this one and drive the terminal — the same
+        // defense-in-depth the renderer path applies to file content.
+        let seq = format!("\x1b]52;c;{}\x07", base64_encode(text.as_bytes()));
+        let mut out = io::stdout();
+        out.write_all(seq.as_bytes())?;
+        out.flush()
+    }
+}
+
+/// Standard base64 (RFC 4648) — a few lines so OSC 52 needs no extra dependency, matching the
+/// project's minimal-deps style. OSC 52 payloads are base64; the terminal decodes them.
+fn base64_encode(input: &[u8]) -> String {
+    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::with_capacity(input.len().div_ceil(3) * 4);
+    for chunk in input.chunks(3) {
+        let b0 = chunk[0] as u32;
+        let b1 = *chunk.get(1).unwrap_or(&0) as u32;
+        let b2 = *chunk.get(2).unwrap_or(&0) as u32;
+        let n = (b0 << 16) | (b1 << 8) | b2;
+        out.push(ALPHABET[(n >> 18 & 0x3f) as usize] as char);
+        out.push(ALPHABET[(n >> 12 & 0x3f) as usize] as char);
+        // Pad the final partial group with '=' (one byte → "xx==", two bytes → "xxx=").
+        out.push(if chunk.len() > 1 {
+            ALPHABET[(n >> 6 & 0x3f) as usize] as char
+        } else {
+            '='
+        });
+        out.push(if chunk.len() > 2 {
+            ALPHABET[(n & 0x3f) as usize] as char
+        } else {
+            '='
+        });
+    }
+    out
 }
 
 /// Runs the editor command and waits for it (the hand-off is synchronous, as for a terminal
@@ -450,6 +501,36 @@ mod tests {
             r.syntax.iter().any(|a| a == "--style=numbers"),
             "bat line numbers: {:?}",
             r.syntax
+        );
+    }
+
+    #[test]
+    fn base64_encode_matches_rfc4648_including_padding() {
+        // Padding is what OSC 52 consumers expect; the partial-group cases are the easy ones to
+        // get wrong. Vectors from RFC 4648 §10.
+        assert_eq!(base64_encode(b""), "");
+        assert_eq!(base64_encode(b"f"), "Zg==");
+        assert_eq!(base64_encode(b"fo"), "Zm8=");
+        assert_eq!(base64_encode(b"foo"), "Zm9v");
+        assert_eq!(base64_encode(b"foob"), "Zm9vYg==");
+        assert_eq!(base64_encode(b"fooba"), "Zm9vYmE=");
+        assert_eq!(base64_encode(b"foobar"), "Zm9vYmFy");
+        // A path with a slash exercises the '+/' tail of the alphabet via high bytes.
+        assert_eq!(base64_encode(b"src/app.rs"), "c3JjL2FwcC5ycw==");
+    }
+
+    #[test]
+    fn base64_confines_control_bytes_to_the_safe_alphabet() {
+        // Security: the OSC 52 payload may carry an attacker-chosen file name (trust boundary
+        // #1). Encoding must leave no ESC/BEL or other raw control byte that could break out of
+        // the escape sequence — the output is strictly `[A-Za-z0-9+/=]`.
+        let hostile = b"\x1b]52;c;evil\x07\x1b\\name\nwith\x07bel";
+        let encoded = base64_encode(hostile);
+        assert!(
+            encoded
+                .bytes()
+                .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'+' | b'/' | b'=')),
+            "encoded output stays within the base64 alphabet: {encoded}"
         );
     }
 

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -831,14 +831,22 @@ impl Controller {
         let Some(node) = self.tree.selected() else {
             return Effects::noop();
         };
-        let text = match kind {
+        let raw = match kind {
             PathKind::Absolute => node.path.to_string_lossy().into_owned(),
             PathKind::Repo => self
                 .rel(&node.path)
-                .unwrap_or(node.path.clone())
+                .unwrap_or_else(|| node.path.clone())
                 .to_string_lossy()
                 .into_owned(),
         };
+        // A filename is untrusted — an attacker can craft one in a browsed repo, and a path may
+        // legally contain control bytes: ESC/BEL (a terminal escape, e.g. a forged OSC 52) or a
+        // newline that would paste-inject into a shell. Strip them before the path reaches the
+        // clipboard *or* the notice — the same defense `sanitize_label` applies to every other
+        // filesystem-derived string we display. (The OSC 52 payload is base64-encoded only for
+        // transport; the terminal decodes it back to this exact string onto the clipboard, so the
+        // encoding alone does not make a control-bearing path safe to paste.)
+        let text: String = raw.chars().filter(|c| !c.is_control()).collect();
         self.action_notice = Some(match self.clipboard.copy(&text) {
             Ok(()) => format!("Copied {text}"),
             Err(e) => format!("Could not copy path: {e}"),

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -83,6 +83,14 @@ pub trait EditorHandoff {
     fn open(&mut self, file: &Path) -> io::Result<bool>;
 }
 
+/// Copy a string to the system clipboard (the `y` / `Y` path-copy keys). Behind a trait so
+/// the controller never touches the terminal directly — the live implementation emits an
+/// OSC 52 sequence — and tests record the copied text instead of writing a real clipboard.
+/// Read-only with respect to files: it only ever copies a path string (AC-N3).
+pub trait Clipboard {
+    fn copy(&mut self, text: &str) -> io::Result<()>;
+}
+
 /// The injected components the controller orchestrates.
 pub struct Components {
     /// Shared (`Arc`) because both the controller (status / changed-set) and the render
@@ -90,6 +98,7 @@ pub struct Components {
     pub git: Arc<dyn GitService>,
     pub content: Box<dyn ContentProvider>,
     pub editor: Box<dyn EditorHandoff>,
+    pub clipboard: Box<dyn Clipboard>,
 }
 
 /// What the run loop should do after an intent is handled.
@@ -173,6 +182,7 @@ pub struct Controller {
     action_notice: Option<String>,
     git: Arc<dyn GitService>,
     editor: Box<dyn EditorHandoff>,
+    clipboard: Box<dyn Clipboard>,
     /// Render dispatch to the worker thread (AC-23). `latest_seq` is the most recently
     /// dispatched job; a `poll`ed result with a smaller seq is stale and dropped.
     job_tx: mpsc::Sender<RenderJob>,
@@ -211,6 +221,7 @@ impl Controller {
             git,
             content,
             editor,
+            clipboard,
         } = components;
         // The Content Renderer (and the diff query it needs) live on a worker thread; the
         // controller talks to it over a job channel and reads finished renders off a result
@@ -277,6 +288,7 @@ impl Controller {
             action_notice: None,
             git,
             editor,
+            clipboard,
             job_tx,
             result_rx,
             latest_seq: 0,
@@ -436,6 +448,8 @@ impl Controller {
             Intent::ToggleBaseline => self.toggle_baseline(),
             Intent::CycleView => self.cycle_view(),
             Intent::OpenInEditor => self.open_in_editor(),
+            Intent::CopyRepoPath => self.copy_path(PathKind::Repo),
+            Intent::CopyAbsPath => self.copy_path(PathKind::Absolute),
             Intent::ToggleFocus => self.toggle_focus(),
             Intent::ShrinkTree => self.resize_split(-(SPLIT_STEP as i16)),
             Intent::GrowTree => self.resize_split(SPLIT_STEP as i16),
@@ -807,6 +821,31 @@ impl Controller {
         }
     }
 
+    /// Copy the selected node's path to the clipboard (`y` repo-relative, `Y` absolute). Works
+    /// for files and directories alike — copying a path mutates nothing (AC-N3). The outcome is
+    /// surfaced as a transient notice ("Copied …" / a clipboard-failure message). Inert when
+    /// nothing is selected. The repo-relative form falls back to the absolute path for a node
+    /// outside the tree root (there is no relative form to give), which in practice cannot
+    /// happen since every node is under the root.
+    fn copy_path(&mut self, kind: PathKind) -> Effects {
+        let Some(node) = self.tree.selected() else {
+            return Effects::noop();
+        };
+        let text = match kind {
+            PathKind::Absolute => node.path.to_string_lossy().into_owned(),
+            PathKind::Repo => self
+                .rel(&node.path)
+                .unwrap_or(node.path.clone())
+                .to_string_lossy()
+                .into_owned(),
+        };
+        self.action_notice = Some(match self.clipboard.copy(&text) {
+            Ok(()) => format!("Copied {text}"),
+            Err(e) => format!("Could not copy path: {e}"),
+        });
+        Effects::redraw()
+    }
+
     fn toggle_focus(&mut self) -> Effects {
         // While zoomed the tree is hidden, so there is nothing to switch focus to: keep focus
         // pinned to the content pane (entering zoom set it there). Without this guard, Tab would
@@ -1037,6 +1076,15 @@ impl Controller {
     fn rel(&self, path: &Path) -> Option<PathBuf> {
         path.strip_prefix(&self.root).ok().map(Path::to_path_buf)
     }
+}
+
+/// Which form of the selected node's path the copy keys put on the clipboard.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PathKind {
+    /// Relative to the tree/repo root (`y`), e.g. `src/app.rs`.
+    Repo,
+    /// The full absolute path (`Y`).
+    Absolute,
 }
 
 /// Where a mouse cell falls in the drawn layout.

--- a/src/input.rs
+++ b/src/input.rs
@@ -28,6 +28,8 @@ pub fn map_key(key: KeyEvent) -> Option<Intent> {
         KeyCode::Char('b') => Some(Intent::ToggleBaseline),
         KeyCode::Char('v') => Some(Intent::CycleView),
         KeyCode::Char('e') => Some(Intent::OpenInEditor),
+        KeyCode::Char('y') => Some(Intent::CopyRepoPath),
+        KeyCode::Char('Y') => Some(Intent::CopyAbsPath),
         KeyCode::Tab => Some(Intent::ToggleFocus),
         KeyCode::Char('<') => Some(Intent::ShrinkTree),
         KeyCode::Char('>') => Some(Intent::GrowTree),
@@ -65,6 +67,8 @@ mod tests {
         (KeyCode::Char('b'), Intent::ToggleBaseline),
         (KeyCode::Char('v'), Intent::CycleView),
         (KeyCode::Char('e'), Intent::OpenInEditor),
+        (KeyCode::Char('y'), Intent::CopyRepoPath),
+        (KeyCode::Char('Y'), Intent::CopyAbsPath),
         (KeyCode::Tab, Intent::ToggleFocus),
         (KeyCode::Char('<'), Intent::ShrinkTree),
         (KeyCode::Char('>'), Intent::GrowTree),
@@ -142,6 +146,21 @@ mod tests {
         );
         assert_eq!(
             map_key(KeyEvent::new(KeyCode::Char('<'), KeyModifiers::CONTROL)),
+            None
+        );
+    }
+
+    #[test]
+    fn copy_path_keys_are_distinct_and_shift_capital_y_is_the_absolute_path() {
+        // `y` copies the repo-relative path; `Y` (Shift+y, reported as `Char('Y')` with the
+        // Shift bit set) copies the absolute path. A Ctrl chord on the same key fires neither.
+        assert_eq!(map_key(k(KeyCode::Char('y'))), Some(Intent::CopyRepoPath));
+        assert_eq!(
+            map_key(KeyEvent::new(KeyCode::Char('Y'), KeyModifiers::SHIFT)),
+            Some(Intent::CopyAbsPath)
+        );
+        assert_eq!(
+            map_key(KeyEvent::new(KeyCode::Char('y'), KeyModifiers::CONTROL)),
             None
         );
     }

--- a/src/intent.rs
+++ b/src/intent.rs
@@ -30,6 +30,12 @@ pub enum Intent {
     CycleView,
     /// Hand the selected file off to an external editor (AC-19).
     OpenInEditor,
+    /// Copy the selected node's **repo-relative** path to the clipboard (e.g. `src/app.rs`).
+    /// Read-only — it copies a path string, never reads or writes the file's contents (AC-N3).
+    CopyRepoPath,
+    /// Copy the selected node's **absolute** path to the clipboard. Read-only, like
+    /// [`Intent::CopyRepoPath`] — no file contents are touched.
+    CopyAbsPath,
     /// Move focus between the tree and content columns (AC-21).
     ToggleFocus,
     /// Narrow the tree column (move the tree/content divider left).
@@ -55,7 +61,7 @@ pub enum Intent {
 impl Intent {
     /// Every intent variant — lets the dispatcher and tests enumerate the closed set so
     /// keyboard-completeness (AC-18) and the no-edit invariant (AC-N3) stay checkable.
-    pub const ALL: [Intent; 18] = [
+    pub const ALL: [Intent; 20] = [
         Intent::NavUp,
         Intent::NavDown,
         Intent::Expand,
@@ -66,6 +72,8 @@ impl Intent {
         Intent::ToggleBaseline,
         Intent::CycleView,
         Intent::OpenInEditor,
+        Intent::CopyRepoPath,
+        Intent::CopyAbsPath,
         Intent::ToggleFocus,
         Intent::ShrinkTree,
         Intent::GrowTree,
@@ -100,6 +108,8 @@ mod tests {
                 | Intent::ToggleBaseline
                 | Intent::CycleView
                 | Intent::OpenInEditor
+                | Intent::CopyRepoPath
+                | Intent::CopyAbsPath
                 | Intent::ToggleFocus
                 | Intent::ShrinkTree
                 | Intent::GrowTree

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -4,9 +4,11 @@
 
 #![allow(dead_code)] // not every integration test uses every helper
 
+use herdr_file_viewer::controller::Clipboard;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
 
 static COUNTER: AtomicU64 = AtomicU64::new(0);
 
@@ -40,6 +42,22 @@ impl TempDir {
 impl Drop for TempDir {
     fn drop(&mut self) {
         let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+/// A Clipboard stub that records every copied string instead of touching a real clipboard,
+/// so a test can assert what the `y`/`Y` keys would have copied. The `copied` log is shared
+/// (`Arc<Mutex<_>>`) so the test keeps a handle to read back after handing the stub to the
+/// controller.
+#[derive(Default, Clone)]
+pub struct RecordingClipboard {
+    pub copied: Arc<Mutex<Vec<String>>>,
+}
+
+impl Clipboard for RecordingClipboard {
+    fn copy(&mut self, text: &str) -> std::io::Result<()> {
+        self.copied.lock().unwrap().push(text.to_string());
+        Ok(())
     }
 }
 

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -1487,3 +1487,36 @@ fn copy_abs_path_copies_the_absolute_path() {
         log[0]
     );
 }
+
+#[test]
+fn copy_path_strips_control_bytes_from_a_hostile_filename() {
+    // A filename is attacker-controllable in a browsed repo and may legally contain control bytes —
+    // ESC/BEL (a terminal escape, e.g. a forged OSC 52) or a newline (a shell paste-injection when
+    // the copied path is later pasted). Both the clipboard payload and the confirmation notice must
+    // be stripped of control characters, matching the `sanitize_label` defense the tree and update
+    // banner already apply to filesystem-derived strings.
+    let dir = TempDir::new();
+    let hostile = "a\u{1b}]52;c;evil\u{07}\nrm -rf b";
+    std::fs::write(dir.path().join(hostile), "x\n").unwrap();
+    let (mut ctrl, copied) = controller_with_clipboard(dir.path(), false);
+
+    ctrl.handle(Intent::CopyRepoPath);
+    let log = copied.lock().unwrap();
+    assert_eq!(log.len(), 1, "exactly one copy");
+    assert_eq!(
+        log[0], "a]52;c;evilrm -rf b",
+        "control bytes (ESC/BEL/newline) are stripped, printable chars kept"
+    );
+    assert!(
+        !log[0].chars().any(|c| c.is_control()),
+        "the copied path carries no control bytes: {:?}",
+        log[0]
+    );
+    assert!(
+        ctrl.notices()
+            .iter()
+            .all(|n| !n.chars().any(|c| c.is_control())),
+        "the confirmation notice carries no control bytes: {:?}",
+        ctrl.notices()
+    );
+}

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -99,6 +99,7 @@ fn controller(
             fail: editor_fails,
             opened: opened.clone(),
         }),
+        clipboard: Box::new(common::RecordingClipboard::default()),
     };
     let ctrl = Controller::new(root.to_path_buf(), is_git_repo, Baseline::Head, components);
     (ctrl, changed_calls, opened)
@@ -533,6 +534,7 @@ fn controller_with_lines(root: &Path, n: usize) -> Controller {
             fail: false,
             opened: Arc::new(Mutex::new(Vec::new())),
         }),
+        clipboard: Box::new(common::RecordingClipboard::default()),
     };
     Controller::new(root.to_path_buf(), false, Baseline::Head, components)
 }
@@ -678,6 +680,7 @@ fn left_right_scroll_the_content_horizontally_when_focused_and_unwrapped() {
             fail: false,
             opened: Arc::new(Mutex::new(Vec::new())),
         }),
+        clipboard: Box::new(common::RecordingClipboard::default()),
     };
     let mut ctrl = Controller::new(dir.path().to_path_buf(), false, Baseline::Head, components);
     await_marker(&mut ctrl, "WIDE");
@@ -742,6 +745,7 @@ fn wrapped_content_scrolls_vertically_to_the_bottom_and_not_horizontally() {
             fail: false,
             opened: Arc::new(Mutex::new(Vec::new())),
         }),
+        clipboard: Box::new(common::RecordingClipboard::default()),
     };
     let mut ctrl = Controller::new(dir.path().to_path_buf(), false, Baseline::Head, components);
     await_marker(&mut ctrl, "WIDE");
@@ -1229,6 +1233,7 @@ fn horizontal_wheel_scrolls_the_content_sideways() {
             fail: false,
             opened: Arc::new(Mutex::new(Vec::new())),
         }),
+        clipboard: Box::new(common::RecordingClipboard::default()),
     };
     let mut ctrl = Controller::new(dir.path().to_path_buf(), false, Baseline::Head, components);
     await_marker(&mut ctrl, "WIDE");
@@ -1299,6 +1304,7 @@ fn focus_gained_re_queries_git_but_preserves_content_scroll() {
             fail: false,
             opened: Arc::new(Mutex::new(Vec::new())),
         }),
+        clipboard: Box::new(common::RecordingClipboard::default()),
     };
     let mut ctrl = Controller::new(dir.path().to_path_buf(), true, Baseline::Head, components);
     await_marker(&mut ctrl, "L0");
@@ -1398,6 +1404,7 @@ fn focus_gained_keeps_tree_and_content_in_sync_after_a_changed_only_refilter() {
             fail: false,
             opened: Arc::new(Mutex::new(Vec::new())),
         }),
+        clipboard: Box::new(common::RecordingClipboard::default()),
     };
     let mut ctrl = Controller::new(dir.path().to_path_buf(), true, Baseline::Head, components);
     ctrl.handle(Intent::ToggleChangedOnly); // changed-only: only a.rs visible → it's selected
@@ -1419,5 +1426,64 @@ fn focus_gained_keeps_tree_and_content_in_sync_after_a_changed_only_refilter() {
     assert!(
         flatten(ctrl.content()).contains("b.rs"),
         "content pane shows the selected file — in sync"
+    );
+}
+
+/// Build a controller over `root` whose clipboard records what it was asked to copy, so the
+/// path-copy keys (`y` / `Y`) can be asserted without a real clipboard.
+fn controller_with_clipboard(root: &Path, is_git_repo: bool) -> (Controller, Recorder<String>) {
+    let clipboard = common::RecordingClipboard::default();
+    let copied = clipboard.copied.clone();
+    let components = Components {
+        git: Arc::new(StubGit::default()),
+        content: Box::new(StubContent),
+        editor: Box::new(StubEditor {
+            fail: false,
+            opened: Arc::new(Mutex::new(Vec::new())),
+        }),
+        clipboard: Box::new(clipboard),
+    };
+    let ctrl = Controller::new(root.to_path_buf(), is_git_repo, Baseline::Head, components);
+    (ctrl, copied)
+}
+
+#[test]
+fn copy_repo_path_copies_the_repo_relative_path_and_confirms() {
+    // `y`: the selected node's path relative to the tree root goes to the clipboard, and the
+    // action is confirmed in a notice. Copying a path touches no file (AC-N3).
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.rs"), "x\n").unwrap();
+    let (mut ctrl, copied) = controller_with_clipboard(dir.path(), false);
+
+    let fx = ctrl.handle(Intent::CopyRepoPath);
+    assert!(fx.redraw, "copying redraws to show the confirmation notice");
+    assert_eq!(
+        copied.lock().unwrap().as_slice(),
+        ["a.rs"],
+        "the repo-relative path was copied"
+    );
+    assert!(
+        ctrl.notices().iter().any(|n| n.contains("Copied a.rs")),
+        "the copy is confirmed: {:?}",
+        ctrl.notices()
+    );
+}
+
+#[test]
+fn copy_abs_path_copies_the_absolute_path() {
+    // `Y`: the full absolute path goes to the clipboard.
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.rs"), "x\n").unwrap();
+    let (mut ctrl, copied) = controller_with_clipboard(dir.path(), false);
+
+    ctrl.handle(Intent::CopyAbsPath);
+    let log = copied.lock().unwrap();
+    assert_eq!(log.len(), 1, "exactly one copy");
+    let want = dir.path().join("a.rs").to_string_lossy().into_owned();
+    assert_eq!(log[0], want, "the absolute path was copied");
+    assert!(
+        Path::new(&log[0]).is_absolute(),
+        "the copied path is absolute: {}",
+        log[0]
     );
 }

--- a/tests/controller_async.rs
+++ b/tests/controller_async.rs
@@ -123,6 +123,7 @@ fn a_select_intent_does_not_block_on_a_slow_render_and_content_arrives_later() {
         git: Arc::new(NoGit),
         content: Box::new(SlowContent { delay }),
         editor: Box::new(NoEditor),
+        clipboard: Box::new(common::RecordingClipboard::default()),
     };
     let mut ctrl = Controller::new(dir.path().to_path_buf(), false, Baseline::Head, components);
 
@@ -186,6 +187,7 @@ fn full_diff_mode_asks_git_for_whole_file_context() {
             delay: Duration::from_millis(0),
         }),
         editor: Box::new(NoEditor),
+        clipboard: Box::new(common::RecordingClipboard::default()),
     };
     let mut ctrl = Controller::new(dir.path().to_path_buf(), true, Baseline::Head, components);
 
@@ -226,6 +228,7 @@ fn a_superseded_render_does_not_overwrite_a_newer_selection() {
             delay: Duration::from_millis(80),
         }),
         editor: Box::new(NoEditor),
+        clipboard: Box::new(common::RecordingClipboard::default()),
     };
     let mut ctrl = Controller::new(dir.path().to_path_buf(), false, Baseline::Head, components);
 
@@ -263,6 +266,7 @@ fn a_panicking_renderer_is_contained_and_the_worker_survives() {
         git: Arc::new(NoGit),
         content: Box::new(PanicOnContent { panic_file: "b.rs" }),
         editor: Box::new(NoEditor),
+        clipboard: Box::new(common::RecordingClipboard::default()),
     };
     let mut ctrl = Controller::new(dir.path().to_path_buf(), false, Baseline::Head, components);
 

--- a/tests/update_banner.rs
+++ b/tests/update_banner.rs
@@ -60,6 +60,7 @@ fn controller_in(dir: &Path) -> Controller {
             git: Arc::new(Git),
             content: Box::new(Content),
             editor: Box::new(Editor),
+            clipboard: Box::new(common::RecordingClipboard::default()),
         },
     )
 }


### PR DESCRIPTION
Closes #37.

Adds two keyboard shortcuts to the viewer:

- **`y`** copies the selected file's **repo-relative** path (e.g. `src/app.rs`)
- **`Y`** copies its **absolute** path

Both surface a `Copied …` confirmation in the notices strip, work regardless of which pane is focused (and while zoomed), and also work for directories. Like every other key, they're **read-only** — they only copy a path string, never touching file contents (AC-N3).

### How it works
The copy uses the terminal's **OSC 52** clipboard escape — the portable, dependency-free way for a pane to set the *host* terminal's clipboard. It travels through herdr (and SSH) with no extra tooling, unlike a native clipboard API bound to the local display. A confirmation toast from the terminal/multiplexer is a nice bonus where supported.

The OSC 52 payload is base64-encoded with a small in-crate RFC 4648 encoder (**no new dependency**, matching the project's minimal-deps style). Base64 also confines an attacker-chosen file name (trust boundary #1) to `[A-Za-z0-9+/=]`, so a name containing `ESC`/`BEL` can't break out of the escape sequence and drive the terminal — the same defense-in-depth the renderer path applies to file content.

### Design
Follows the existing trait-injection pattern so the controller stays unit-testable:
- new `Clipboard` trait in `Components` (live OSC 52 impl in `app`, recording stub in tests)
- two new read-only `Intent`s (`CopyRepoPath` / `CopyAbsPath`), wired through `input` with `Y` riding the existing "Shift permitted" rule
- a single `copy_path` handler in the controller

### Tests
- `input`: `y`/`Y` map to distinct intents; a Ctrl chord on the key fires neither
- `controller`: `y` copies the repo-relative path + confirms; `Y` copies the absolute path
- `app`: base64 matches RFC 4648 vectors (incl. padding); control bytes stay within the safe alphabet

`cargo build`, `cargo clippy --all-targets`, and `cargo fmt --check` are clean. All tests pass except one pre-existing, unrelated failure in `update::tests::hardened_git_ignores_a_malicious_repo_local_insteadof` (fails on a clean checkout too — an environment/git-config issue, untouched by this change).

### Notes for the maintainer
- The CHANGELOG entry sits under `[Unreleased]`; I didn't bump `Cargo.toml` / `herdr-plugin.toml` versions — that's your release call (this is a minor feature → `1.3.0`).
- No new runtime dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UygKVzkcVg2cM5dZWQiS78