### PR TITLE
chore(release): v1.4.0 — switch worktree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2026-06-25
+
+### Added
+- **Switch worktree (`W`).** Press `W` to open a picker of the repository's git worktrees and
+  select one to re-root the viewer in place — the tree, git status, and content pane all rebuild
+  around the chosen worktree without relaunching the plugin. Your view preferences carry over and
+  navigation resets to the new root. It is purely a change of *where you're looking*: read-only, no
+  branch is checked out, and nothing on disk is modified.
+- The picker marks the worktree you're currently viewing and pre-selects the one where a herdr
+  agent is active, so you can jump straight to what an agent is working on.
+- Each picker row shows the worktree's branch (or a detached-HEAD marker) and, when herdr reports
+  it, the live status of the agent running there.
+
+### Changed
+- All notices shown in the viewer's notice strip are now stripped of control characters at the
+  render sink (previously only the copied-path confirmation was), so any filesystem-derived string
+  surfaced in a notice — such as a worktree path — cannot emit a terminal escape or paste-inject.
+
 ## [1.3.0] - 2026-06-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -574,7 +574,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "herdr-file-viewer"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "ansi-to-tui",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "herdr-file-viewer"
-version = "1.3.0"
+version = "1.4.0"
 edition = "2024"
 rust-version = "1.96"
 description = "A git-aware, read-only file viewer that runs as a herdr TUI pane"


### PR DESCRIPTION
Release **v1.4.0** — the Switch-worktree feature (PR #41) to users.

Bumps `Cargo.toml` + `Cargo.lock` to `1.4.0` and adds the `CHANGELOG.md` entry. No code changes — the feature already merged in #41.

### Changelog
**Added** — Switch worktree (`W`): open a picker of the repo's git worktrees and select one to re-root the viewer in place (tree + git + content rebuild, no relaunch). Read-only. Picker marks the current worktree, pre-selects the agent-active one, and shows each worktree's branch + live agent status.

**Changed** — all notice-strip text is now control-char-stripped at the render sink (previously only the copied-path confirmation), so a filesystem-derived string in a notice can't emit a terminal escape.

After merge: tag `v1.4.0` at the merge commit → `release.yml` builds & publishes the prebuilt binaries.
