### PR TITLE
docs: switch worktree (W) — README keys/feature + ARCHITECTURE modules

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -24,15 +24,18 @@ is unit-testable with stubs.
 | --- | --- |
 | `host` | The herdr boundary — parse the injected `HERDR_PLUGIN_CONTEXT_JSON` launch context, degrading to `{ cwd }` on anything malformed (never panics). |
 | `context` | The normalized `LaunchContext` the host hands to the resolver. |
-| `root` | Resolve the tree root (git worktree top-level, else cwd) and git-presence. |
+| `root` | Resolve the tree root (git worktree top-level, else cwd) and git-presence; the re-root engine re-resolves the root and rebuilds the tree + git services in place when you switch worktrees. |
 | `git` | Read-only git queries: status, baseline selection, changed-set, per-file diff. The **only** module that shells out to `git`, and only with read-only subcommands. |
+| `herdr` | Read-only queries to the herdr CLI (`$HERDR_BIN_PATH`) — list git worktrees and which workspaces have an active agent; an absent or failing herdr degrades gracefully to git-only. |
+| `worktree` | Enumerate the repo's git worktrees (`git worktree list --porcelain`) and overlay herdr's agent-active workspace + per-row agent status, feeding the switch-worktree picker. |
 | `tree` | The rooted, `.gitignore`-aware file tree: filters, cursor, expansion, status markers. |
 | `view_policy` | A pure decision: which view mode a file gets (changed → diff, markdown → rendered, else → syntax content) and the cycle order. |
 | `render` | Produce the content-pane text: classify the file, delegate styling to an external CLI, and **neutralize escape sequences** before display. |
 | `presenter` | Draw the two-column (or zoomed / narrow) layout with ratatui; report the content viewport + pane geometry back. |
+| `picker` | The modal worktree-switcher overlay state (rows, cursor, horizontal scroll) drawn over the layout; captures its own nav / confirm / cancel keys while open. |
 | `input` | Map crossterm key events → intents. |
 | `intent` | The closed set of user intents (one exhaustive enum). |
-| `controller` | Orchestrate intents → state changes; hold the ephemeral session state; dispatch renders to the worker. |
+| `controller` | Orchestrate intents → state changes; hold the ephemeral session state; dispatch renders to the worker; on a worktree switch, rebuild the root-bound services through a provider factory and respawn the render worker. |
 | `editor` | Hand a file off to `$EDITOR` (launch only — never reads or writes the file). |
 | `launch` | The "launch-or-focus-or-toggle" decision behind the shell launch scripts (pure, hermetically testable). |
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ right into the tree. It opens beside whatever you're doing and never touches you
 
 - **Tree, scoped to your work** — rooted at the worktree root inside a git repo, else the
   launch directory. Honors `.gitignore` (toggle to reveal ignored files).
+- **Switch worktree on the fly** — press `W` to re-root the viewer at another git worktree of
+  the repo without relaunching; it pre-selects the worktree a herdr agent is working in, so you
+  can jump straight to it. Read-only — it changes only *what you're viewing*, never the branch
+  or any files.
 - **Git woven in** — per-file status markers (`M`/`A`/`D`/`?`), **colored** so changes read at
   a glance (changed files and folders containing changes are red, new files green); a
   changed-files-only filter; and a baseline you can switch between the merge-base of your
@@ -107,6 +111,7 @@ you only add the keybinding. The [keys](#keys) are below; deeper detail lives in
 | `w` | Toggle line wrapping for the content pane |
 | `z` | Zoom — hide the tree so the content pane fills the frame; press again (or `q`/`Esc`) to restore the two-column layout |
 | `r` | Refresh git state — pick up changes made outside the viewer (a merge / pull / commit elsewhere) |
+| `W` (Shift+`w`) | **Switch worktree** — open a picker of the repo's git worktrees and re-root the viewer to the one you pick (read-only; no branch checkout). Marks the current worktree and pre-selects the one with an active herdr agent; `↑`/`↓` move, `←`/`→` scroll long paths, `Enter` switches, `Esc` cancels |
 | `u` | Dismiss the "update available" banner for this session |
 | `q` / `Esc` | Back out of zoom if zoomed; otherwise close the viewer and return to the prior pane |
 
@@ -122,7 +127,7 @@ forces a full refresh on demand. (Focus-refresh updates the tree's status withou
 content scroll.)
 
 Character keys act only when no control chord is held (so terminal chords like `Ctrl+C` are
-never intercepted); `Shift` is permitted, for keys such as `<` and `>` (and `y`/`Y`).
+never intercepted); `Shift` is permitted, for keys such as `<` and `>` (and `y`/`Y`, `W`).
 
 **Copy a path (`y` / `Y`).** `y` copies the selected file's repo-relative path; `Y` copies its
 absolute path — handy for pasting into a prompt, a command, or an agent. The copy uses the


### PR DESCRIPTION
Documents the switch-worktree feature shipped in v1.4.0 (the build/release added the feature + CHANGELOG but missed the README/architecture docs).

- **README** — a "Switch worktree on the fly" feature bullet; the `W` row in the Keys table (shown as `W` (Shift+`w`) to disambiguate from `w` = line-wrap); and `W` added to the Shift-permitted-keys note.
- **ARCHITECTURE.md** — new `worktree` / `picker` / `herdr` module rows, plus the re-root behavior on `root` and the provider-factory/worker-respawn behavior on `controller`.

`docs/usage.md` (summoning only) needs nothing; the Roadmap never listed this feature. Docs-only, no code change.
