### PR TITLE
chore(release): v1.3.0 — copy-path keys (y/Y) + control-char hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.3.0] - 2026-06-24
 
 ### Added
 - **Copy a file's path to the clipboard.** `y` copies the selected file's repo-relative path
@@ -12,6 +12,12 @@ All notable changes to this project are documented here. The format is based on
   clipboard escape, so it travels through herdr and SSH to your real clipboard with no extra
   tooling, and a confirmation shows in the notices strip. Read-only — like every other key, it
   never touches the file's contents.
+
+### Security
+- The copied path and its confirmation notice are stripped of control characters, so a
+  maliciously-named file (e.g. one with an embedded newline or escape byte) can't paste-inject
+  into a shell or emit a terminal escape when its path is copied — consistent with how the viewer
+  already sanitizes other filesystem-derived strings it displays.
 
 ## [1.2.2] - 2026-06-23
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -574,7 +574,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "herdr-file-viewer"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "ansi-to-tui",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "herdr-file-viewer"
-version = "1.2.2"
+version = "1.3.0"
 edition = "2024"
 rust-version = "1.96"
 description = "A git-aware, read-only file viewer that runs as a herdr TUI pane"

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -6,7 +6,7 @@
 
 id = "herdr-file-viewer"
 name = "herdr-file-viewer"
-version = "1.2.2"
+version = "1.3.0"
 description = "A git-aware, read-only file viewer: a keyboard-driven TUI in a herdr split pane."
 min_herdr_version = "0.7.0"
 platforms = ["linux", "macos"]


### PR DESCRIPTION
Release **1.3.0**.

### Shipping in this release
- **feat:** copy the selected file's path to the clipboard — `y` (repo-relative) / `Y` (absolute), via the terminal's OSC 52 escape (#38, thanks @riclib)
- **security:** strip control characters from the copied path and its confirmation notice, so a maliciously-named file can't paste-inject or emit a terminal escape (review-gate hardening on #38)

### This PR
- Bumps the version → `1.3.0` (`Cargo.toml`, `herdr-plugin.toml`, `Cargo.lock`)
- CHANGELOG: promotes `[Unreleased]` → `## [1.3.0]` and adds the Security note

Full `cargo test` + `clippy -D warnings` + `fmt` are clean. After merge, tag `v1.3.0` to publish the prebuilt binaries.
