### PR TITLE
fix(release): herdr-plugin.toml version → 1.4.0 (+ release.yml manifest guard)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,15 +24,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Fail fast if the pushed tag disagrees with the crate version, so we never publish a release
-      # whose assets don't match the source the install step clones.
-      - name: Verify tag matches Cargo.toml version
+      # Fail fast if the pushed tag disagrees with the crate version OR the herdr manifest version,
+      # so we never publish a release whose assets/manifest don't match the source the install step
+      # clones. (herdr displays the herdr-plugin.toml version, which must track Cargo.toml.)
+      - name: Verify tag matches Cargo.toml and herdr-plugin.toml versions
         shell: bash
         run: |
           tag="${GITHUB_REF_NAME#v}"
           crate="$(grep -E '^version *= *"' Cargo.toml | head -n1 | sed -E 's/^version *= *"([^"]+)".*/\1/')"
+          manifest="$(grep -E '^version *= *"' herdr-plugin.toml | head -n1 | sed -E 's/^version *= *"([^"]+)".*/\1/')"
           if [ "$tag" != "$crate" ]; then
             echo "tag $GITHUB_REF_NAME ($tag) != Cargo.toml version ($crate)" >&2
+            exit 1
+          fi
+          if [ "$tag" != "$manifest" ]; then
+            echo "tag $GITHUB_REF_NAME ($tag) != herdr-plugin.toml version ($manifest)" >&2
             exit 1
           fi
 

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -6,7 +6,7 @@
 
 id = "herdr-file-viewer"
 name = "herdr-file-viewer"
-version = "1.3.0"
+version = "1.4.0"
 description = "A git-aware, read-only file viewer: a keyboard-driven TUI in a herdr split pane."
 min_herdr_version = "0.7.0"
 platforms = ["linux", "macos"]


### PR DESCRIPTION
The v1.4.0 release bumped `Cargo.toml` + `Cargo.lock` but **left `herdr-plugin.toml` at 1.3.0**, so a `herdr plugin install` shows `version: 1.3.0` even though the binary is 1.4.0:

```
version: 1.3.0
commit:  6e6b4886cc0e0cade3d2cdc63f17ba65972c1601   # the v1.4.0 commit
```

`release.yml` only cross-checked the tag against `Cargo.toml`, so the drift shipped silently.

**This PR**
- Bumps `herdr-plugin.toml` → `1.4.0`.
- Extends `release.yml`'s pre-build version check to also verify the tag matches `herdr-plugin.toml`, so the manifest and crate versions can't drift past a release again.

After merge, `v1.4.0` will be re-cut at the new merge commit (the current tag/release is minutes old and not yet depended on).
