### PR TITLE
fix(tree): scroll to keep selection visible + overflow scrollbars (#45)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -31,7 +31,7 @@ is unit-testable with stubs.
 | `tree` | The rooted, `.gitignore`-aware file tree: filters, cursor, expansion, status markers. |
 | `view_policy` | A pure decision: which view mode a file gets (changed → diff, markdown → rendered, else → syntax content) and the cycle order. |
 | `render` | Produce the content-pane text: classify the file, delegate styling to an external CLI, and **neutralize escape sequences** before display. |
-| `presenter` | Draw the two-column (or zoomed / narrow) layout with ratatui; report the content viewport + pane geometry back. |
+| `presenter` | Draw the two-column (or zoomed / narrow) layout with ratatui; scroll the tree to keep the selection in view and draw scrollbars where a pane overflows; report the content viewport + tree scroll offset + pane geometry back (the controller adds the offset when hit-testing a tree click). |
 | `picker` | The modal worktree-switcher overlay state (rows, cursor, horizontal scroll) drawn over the layout; captures its own nav / confirm / cancel keys while open. |
 | `input` | Map crossterm key events → intents. |
 | `intent` | The closed set of user intents (one exhaustive enum). |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -31,11 +31,11 @@ is unit-testable with stubs.
 | `tree` | The rooted, `.gitignore`-aware file tree: filters, cursor, expansion, status markers. |
 | `view_policy` | A pure decision: which view mode a file gets (changed → diff, markdown → rendered, else → syntax content) and the cycle order. |
 | `render` | Produce the content-pane text: classify the file, delegate styling to an external CLI, and **neutralize escape sequences** before display. |
-| `presenter` | Draw the two-column (or zoomed / narrow) layout with ratatui; scroll the tree to keep the selection in view and draw scrollbars where a pane overflows; report the content viewport + tree scroll offset + pane geometry back (the controller adds the offset when hit-testing a tree click). |
+| `presenter` | Draw the two-column (or zoomed / narrow) layout with ratatui; scroll the tree to keep the selection in view (and horizontally for long rows) and draw scrollbars where a pane overflows; report the content viewport + tree scroll offset + widest tree row + pane geometry back, so the controller can hit-test a tree click and map a scrollbar drag. |
 | `picker` | The modal worktree-switcher overlay state (rows, cursor, horizontal scroll) drawn over the layout; captures its own nav / confirm / cancel keys while open. |
 | `input` | Map crossterm key events → intents. |
 | `intent` | The closed set of user intents (one exhaustive enum). |
-| `controller` | Orchestrate intents → state changes; hold the ephemeral session state; dispatch renders to the worker; on a worktree switch, rebuild the root-bound services through a provider factory and respawn the render worker. |
+| `controller` | Orchestrate intents → state changes; hold the ephemeral session state; dispatch renders to the worker; map mouse events (clicks, wheel, divider + scrollbar drags) against the fed-back geometry; on a worktree switch, rebuild the root-bound services through a provider factory and respawn the render worker. |
 | `editor` | Hand a file off to `$EDITOR` (launch only — never reads or writes the file). |
 | `launch` | The "launch-or-focus-or-toggle" decision behind the shell launch scripts (pure, hermetically testable). |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **The tree now scrolls to follow the selection.** On a long file list the tree stayed pinned to
+  the top, so moving the cursor past the last visible row selected files you couldn't see. The tree
+  now scrolls to keep the selected row in view (mouse clicks still map to the right row when
+  scrolled). ([#45](https://github.com/smarzban/herdr-file-viewer/issues/45))
+
+### Added
+- **Scrollbars** appear on the tree and content panes whenever there's more to see than fits — a
+  vertical bar when the list or file is taller than the pane, and a horizontal bar when an unwrapped
+  line is wider than the content pane. They show only where there is something to scroll.
+
 ## [1.4.0] - 2026-06-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,13 @@ All notable changes to this project are documented here. The format is based on
 
 ### Added
 - **Scrollbars** appear on the tree and content panes whenever there's more to see than fits — a
-  vertical bar when the list or file is taller than the pane, and a horizontal bar when an unwrapped
-  line is wider than the content pane. They show only where there is something to scroll.
+  vertical bar when the list or file is taller than the pane, and a horizontal bar when a row /
+  unwrapped line is wider than the pane. They show only where there is something to scroll, and the
+  bars are **draggable with the mouse** (drag ↕ to scroll vertically, ↔ to scroll horizontally;
+  pressing the track jumps to that position).
+- **The tree scrolls horizontally** so a long or deeply-nested file name can be read in full — via
+  the horizontal mouse wheel or by dragging the tree's horizontal scrollbar (the `←`/`→` keys stay
+  expand/collapse in the tree).
 
 ## [1.4.0] - 2026-06-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,10 @@ All notable changes to this project are documented here. The format is based on
 ### Added
 - **Scrollbars** appear on the tree and content panes whenever there's more to see than fits — a
   vertical bar when the list or file is taller than the pane, and a horizontal bar when a row /
-  unwrapped line is wider than the pane. They show only where there is something to scroll, and the
-  bars are **draggable with the mouse** (drag ↕ to scroll vertically, ↔ to scroll horizontally;
-  pressing the track jumps to that position).
+  unwrapped line is wider than the pane. They show only where there is something to scroll. The
+  bars render **inside** the pane (one cell off the text) and are **draggable with the mouse**:
+  drag a vertical bar ↕ or a horizontal bar ↔ to scroll, and pressing the track jumps to that
+  position. Dragging the tree's vertical bar scrubs the selection through the file list.
 - **The tree scrolls horizontally** so a long or deeply-nested file name can be read in full — via
   the horizontal mouse wheel or by dragging the tree's horizontal scrollbar (the `←`/`→` keys stay
   expand/collapse in the tree).

--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ right into the tree. It opens beside whatever you're doing and never touches you
   line numbers and the diff shown inline.
 - **Navigable content** — scroll the content pane in all four directions, toggle line
   wrapping, resize the tree/content split, or zoom (`z`) to hide the tree and read a file
-  full-screen; the layout reflows when the pane is resized.
+  full-screen; the layout reflows when the pane is resized. The tree scrolls to keep the
+  selection in view, and a scrollbar appears on the tree or content pane whenever there is
+  more to see than fits.
 - **Keyboard-first** — every function has a key; no mouse required.
 
 ## Quick start

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ right into the tree. It opens beside whatever you're doing and never touches you
 - **Navigable content** — scroll the content pane in all four directions, toggle line
   wrapping, resize the tree/content split, or zoom (`z`) to hide the tree and read a file
   full-screen; the layout reflows when the pane is resized. The tree scrolls to keep the
-  selection in view, and a scrollbar appears on the tree or content pane whenever there is
-  more to see than fits.
+  selection in view (and sideways, for long names), and a scrollbar appears on the tree or
+  content pane whenever there is more to see than fits — drag it with the mouse to scroll.
 - **Keyboard-first** — every function has a key; no mouse required.
 
 ## Quick start
@@ -148,7 +148,8 @@ The viewer is keyboard-first; the mouse is additive and on by default:
 | **Double-click** a folder | Expand / collapse it (same as `Enter`) |
 | **Double-click** a file | Open it in **zoom mode** — content full-screen (same as `Enter`); the editor is the `e` key |
 | **Wheel** over the content pane | Scroll it vertically; over the tree, move the selection |
-| **Horizontal wheel / swipe** over the content | Scroll it sideways (terminal-dependent — see below) |
+| **Horizontal wheel / swipe** | Scroll the content — or the tree — sideways (terminal-dependent — see below) |
+| **Drag** a scrollbar | Scroll that pane — drag ↕ on a vertical bar, ↔ on a horizontal bar; pressing the track jumps there |
 | **Drag** the divider | Resize the tree / content split |
 
 **`Shift`+drag is left to your terminal**, so its native select-and-copy still works while the

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -632,6 +632,9 @@ impl Controller {
             width: self.width,
             content_scroll: self.content_scroll,
             content_hscroll: self.content_hscroll,
+            // Last frame's tree offset, so the Presenter scrolls minimally from it (#45): selecting
+            // a row already in view — e.g. a mouse click — never jumps the viewport.
+            tree_scroll: self.geom.tree_scroll,
             wrap,
             split_pct: self.split_pct,
             zoomed: self.zoomed,
@@ -873,8 +876,8 @@ impl Controller {
         }
     }
 
-    /// Scroll the pane under the cursor: the content pane scrolls vertically; over the tree
-    /// (which does not scroll) the wheel moves the selection — the closest equivalent.
+    /// Scroll the pane under the cursor: the content pane scrolls vertically; over the tree the
+    /// wheel moves the selection (the tree then scrolls to keep it in view, #45).
     fn scroll_at(&mut self, col: u16, row: u16, delta: isize) -> Effects {
         match self.hit_test(col, row) {
             MouseRegion::Content => {

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -927,9 +927,11 @@ impl Controller {
         if let Some(t) = self.geom.tree_inner
             && t.contains(Position { x: col, y: row })
         {
-            // The row index may exceed the node count (the empty area below the last node): the
-            // click handler treats that as inert, while the wheel still scrolls the column.
-            return MouseRegion::TreeRow((row - t.y) as usize);
+            // Map the screen row to the node actually drawn there: the on-screen offset plus the
+            // tree's scroll offset (#45), the same value `draw_tree` scrolled by. The row index may
+            // still exceed the node count (the empty area below the last node): the click handler
+            // treats that as inert, while the wheel still scrolls the column.
+            return MouseRegion::TreeRow((row - t.y) as usize + self.geom.tree_scroll as usize);
         }
         if let Some(c) = self.geom.content_inner
             && c.contains(Position { x: col, y: row })

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -628,6 +628,11 @@ impl Controller {
         let nodes = self.tree.visible_nodes();
         let selected = self.tree.cursor();
         let wrap = self.wrap_for(nodes.get(selected));
+        // The wrapped-aware content row total, so the content vertical scrollbar sizes/positions
+        // against the SAME extent the scroll clamp uses (raw `lines.len()` undercounts under wrap,
+        // mis-sizing the thumb / hiding the bar). Computed with the wrap we already have — no extra
+        // tree walk.
+        let content_rows = self.rendered_line_count_for(wrap);
         ViewState {
             nodes,
             selected,
@@ -641,6 +646,7 @@ impl Controller {
             // a row already in view — e.g. a mouse click — never jumps the viewport.
             tree_scroll: self.geom.tree_scroll,
             tree_hscroll: self.tree_hscroll,
+            content_rows,
             wrap,
             split_pct: self.split_pct,
             zoomed: self.zoomed,
@@ -828,28 +834,22 @@ impl Controller {
             MouseEventKind::Down(MouseButton::Left) => {
                 // A press on the divider begins a resize drag; on a scrollbar it begins a scroll
                 // drag AND jumps to the pressed position (click-to-scroll). Anything else waits for
-                // the release (a click).
-                match self.hit_test(col, row) {
-                    MouseRegion::Divider => {
-                        self.drag = Some(Drag::Divider);
-                        Effects::noop()
-                    }
-                    MouseRegion::ContentVBar => {
-                        self.drag = Some(Drag::ContentV);
-                        self.scroll_content_to_row(row)
-                    }
-                    MouseRegion::ContentHBar => {
-                        self.drag = Some(Drag::ContentH);
-                        self.scroll_content_h_to_col(col)
-                    }
-                    MouseRegion::TreeVBar => {
-                        self.drag = Some(Drag::TreeV);
-                        self.scroll_tree_to_row(row)
-                    }
-                    MouseRegion::TreeHBar => {
-                        self.drag = Some(Drag::TreeH);
-                        self.scroll_tree_h_to_col(col)
-                    }
+                // the release (a click). Always (re)set `drag` from the press — so a stale drag from
+                // a release we never saw (e.g. swallowed by a modal) can't keep acting on later moves.
+                let region = self.hit_test(col, row);
+                self.drag = match region {
+                    MouseRegion::Divider => Some(Drag::Divider),
+                    MouseRegion::ContentVBar => Some(Drag::ContentV),
+                    MouseRegion::ContentHBar => Some(Drag::ContentH),
+                    MouseRegion::TreeVBar => Some(Drag::TreeV),
+                    MouseRegion::TreeHBar => Some(Drag::TreeH),
+                    _ => None,
+                };
+                match region {
+                    MouseRegion::ContentVBar => self.scroll_content_to_row(row),
+                    MouseRegion::ContentHBar => self.scroll_content_h_to_col(col),
+                    MouseRegion::TreeVBar => self.scroll_tree_to_row(row),
+                    MouseRegion::TreeHBar => self.scroll_tree_h_to_col(col),
                     _ => Effects::noop(),
                 }
             }
@@ -863,7 +863,11 @@ impl Controller {
             },
             MouseEventKind::Up(MouseButton::Left) => {
                 if self.drag.take().is_some() {
-                    return Effects::noop(); // end of a drag, not a click
+                    // End of a drag, not a click. Clear the pending-click so a tree-row click made
+                    // before the drag can't pair with a later one as a double-click — the drag may
+                    // have scrolled the viewport, so the same screen row now maps to a different node.
+                    self.last_click = None;
+                    return Effects::noop();
                 }
                 self.handle_click(col, row)
             }
@@ -1024,6 +1028,12 @@ impl Controller {
         }
         let idx = ((rel * (len as u32 - 1) + span / 2) / span) as usize;
         self.focus = Focus::Tree;
+        // A drag fires many events on the same row; only re-select (and re-render the content, an
+        // expensive job) when the target actually changes, so a held scrub doesn't re-render the
+        // same file every tick.
+        if idx == self.tree.cursor() {
+            return Effects::redraw();
+        }
         self.tree.set_cursor(idx);
         self.dispatch_render();
         Effects::redraw()
@@ -1124,7 +1134,15 @@ impl Controller {
     /// make it undershoot. Off the per-frame path: only scroll / resize / wrap-toggle keypaths
     /// reach it (`set_content_viewport` early-returns on an unchanged size).
     fn rendered_line_count(&self) -> u16 {
-        let count = if self.effective_wrap() {
+        self.rendered_line_count_for(self.effective_wrap())
+    }
+
+    /// Like [`rendered_line_count`] but takes the wrap flag, so a caller that already knows it
+    /// (e.g. `view_state`, which computes wrap from the visible nodes it just built) avoids the
+    /// extra tree walk `effective_wrap` would do. This is the wrapped-aware row total the content
+    /// vertical scrollbar must size/position against — raw `lines.len()` undercounts under wrap.
+    fn rendered_line_count_for(&self, wrap: bool) -> u16 {
+        let count = if wrap {
             let w = self.content_width.max(1) as usize;
             self.content
                 .lines

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -164,6 +164,9 @@ pub struct Controller {
     baseline: Baseline,
     show_ignored: bool,
     changed_only: bool,
+    /// The tree's horizontal scroll offset (columns), for reading long / deeply-nested rows. Like
+    /// the cursor it is navigation state: reset on a re-root (AC-13), not carried.
+    tree_hscroll: u16,
     focus: Focus,
     /// The pane width the run loop last observed (session state for the narrow-split flag,
     /// AC-21); the Presenter still lays out from the live frame, never this.
@@ -214,9 +217,9 @@ pub struct Controller {
     geom: PaneGeometry,
     /// The previous left-click `(col, row, time)`, for double-click detection.
     last_click: Option<(u16, u16, Instant)>,
-    /// True while the left button is held after pressing on the divider (a resize drag), so the
-    /// release is treated as the end of the drag, not a click.
-    dragging_divider: bool,
+    /// What the held left button is dragging (divider resize or a scrollbar), so the release is
+    /// treated as the end of the drag, not a click. `None` ⇒ no drag in progress.
+    drag: Option<Drag>,
     /// The newer version to advertise, if any (set from the cached value at startup and
     /// refreshed by the background check). `None` ⇒ up-to-date / unknown.
     update_available: Option<Version>,
@@ -276,6 +279,7 @@ impl Controller {
             is_git_repo,
             baseline,
             show_ignored: false,
+            tree_hscroll: 0,
             changed_only: false,
             focus: Focus::Tree,
             width: 0,
@@ -300,7 +304,7 @@ impl Controller {
             latest_seq: 0,
             geom: PaneGeometry::default(),
             last_click: None,
-            dragging_divider: false,
+            drag: None,
             update_available: None,
             update_dismissed: false,
             update_rx: None,
@@ -429,6 +433,7 @@ impl Controller {
         self.zoomed = false;
         self.content_scroll = 0;
         self.content_hscroll = 0;
+        self.tree_hscroll = 0;
         self.overrides.clear();
         self.action_notice = None;
         self.changed = BTreeMap::new();
@@ -635,6 +640,7 @@ impl Controller {
             // Last frame's tree offset, so the Presenter scrolls minimally from it (#45): selecting
             // a row already in view — e.g. a mouse click — never jumps the viewport.
             tree_scroll: self.geom.tree_scroll,
+            tree_hscroll: self.tree_hscroll,
             wrap,
             split_pct: self.split_pct,
             zoomed: self.zoomed,
@@ -820,16 +826,39 @@ impl Controller {
             MouseEventKind::ScrollRight => self.hscroll_at(col, row, HSCROLL_STEP as i32),
             MouseEventKind::ScrollLeft => self.hscroll_at(col, row, -(HSCROLL_STEP as i32)),
             MouseEventKind::Down(MouseButton::Left) => {
-                // A press on the divider begins a resize drag; otherwise wait for the release.
-                self.dragging_divider = matches!(self.hit_test(col, row), MouseRegion::Divider);
-                Effects::noop()
+                // A press on the divider begins a resize drag; on a scrollbar it begins a scroll
+                // drag AND jumps to the pressed position (click-to-scroll). Anything else waits for
+                // the release (a click).
+                match self.hit_test(col, row) {
+                    MouseRegion::Divider => {
+                        self.drag = Some(Drag::Divider);
+                        Effects::noop()
+                    }
+                    MouseRegion::ContentVBar => {
+                        self.drag = Some(Drag::ContentV);
+                        self.scroll_content_to_row(row)
+                    }
+                    MouseRegion::ContentHBar => {
+                        self.drag = Some(Drag::ContentH);
+                        self.scroll_content_h_to_col(col)
+                    }
+                    MouseRegion::TreeHBar => {
+                        self.drag = Some(Drag::TreeH);
+                        self.scroll_tree_h_to_col(col)
+                    }
+                    _ => Effects::noop(),
+                }
             }
-            MouseEventKind::Drag(MouseButton::Left) if self.dragging_divider => {
-                self.resize_split_to_col(col)
-            }
+            MouseEventKind::Drag(MouseButton::Left) => match self.drag {
+                Some(Drag::Divider) => self.resize_split_to_col(col),
+                Some(Drag::ContentV) => self.scroll_content_to_row(row),
+                Some(Drag::ContentH) => self.scroll_content_h_to_col(col),
+                Some(Drag::TreeH) => self.scroll_tree_h_to_col(col),
+                None => Effects::noop(),
+            },
             MouseEventKind::Up(MouseButton::Left) => {
-                if std::mem::take(&mut self.dragging_divider) {
-                    return Effects::noop(); // end of a resize drag, not a click
+                if self.drag.take().is_some() {
+                    return Effects::noop(); // end of a drag, not a click
                 }
                 self.handle_click(col, row)
             }
@@ -869,7 +898,12 @@ impl Controller {
                 self.focus = Focus::Content;
                 Effects::redraw()
             }
-            MouseRegion::Divider | MouseRegion::Outside => {
+            // Scrollbars are handled on press/drag (above), not as a click; reaching here is inert.
+            MouseRegion::Divider
+            | MouseRegion::ContentVBar
+            | MouseRegion::ContentHBar
+            | MouseRegion::TreeHBar
+            | MouseRegion::Outside => {
                 self.last_click = None;
                 Effects::noop()
             }
@@ -894,16 +928,75 @@ impl Controller {
         }
     }
 
-    /// Horizontal wheel / trackpad swipe over the content pane scrolls it sideways, like the
-    /// `←`/`→` keys (for unwrapped long lines). Over the tree it does nothing — the tree has no
-    /// horizontal scroll. `scroll_content_h` clamps to `[0, widest − viewport]` (zero while
-    /// wrapping), so it is inert on wrapped prose, matching the keys.
+    /// Horizontal wheel / trackpad swipe scrolls sideways: the content pane (like the `←`/`→`
+    /// keys, for unwrapped long lines) or the tree (which has no h-scroll keys). Each clamps to
+    /// `[0, widest − viewport]`, so it is inert when nothing overflows.
     fn hscroll_at(&mut self, col: u16, row: u16, delta: i32) -> Effects {
-        if matches!(self.hit_test(col, row), MouseRegion::Content) {
-            self.scroll_content_h(delta)
-        } else {
-            Effects::noop()
+        match self.hit_test(col, row) {
+            MouseRegion::Content => self.scroll_content_h(delta),
+            MouseRegion::TreeRow(_) => self.scroll_tree_h(delta),
+            _ => Effects::noop(),
         }
+    }
+
+    /// Scroll the tree horizontally by `delta` columns, clamped to `[0, widest − tree width]` from
+    /// the last drawn frame, so a long / deeply-nested row can be read sideways without ever
+    /// over-scrolling past the content.
+    fn scroll_tree_h(&mut self, delta: i32) -> Effects {
+        let max = self
+            .geom
+            .tree_inner
+            .map_or(0, |t| self.geom.tree_content_width.saturating_sub(t.width));
+        let next = (self.tree_hscroll as i32 + delta).clamp(0, max as i32);
+        self.tree_hscroll = next as u16;
+        Effects::redraw()
+    }
+
+    /// Map a vertical position on the content scrollbar track to a content scroll offset (drag /
+    /// click-to-scroll). The track spans the content interior's rows; the fraction maps linearly
+    /// onto `[0, max_content_scroll]`. Rounds to the nearest line. No-op without overflow.
+    fn scroll_content_to_row(&mut self, row: u16) -> Effects {
+        let Some(c) = self.geom.content_inner else {
+            return Effects::noop();
+        };
+        let max = self.max_content_scroll();
+        if c.height <= 1 || max == 0 {
+            return Effects::noop();
+        }
+        let rel = row.saturating_sub(c.y).min(c.height - 1) as u32;
+        let span = (c.height - 1) as u32;
+        self.content_scroll = ((rel * max as u32 + span / 2) / span) as u16;
+        Effects::redraw()
+    }
+
+    /// Map a horizontal position on the content horizontal scrollbar to a content h-scroll offset.
+    fn scroll_content_h_to_col(&mut self, col: u16) -> Effects {
+        let Some(c) = self.geom.content_inner else {
+            return Effects::noop();
+        };
+        let max = self.max_content_hscroll();
+        if c.width <= 1 || max == 0 {
+            return Effects::noop();
+        }
+        let rel = col.saturating_sub(c.x).min(c.width - 1) as u32;
+        let span = (c.width - 1) as u32;
+        self.content_hscroll = ((rel * max as u32 + span / 2) / span) as u16;
+        Effects::redraw()
+    }
+
+    /// Map a horizontal position on the tree's horizontal scrollbar to a tree h-scroll offset.
+    fn scroll_tree_h_to_col(&mut self, col: u16) -> Effects {
+        let Some(t) = self.geom.tree_inner else {
+            return Effects::noop();
+        };
+        let max = self.geom.tree_content_width.saturating_sub(t.width);
+        if t.width <= 1 || max == 0 {
+            return Effects::noop();
+        }
+        let rel = col.saturating_sub(t.x).min(t.width - 1) as u32;
+        let span = (t.width - 1) as u32;
+        self.tree_hscroll = ((rel * max as u32 + span / 2) / span) as u16;
+        Effects::redraw()
     }
 
     /// During a divider drag, set the split so the divider tracks the cursor column — clamped
@@ -926,6 +1019,32 @@ impl Controller {
             && (col == dx || col + 1 == dx)
         {
             return MouseRegion::Divider;
+        }
+        // Scrollbars sit on the block borders (just outside the interior rects), drawn only when
+        // the pane overflows — so a hit counts only when the matching scrollbar is actually drawn.
+        // The content pane's vertical bar is on its right border; both panes' horizontal bars are
+        // on their bottom border. (The tree's vertical bar shares the divider column, so it is not
+        // hit-tested as draggable — see `Drag`.)
+        if let Some(c) = self.geom.content_inner {
+            if col == c.x + c.width
+                && (c.y..c.y + c.height).contains(&row)
+                && self.max_content_scroll() > 0
+            {
+                return MouseRegion::ContentVBar;
+            }
+            if row == c.y + c.height
+                && (c.x..c.x + c.width).contains(&col)
+                && self.max_content_hscroll() > 0
+            {
+                return MouseRegion::ContentHBar;
+            }
+        }
+        if let Some(t) = self.geom.tree_inner
+            && row == t.y + t.height
+            && (t.x..t.x + t.width).contains(&col)
+            && self.geom.tree_content_width > t.width
+        {
+            return MouseRegion::TreeHBar;
         }
         if let Some(t) = self.geom.tree_inner
             && t.contains(Position { x: col, y: row })
@@ -1545,7 +1664,24 @@ enum MouseRegion {
     TreeRow(usize),
     Content,
     Divider,
+    /// The content pane's vertical scrollbar (right border) — drag up/down to scroll.
+    ContentVBar,
+    /// The content pane's horizontal scrollbar (bottom border) — drag left/right to scroll.
+    ContentHBar,
+    /// The tree's horizontal scrollbar (bottom border) — drag left/right to scroll the tree.
+    TreeHBar,
     Outside,
+}
+
+/// What a held left-button drag is currently manipulating. Set on press, cleared on release.
+/// (The tree's *vertical* scrollbar shares the divider column, so it is not draggable — the tree
+/// scrolls vertically via the wheel / selection instead.)
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Drag {
+    Divider,
+    ContentV,
+    ContentH,
+    TreeH,
 }
 
 /// Two left-clicks on the same **row** within [`DOUBLE_CLICK`] are a double-click. The column

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -842,6 +842,10 @@ impl Controller {
                         self.drag = Some(Drag::ContentH);
                         self.scroll_content_h_to_col(col)
                     }
+                    MouseRegion::TreeVBar => {
+                        self.drag = Some(Drag::TreeV);
+                        self.scroll_tree_to_row(row)
+                    }
                     MouseRegion::TreeHBar => {
                         self.drag = Some(Drag::TreeH);
                         self.scroll_tree_h_to_col(col)
@@ -853,6 +857,7 @@ impl Controller {
                 Some(Drag::Divider) => self.resize_split_to_col(col),
                 Some(Drag::ContentV) => self.scroll_content_to_row(row),
                 Some(Drag::ContentH) => self.scroll_content_h_to_col(col),
+                Some(Drag::TreeV) => self.scroll_tree_to_row(row),
                 Some(Drag::TreeH) => self.scroll_tree_h_to_col(col),
                 None => Effects::noop(),
             },
@@ -902,6 +907,7 @@ impl Controller {
             MouseRegion::Divider
             | MouseRegion::ContentVBar
             | MouseRegion::ContentHBar
+            | MouseRegion::TreeVBar
             | MouseRegion::TreeHBar
             | MouseRegion::Outside => {
                 self.last_click = None;
@@ -952,50 +958,74 @@ impl Controller {
         Effects::redraw()
     }
 
-    /// Map a vertical position on the content scrollbar track to a content scroll offset (drag /
-    /// click-to-scroll). The track spans the content interior's rows; the fraction maps linearly
-    /// onto `[0, max_content_scroll]`. Rounds to the nearest line. No-op without overflow.
+    /// The fraction `[0,1]` of a press/drag along a scrollbar track of `len` cells starting at
+    /// `start`, as a rounding numerator/denominator: returns `(rel, span)` so callers stay in
+    /// integer math (`offset = round(rel/span * max)`). `span` is 0 for a degenerate 1-cell track.
+    fn track_fraction(pos: u16, start: u16, len: u16) -> (u32, u32) {
+        let rel = pos.saturating_sub(start).min(len.saturating_sub(1)) as u32;
+        (rel, len.saturating_sub(1) as u32)
+    }
+
+    /// Map a vertical press/drag on the content scrollbar track to a content scroll offset. The
+    /// track is the fed-back `content_vbar` rect; the fraction maps linearly onto
+    /// `[0, max_content_scroll]`, rounded to the nearest line. No-op without overflow.
     fn scroll_content_to_row(&mut self, row: u16) -> Effects {
-        let Some(c) = self.geom.content_inner else {
+        let Some(track) = self.geom.content_vbar else {
             return Effects::noop();
         };
         let max = self.max_content_scroll();
-        if c.height <= 1 || max == 0 {
+        let (rel, span) = Self::track_fraction(row, track.y, track.height);
+        if span == 0 || max == 0 {
             return Effects::noop();
         }
-        let rel = row.saturating_sub(c.y).min(c.height - 1) as u32;
-        let span = (c.height - 1) as u32;
         self.content_scroll = ((rel * max as u32 + span / 2) / span) as u16;
         Effects::redraw()
     }
 
-    /// Map a horizontal position on the content horizontal scrollbar to a content h-scroll offset.
+    /// Map a horizontal press/drag on the content horizontal scrollbar to a content h-scroll offset.
     fn scroll_content_h_to_col(&mut self, col: u16) -> Effects {
-        let Some(c) = self.geom.content_inner else {
+        let Some(track) = self.geom.content_hbar else {
             return Effects::noop();
         };
         let max = self.max_content_hscroll();
-        if c.width <= 1 || max == 0 {
+        let (rel, span) = Self::track_fraction(col, track.x, track.width);
+        if span == 0 || max == 0 {
             return Effects::noop();
         }
-        let rel = col.saturating_sub(c.x).min(c.width - 1) as u32;
-        let span = (c.width - 1) as u32;
         self.content_hscroll = ((rel * max as u32 + span / 2) / span) as u16;
         Effects::redraw()
     }
 
-    /// Map a horizontal position on the tree's horizontal scrollbar to a tree h-scroll offset.
+    /// Map a horizontal press/drag on the tree's horizontal scrollbar to a tree h-scroll offset.
     fn scroll_tree_h_to_col(&mut self, col: u16) -> Effects {
-        let Some(t) = self.geom.tree_inner else {
+        let Some(track) = self.geom.tree_hbar else {
             return Effects::noop();
         };
-        let max = self.geom.tree_content_width.saturating_sub(t.width);
-        if t.width <= 1 || max == 0 {
+        let max = self.geom.tree_content_width.saturating_sub(track.width);
+        let (rel, span) = Self::track_fraction(col, track.x, track.width);
+        if span == 0 || max == 0 {
             return Effects::noop();
         }
-        let rel = col.saturating_sub(t.x).min(t.width - 1) as u32;
-        let span = (t.width - 1) as u32;
         self.tree_hscroll = ((rel * max as u32 + span / 2) / span) as u16;
+        Effects::redraw()
+    }
+
+    /// Map a vertical press/drag on the tree's vertical scrollbar to a selection — scrubbing the
+    /// cursor through the file list, which scrolls the tree to keep it in view (the tree has no
+    /// independent vertical offset; its position follows the selection, #45).
+    fn scroll_tree_to_row(&mut self, row: u16) -> Effects {
+        let Some(track) = self.geom.tree_vbar else {
+            return Effects::noop();
+        };
+        let len = self.tree.visible_nodes().len();
+        let (rel, span) = Self::track_fraction(row, track.y, track.height);
+        if span == 0 || len <= 1 {
+            return Effects::noop();
+        }
+        let idx = ((rel * (len as u32 - 1) + span / 2) / span) as usize;
+        self.focus = Focus::Tree;
+        self.tree.set_cursor(idx);
+        self.dispatch_render();
         Effects::redraw()
     }
 
@@ -1020,34 +1050,24 @@ impl Controller {
         {
             return MouseRegion::Divider;
         }
-        // Scrollbars sit on the block borders (just outside the interior rects), drawn only when
-        // the pane overflows — so a hit counts only when the matching scrollbar is actually drawn.
-        // The content pane's vertical bar is on its right border; both panes' horizontal bars are
-        // on their bottom border. (The tree's vertical bar shares the divider column, so it is not
-        // hit-tested as draggable — see `Drag`.)
-        if let Some(c) = self.geom.content_inner {
-            if col == c.x + c.width
-                && (c.y..c.y + c.height).contains(&row)
-                && self.max_content_scroll() > 0
-            {
-                return MouseRegion::ContentVBar;
-            }
-            if row == c.y + c.height
-                && (c.x..c.x + c.width).contains(&col)
-                && self.max_content_hscroll() > 0
-            {
-                return MouseRegion::ContentHBar;
-            }
+        // Scrollbars live INSIDE the panes (a reserved gutter), fed back as 1-cell track rects that
+        // are present only when that bar is drawn — so a hit on a `Some` track is a real bar. Check
+        // them before the text rects. The tree's vertical bar no longer shares the divider column.
+        let pos = Position { x: col, y: row };
+        if self.geom.content_vbar.is_some_and(|r| r.contains(pos)) {
+            return MouseRegion::ContentVBar;
         }
-        if let Some(t) = self.geom.tree_inner
-            && row == t.y + t.height
-            && (t.x..t.x + t.width).contains(&col)
-            && self.geom.tree_content_width > t.width
-        {
+        if self.geom.content_hbar.is_some_and(|r| r.contains(pos)) {
+            return MouseRegion::ContentHBar;
+        }
+        if self.geom.tree_vbar.is_some_and(|r| r.contains(pos)) {
+            return MouseRegion::TreeVBar;
+        }
+        if self.geom.tree_hbar.is_some_and(|r| r.contains(pos)) {
             return MouseRegion::TreeHBar;
         }
         if let Some(t) = self.geom.tree_inner
-            && t.contains(Position { x: col, y: row })
+            && t.contains(pos)
         {
             // Map the screen row to the node actually drawn there: the on-screen offset plus the
             // tree's scroll offset (#45), the same value `draw_tree` scrolled by. The row index may
@@ -1664,23 +1684,26 @@ enum MouseRegion {
     TreeRow(usize),
     Content,
     Divider,
-    /// The content pane's vertical scrollbar (right border) — drag up/down to scroll.
+    /// The content pane's vertical scrollbar — drag up/down to scroll.
     ContentVBar,
-    /// The content pane's horizontal scrollbar (bottom border) — drag left/right to scroll.
+    /// The content pane's horizontal scrollbar — drag left/right to scroll.
     ContentHBar,
-    /// The tree's horizontal scrollbar (bottom border) — drag left/right to scroll the tree.
+    /// The tree's vertical scrollbar — drag up/down to scrub the selection through the list.
+    TreeVBar,
+    /// The tree's horizontal scrollbar — drag left/right to scroll the tree sideways.
     TreeHBar,
     Outside,
 }
 
 /// What a held left-button drag is currently manipulating. Set on press, cleared on release.
-/// (The tree's *vertical* scrollbar shares the divider column, so it is not draggable — the tree
-/// scrolls vertically via the wheel / selection instead.)
+/// The scrollbars now live *inside* the panes (not on the borders), so all four are draggable —
+/// the tree's vertical bar no longer collides with the divider.
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum Drag {
     Divider,
     ContentV,
     ContentH,
+    TreeV,
     TreeH,
 }
 

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -188,9 +188,9 @@ fn scrollbar_state(total: usize, pos: usize, viewport: usize) -> ScrollbarState 
 // segment of the border showing the scroll position — thin and unobtrusive — rather than the
 // default `█` full-block thumb, which looks like a thick solid slab (especially horizontally).
 const VSCROLL_TRACK: &str = "│";
-const VSCROLL_THUMB: &str = "┃";
+const VSCROLL_THUMB: &str = "▐";
 const HSCROLL_TRACK: &str = "─";
-const HSCROLL_THUMB: &str = "━";
+const HSCROLL_THUMB: &str = "▄";
 
 /// Draw a vertical scrollbar on the RIGHT border of `block_area`, but only when the content
 /// overflows (`total > viewport`). Inset by one row top/bottom so it never overwrites the block's

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -183,11 +183,20 @@ fn scrollbar_state(total: usize, pos: usize, viewport: usize) -> ScrollbarState 
         .viewport_content_length(viewport)
 }
 
+// The scrollbars sit ON the pane border, so they use *line* glyphs, not blocks: a light track
+// matching the border (`│` / `─`) with a HEAVY line thumb (`┃` / `━`). This reads as a bold
+// segment of the border showing the scroll position — thin and unobtrusive — rather than the
+// default `█` full-block thumb, which looks like a thick solid slab (especially horizontally).
+const VSCROLL_TRACK: &str = "│";
+const VSCROLL_THUMB: &str = "┃";
+const HSCROLL_TRACK: &str = "─";
+const HSCROLL_THUMB: &str = "━";
+
 /// Draw a vertical scrollbar on the RIGHT border of `block_area`, but only when the content
 /// overflows (`total > viewport`). Inset by one row top/bottom so it never overwrites the block's
-/// corners; the begin/end arrow glyphs are dropped so it reads as a clean track + thumb on the
-/// border (track `║`, thumb `█`). A no-op when everything fits — "a scrollbar only where there is
-/// something to be moved".
+/// corners; arrow glyphs dropped. Thin line glyphs (track `│`, thumb `┃`) so it reads as a bold
+/// segment of the border, not a block. A no-op when everything fits — "a scrollbar only where
+/// there is something to be moved".
 fn draw_vscrollbar(frame: &mut Frame, block_area: Rect, total: usize, pos: usize, viewport: usize) {
     if viewport == 0 || total <= viewport {
         return;
@@ -196,7 +205,9 @@ fn draw_vscrollbar(frame: &mut Frame, block_area: Rect, total: usize, pos: usize
     frame.render_stateful_widget(
         Scrollbar::new(ScrollbarOrientation::VerticalRight)
             .begin_symbol(None)
-            .end_symbol(None),
+            .end_symbol(None)
+            .track_symbol(Some(VSCROLL_TRACK))
+            .thumb_symbol(VSCROLL_THUMB),
         block_area.inner(Margin {
             vertical: 1,
             horizontal: 0,
@@ -207,7 +218,8 @@ fn draw_vscrollbar(frame: &mut Frame, block_area: Rect, total: usize, pos: usize
 
 /// Draw a horizontal scrollbar on the BOTTOM border of `block_area`, only when the content is wider
 /// than the viewport (`total > viewport`). Inset by one column each side so it never overwrites the
-/// corners; arrow glyphs dropped (track `═`, thumb `█`). A no-op when everything fits.
+/// corners; arrow glyphs dropped. Thin line glyphs (track `─`, thumb `━`) so the bottom border
+/// shows a bold segment rather than a thick `█` slab. A no-op when everything fits.
 fn draw_hscrollbar(frame: &mut Frame, block_area: Rect, total: usize, pos: usize, viewport: usize) {
     if viewport == 0 || total <= viewport {
         return;
@@ -216,7 +228,9 @@ fn draw_hscrollbar(frame: &mut Frame, block_area: Rect, total: usize, pos: usize
     frame.render_stateful_widget(
         Scrollbar::new(ScrollbarOrientation::HorizontalBottom)
             .begin_symbol(None)
-            .end_symbol(None),
+            .end_symbol(None)
+            .track_symbol(Some(HSCROLL_TRACK))
+            .thumb_symbol(HSCROLL_THUMB),
         block_area.inner(Margin {
             vertical: 0,
             horizontal: 1,

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -201,11 +201,10 @@ fn scrollbar_state(total: usize, pos: usize, viewport: usize) -> ScrollbarState 
 }
 
 // The scrollbars sit INSIDE the pane (a reserved gutter column / row, one cell off the text — see
-// `bar_layout`), so they use a light track matching the border (`│` / `─`) with a half-block thumb
-// (`▐` / `▄`) — a clear medium-weight bar, neither a thin line nor a full-block slab.
-const VSCROLL_TRACK: &str = "│";
+// `bar_layout`). They are THUMB-ONLY (no track line): a half-block thumb (`▐` vertical, `▄`
+// horizontal) floats in an otherwise-blank gutter, so there's no extra line running beside the
+// border / above the row.
 const VSCROLL_THUMB: &str = "▐";
-const HSCROLL_TRACK: &str = "─";
 const HSCROLL_THUMB: &str = "▄";
 
 /// Lay out a pane interior `inner` with the scrollbars drawn *inside* it (not on the border):
@@ -236,8 +235,9 @@ fn bar_layout(inner: Rect, vbar: bool, hbar: bool) -> (Rect, Option<Rect>, Optio
 }
 
 /// Draw a vertical scrollbar into `track` (a 1-column rect inside the pane), only when the content
-/// overflows (`total > viewport`). Arrow glyphs dropped; thin line track + half-block thumb. No-op
-/// when everything fits — "a scrollbar only where there is something to be moved".
+/// overflows (`total > viewport`). Thumb-only: no track line or arrow glyphs, just the thumb in an
+/// otherwise-blank gutter. No-op when everything fits — "a scrollbar only where there is something
+/// to be moved".
 fn draw_vscrollbar(frame: &mut Frame, track: Rect, total: usize, pos: usize, viewport: usize) {
     if viewport == 0 || total <= viewport {
         return;
@@ -247,7 +247,7 @@ fn draw_vscrollbar(frame: &mut Frame, track: Rect, total: usize, pos: usize, vie
         Scrollbar::new(ScrollbarOrientation::VerticalRight)
             .begin_symbol(None)
             .end_symbol(None)
-            .track_symbol(Some(VSCROLL_TRACK))
+            .track_symbol(None)
             .thumb_symbol(VSCROLL_THUMB),
         track,
         &mut sb,
@@ -255,7 +255,7 @@ fn draw_vscrollbar(frame: &mut Frame, track: Rect, total: usize, pos: usize, vie
 }
 
 /// Draw a horizontal scrollbar into `track` (a 1-row rect inside the pane), only when the content
-/// is wider than it (`total > viewport`). Arrow glyphs dropped; thin line track + half-block thumb.
+/// is wider than it (`total > viewport`). Thumb-only: no track line or arrow glyphs.
 fn draw_hscrollbar(frame: &mut Frame, track: Rect, total: usize, pos: usize, viewport: usize) {
     if viewport == 0 || total <= viewport {
         return;
@@ -265,7 +265,7 @@ fn draw_hscrollbar(frame: &mut Frame, track: Rect, total: usize, pos: usize, vie
         Scrollbar::new(ScrollbarOrientation::HorizontalBottom)
             .begin_symbol(None)
             .end_symbol(None)
-            .track_symbol(Some(HSCROLL_TRACK))
+            .track_symbol(None)
             .thumb_symbol(HSCROLL_THUMB),
         track,
         &mut sb,

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -49,6 +49,11 @@ pub struct ViewState {
     /// Horizontal scroll offset of the content pane, in columns. Only meaningful when not
     /// wrapping (ratatui ignores it under wrap); lets long code/diff lines be read sideways.
     pub content_hscroll: u16,
+    /// The tree's vertical scroll offset from the LAST drawn frame (first visible node index),
+    /// carried back via [`PaneGeometry::tree_scroll`]. The Presenter scrolls *minimally* from it
+    /// so selecting a row already in view (e.g. a mouse click) never jumps the viewport (#45). `0`
+    /// on the first frame and whenever every node fits.
+    pub tree_scroll: u16,
     /// Wrap long content lines (prose: markdown / plain text) instead of truncating them.
     /// Off for diffs and code, whose column alignment must be preserved.
     pub wrap: bool,
@@ -163,6 +168,21 @@ fn tree_row(node: &Node, selected: bool) -> Line<'static> {
     Line::from(Span::styled(text, style))
 }
 
+/// Build a [`ScrollbarState`] that places the thumb correctly for a **scroll offset** (not a list
+/// selection). ratatui's thumb reaches the track end only at `position == content_length - 1`,
+/// while a scroll offset maxes at `total - viewport` — so model the scroll range as its
+/// `(max_scroll + 1)` distinct offsets (`content_length = total - viewport + 1`, positions
+/// `0..=max_scroll`) and set `viewport_content_length` so the thumb is sized to the visible
+/// fraction (`viewport / total`). The thumb then sits at the top at offset 0 and reaches the
+/// bottom at the last offset (fixes the "thumb never reaches the end" misreport). Caller guarantees
+/// `total > viewport`.
+fn scrollbar_state(total: usize, pos: usize, viewport: usize) -> ScrollbarState {
+    let content_length = total - viewport + 1;
+    ScrollbarState::new(content_length)
+        .position(pos.min(content_length - 1))
+        .viewport_content_length(viewport)
+}
+
 /// Draw a vertical scrollbar on the RIGHT border of `block_area`, but only when the content
 /// overflows (`total > viewport`). Inset by one row top/bottom so it never overwrites the block's
 /// corners; the begin/end arrow glyphs are dropped so it reads as a clean track + thumb on the
@@ -172,9 +192,7 @@ fn draw_vscrollbar(frame: &mut Frame, block_area: Rect, total: usize, pos: usize
     if viewport == 0 || total <= viewport {
         return;
     }
-    let mut sb = ScrollbarState::new(total)
-        .position(pos.min(total.saturating_sub(1)))
-        .viewport_content_length(viewport);
+    let mut sb = scrollbar_state(total, pos, viewport);
     frame.render_stateful_widget(
         Scrollbar::new(ScrollbarOrientation::VerticalRight)
             .begin_symbol(None)
@@ -194,9 +212,7 @@ fn draw_hscrollbar(frame: &mut Frame, block_area: Rect, total: usize, pos: usize
     if viewport == 0 || total <= viewport {
         return;
     }
-    let mut sb = ScrollbarState::new(total)
-        .position(pos.min(total.saturating_sub(1)))
-        .viewport_content_length(viewport);
+    let mut sb = scrollbar_state(total, pos, viewport);
     frame.render_stateful_widget(
         Scrollbar::new(ScrollbarOrientation::HorizontalBottom)
             .begin_symbol(None)
@@ -232,12 +248,22 @@ fn draw_tree(frame: &mut Frame, area: Rect, state: &ViewState) {
         .enumerate()
         .map(|(i, node)| tree_row(node, i == state.selected))
         .collect();
-    // Scroll the tree so the selected row stays visible (#45). The offset is a pure function of
-    // the selection, node count, and the live interior height — so it never needs controller
-    // state, and `geometry` recomputes the SAME value for hit-testing (clicks stay correct when
-    // scrolled). `Paragraph::scroll((y, 0))` clips the leading `y` rows off the top.
-    let offset = scroll_offset(state.selected, state.nodes.len(), inner.height as usize);
-    frame.render_widget(Paragraph::new(rows).scroll((offset as u16, 0)), inner);
+    // Scroll the tree so the selected row stays visible (#45), minimally from last frame's offset
+    // (`state.tree_scroll`) so selecting a row already in view doesn't jump the viewport. The
+    // offset is a pure function of the selection, node count, last offset, and the live interior
+    // height — so `geometry` recomputes the SAME value for hit-testing (clicks stay correct when
+    // scrolled). `Paragraph::scroll((y, 0))` clips the leading `y` rows off the top; the cast
+    // saturates so an absurd tree (>65535 rows above the fold) can't wrap the offset.
+    let offset = sticky_scroll_offset(
+        state.selected,
+        state.nodes.len(),
+        inner.height as usize,
+        state.tree_scroll as usize,
+    );
+    frame.render_widget(
+        Paragraph::new(rows).scroll((offset.min(u16::MAX as usize) as u16, 0)),
+        inner,
+    );
     // A vertical scrollbar on the right border when there are more nodes than fit.
     draw_vscrollbar(
         frame,
@@ -398,10 +424,17 @@ pub fn geometry(area: Rect, state: &ViewState) -> PaneGeometry {
     let inner = |r: Rect| Block::bordered().inner(r);
     let tree_inner = tree.map(inner);
     // The tree's scroll offset MUST match what `draw_tree` applies, or a click maps to the wrong
-    // node once the tree scrolls. Both derive it from the same pure `scroll_offset` over the live
-    // interior height — so the drawn window and the hit-test window can never disagree.
+    // node once the tree scrolls. Both derive it from the same pure `sticky_scroll_offset` over the
+    // live interior height and last frame's offset — so the drawn window and the hit-test window
+    // can never disagree. Saturating cast: an absurd >65535 offset clamps instead of wrapping.
     let tree_scroll = tree_inner.map_or(0, |t| {
-        scroll_offset(state.selected, state.nodes.len(), t.height as usize) as u16
+        sticky_scroll_offset(
+            state.selected,
+            state.nodes.len(),
+            t.height as usize,
+            state.tree_scroll as usize,
+        )
+        .min(u16::MAX as usize) as u16
     });
     PaneGeometry {
         area_x: body.x,
@@ -584,10 +617,10 @@ fn draw_picker_overlay(frame: &mut Frame, area: Rect, picker: &PickerView) {
     frame.render_widget(Paragraph::new(window).scroll((0, hscroll)), inner);
 }
 
-/// The first row index to render so the `cursor` row stays within a window of `visible` rows.
-/// Returns 0 when every row fits (or the window is degenerate), and never scrolls past the end.
-/// Shared by the file tree ([`draw_tree`]) and the worktree picker overlay so both keep their
-/// selection on screen with identical semantics (#45).
+/// The first row index to render so the `cursor` row stays within a window of `visible` rows,
+/// **anchoring** the window to the cursor (cursor in the first page ⇒ offset 0). Returns 0 when
+/// every row fits (or the window is degenerate), and never scrolls past the end. Used by the
+/// worktree picker, whose cursor only ever moves by keyboard (no jump to worry about).
 fn scroll_offset(cursor: usize, len: usize, visible: usize) -> usize {
     if visible == 0 || len <= visible {
         return 0;
@@ -600,6 +633,27 @@ fn scroll_offset(cursor: usize, len: usize, visible: usize) -> usize {
     } else {
         (cursor + 1 - visible).min(max_offset)
     }
+}
+
+/// Like [`scroll_offset`] but scrolls **minimally** from the `current` offset: if the cursor is
+/// already inside `[current, current + visible)` the offset does not move. The file tree uses this
+/// so selecting a row that is already on screen — e.g. a mouse click — never jumps the viewport
+/// (a jump would also make a double-click land on the wrong row). Off-screen, it scrolls just
+/// enough to bring the cursor to the nearest edge. Clamped to `[0, len - visible]`.
+fn sticky_scroll_offset(cursor: usize, len: usize, visible: usize, current: usize) -> usize {
+    if visible == 0 || len <= visible {
+        return 0;
+    }
+    let max_offset = len - visible;
+    let current = current.min(max_offset);
+    let offset = if cursor < current {
+        cursor // above the window → bring the cursor to the top edge
+    } else if cursor >= current + visible {
+        cursor + 1 - visible // below the window → bring it to the bottom edge
+    } else {
+        current // already visible → don't move (no jump on a click)
+    };
+    offset.min(max_offset)
 }
 
 /// The color for an agent-status badge: `working`/`done` green, `idle` blue, `blocked` red,

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -10,10 +10,12 @@
 use crate::git::Status;
 use crate::tree::{Node, NodeKind};
 use ratatui::Frame;
-use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::layout::{Constraint, Layout, Margin, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span, Text};
-use ratatui::widgets::{Block, Clear, Padding, Paragraph, Wrap};
+use ratatui::widgets::{
+    Block, Clear, Padding, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState, Wrap,
+};
 
 /// Which column currently has keyboard focus.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -161,6 +163,52 @@ fn tree_row(node: &Node, selected: bool) -> Line<'static> {
     Line::from(Span::styled(text, style))
 }
 
+/// Draw a vertical scrollbar on the RIGHT border of `block_area`, but only when the content
+/// overflows (`total > viewport`). Inset by one row top/bottom so it never overwrites the block's
+/// corners; the begin/end arrow glyphs are dropped so it reads as a clean track + thumb on the
+/// border (track `║`, thumb `█`). A no-op when everything fits — "a scrollbar only where there is
+/// something to be moved".
+fn draw_vscrollbar(frame: &mut Frame, block_area: Rect, total: usize, pos: usize, viewport: usize) {
+    if viewport == 0 || total <= viewport {
+        return;
+    }
+    let mut sb = ScrollbarState::new(total)
+        .position(pos.min(total.saturating_sub(1)))
+        .viewport_content_length(viewport);
+    frame.render_stateful_widget(
+        Scrollbar::new(ScrollbarOrientation::VerticalRight)
+            .begin_symbol(None)
+            .end_symbol(None),
+        block_area.inner(Margin {
+            vertical: 1,
+            horizontal: 0,
+        }),
+        &mut sb,
+    );
+}
+
+/// Draw a horizontal scrollbar on the BOTTOM border of `block_area`, only when the content is wider
+/// than the viewport (`total > viewport`). Inset by one column each side so it never overwrites the
+/// corners; arrow glyphs dropped (track `═`, thumb `█`). A no-op when everything fits.
+fn draw_hscrollbar(frame: &mut Frame, block_area: Rect, total: usize, pos: usize, viewport: usize) {
+    if viewport == 0 || total <= viewport {
+        return;
+    }
+    let mut sb = ScrollbarState::new(total)
+        .position(pos.min(total.saturating_sub(1)))
+        .viewport_content_length(viewport);
+    frame.render_stateful_widget(
+        Scrollbar::new(ScrollbarOrientation::HorizontalBottom)
+            .begin_symbol(None)
+            .end_symbol(None),
+        block_area.inner(Margin {
+            vertical: 0,
+            horizontal: 1,
+        }),
+        &mut sb,
+    );
+}
+
 /// Border style for a column — highlighted when it holds focus.
 fn border_style(focused: bool) -> Style {
     if focused {
@@ -184,7 +232,20 @@ fn draw_tree(frame: &mut Frame, area: Rect, state: &ViewState) {
         .enumerate()
         .map(|(i, node)| tree_row(node, i == state.selected))
         .collect();
-    frame.render_widget(Paragraph::new(rows), inner);
+    // Scroll the tree so the selected row stays visible (#45). The offset is a pure function of
+    // the selection, node count, and the live interior height — so it never needs controller
+    // state, and `geometry` recomputes the SAME value for hit-testing (clicks stay correct when
+    // scrolled). `Paragraph::scroll((y, 0))` clips the leading `y` rows off the top.
+    let offset = scroll_offset(state.selected, state.nodes.len(), inner.height as usize);
+    frame.render_widget(Paragraph::new(rows).scroll((offset as u16, 0)), inner);
+    // A vertical scrollbar on the right border when there are more nodes than fit.
+    draw_vscrollbar(
+        frame,
+        area,
+        state.nodes.len(),
+        offset,
+        inner.height as usize,
+    );
 }
 
 /// Draw the right column: a notices strip (if any) above the content pane. Returns the
@@ -223,6 +284,36 @@ fn draw_content(frame: &mut Frame, area: Rect, state: &ViewState) -> (u16, u16) 
         content = content.wrap(Wrap { trim: false });
     }
     frame.render_widget(content, parts[1]);
+
+    // Scrollbars on the content block's borders, only where the file overflows its viewport.
+    // Counts are taken from the raw content lines — exact for the unwrapped case (code/diffs, the
+    // primary scroll use), and a close approximation under wrap. The horizontal bar is suppressed
+    // under wrap, where there is nothing to scroll sideways. `viewport` is the true content
+    // region (`parts[1]`), below the notices strip.
+    let total_lines = state.content.lines.len();
+    draw_vscrollbar(
+        frame,
+        area,
+        total_lines,
+        state.content_scroll as usize,
+        parts[1].height as usize,
+    );
+    if !state.wrap {
+        let max_width = state
+            .content
+            .lines
+            .iter()
+            .map(|l| l.width())
+            .max()
+            .unwrap_or(0);
+        draw_hscrollbar(
+            frame,
+            area,
+            max_width,
+            state.content_hscroll as usize,
+            parts[1].width as usize,
+        );
+    }
     (parts[1].width, parts[1].height)
 }
 
@@ -281,14 +372,19 @@ fn columns(area: Rect, state: &ViewState) -> (Option<Rect>, Option<Rect>, Option
 }
 
 /// Hit-test geometry for mouse input, derived from the same split [`draw`] renders.
-/// `tree_inner` is the interior where tree rows are drawn — visible node `i` is at row
-/// `tree_inner.y + i` (the tree does not scroll). `content_inner` is the content column
-/// interior. `divider_x` is the draggable boundary column (wide layout only).
+/// `tree_inner` is the interior where tree rows are drawn — the visible node at screen row
+/// `tree_inner.y + r` is index `r + tree_scroll` (the tree scrolls to keep the selection in
+/// view, #45). `content_inner` is the content column interior. `divider_x` is the draggable
+/// boundary column (wide layout only).
 #[derive(Clone, Copy, Default, Debug, PartialEq, Eq)]
 pub struct PaneGeometry {
     pub area_x: u16,
     pub area_width: u16,
     pub tree_inner: Option<Rect>,
+    /// The tree's vertical scroll offset (first visible node index) on the last drawn frame —
+    /// the same value [`draw_tree`] scrolled by. Hit-testing adds it to map a screen row to the
+    /// node actually drawn there. `0` when every node fits.
+    pub tree_scroll: u16,
     pub content_inner: Option<Rect>,
     pub divider_x: Option<u16>,
 }
@@ -300,10 +396,18 @@ pub fn geometry(area: Rect, state: &ViewState) -> PaneGeometry {
     let (body, _footer) = body_and_footer(area, state);
     let (tree, content, divider_x) = columns(body, state);
     let inner = |r: Rect| Block::bordered().inner(r);
+    let tree_inner = tree.map(inner);
+    // The tree's scroll offset MUST match what `draw_tree` applies, or a click maps to the wrong
+    // node once the tree scrolls. Both derive it from the same pure `scroll_offset` over the live
+    // interior height — so the drawn window and the hit-test window can never disagree.
+    let tree_scroll = tree_inner.map_or(0, |t| {
+        scroll_offset(state.selected, state.nodes.len(), t.height as usize) as u16
+    });
     PaneGeometry {
         area_x: body.x,
         area_width: body.width,
-        tree_inner: tree.map(inner),
+        tree_inner,
+        tree_scroll,
         content_inner: content.map(inner),
         divider_x,
     }
@@ -465,7 +569,7 @@ fn draw_picker_overlay(frame: &mut Frame, area: Rect, picker: &PickerView) {
     // `cursor` inside `[offset, offset + visible)`: clamp the offset so it never scrolls past
     // the end and is 0 whenever all rows fit (preserving the small-list rendering).
     let visible = inner.height as usize;
-    let offset = picker_scroll_offset(picker.cursor, picker.rows.len(), visible);
+    let offset = scroll_offset(picker.cursor, picker.rows.len(), visible);
 
     // Clamp the horizontal scroll to the widest ROW: at most `max_row_width - inner_width`
     // (0 when every row fits). NOT against `desired_inner_w`, which is inflated by the title/footer
@@ -482,7 +586,9 @@ fn draw_picker_overlay(frame: &mut Frame, area: Rect, picker: &PickerView) {
 
 /// The first row index to render so the `cursor` row stays within a window of `visible` rows.
 /// Returns 0 when every row fits (or the window is degenerate), and never scrolls past the end.
-fn picker_scroll_offset(cursor: usize, len: usize, visible: usize) -> usize {
+/// Shared by the file tree ([`draw_tree`]) and the worktree picker overlay so both keep their
+/// selection on screen with identical semantics (#45).
+fn scroll_offset(cursor: usize, len: usize, visible: usize) -> usize {
     if visible == 0 || len <= visible {
         return 0;
     }

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -10,7 +10,7 @@
 use crate::git::Status;
 use crate::tree::{Node, NodeKind};
 use ratatui::Frame;
-use ratatui::layout::{Constraint, Layout, Margin, Rect};
+use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span, Text};
 use ratatui::widgets::{
@@ -200,21 +200,45 @@ fn scrollbar_state(total: usize, pos: usize, viewport: usize) -> ScrollbarState 
         .viewport_content_length(viewport)
 }
 
-// The scrollbars sit ON the pane border, so they use *line* glyphs, not blocks: a light track
-// matching the border (`│` / `─`) with a HEAVY line thumb (`┃` / `━`). This reads as a bold
-// segment of the border showing the scroll position — thin and unobtrusive — rather than the
-// default `█` full-block thumb, which looks like a thick solid slab (especially horizontally).
+// The scrollbars sit INSIDE the pane (a reserved gutter column / row, one cell off the text — see
+// `bar_layout`), so they use a light track matching the border (`│` / `─`) with a half-block thumb
+// (`▐` / `▄`) — a clear medium-weight bar, neither a thin line nor a full-block slab.
 const VSCROLL_TRACK: &str = "│";
 const VSCROLL_THUMB: &str = "▐";
 const HSCROLL_TRACK: &str = "─";
 const HSCROLL_THUMB: &str = "▄";
 
-/// Draw a vertical scrollbar on the RIGHT border of `block_area`, but only when the content
-/// overflows (`total > viewport`). Inset by one row top/bottom so it never overwrites the block's
-/// corners; arrow glyphs dropped. Thin line glyphs (track `│`, thumb `┃`) so it reads as a bold
-/// segment of the border, not a block. A no-op when everything fits — "a scrollbar only where
-/// there is something to be moved".
-fn draw_vscrollbar(frame: &mut Frame, block_area: Rect, total: usize, pos: usize, viewport: usize) {
+/// Lay out a pane interior `inner` with the scrollbars drawn *inside* it (not on the border):
+/// reserve the rightmost column for a vertical bar with a one-column gap before it, and/or the
+/// bottom row for a horizontal bar with a one-row gap above it. Returns the (shrunk) text rect and
+/// each bar's 1-cell track. The gap keeps the bar off the text; the two bars never overlap (the
+/// vbar spans only the text rows, the hbar only the text columns), leaving the inner corner blank.
+fn bar_layout(inner: Rect, vbar: bool, hbar: bool) -> (Rect, Option<Rect>, Option<Rect>) {
+    let text = Rect {
+        x: inner.x,
+        y: inner.y,
+        width: inner.width.saturating_sub(if vbar { 2 } else { 0 }),
+        height: inner.height.saturating_sub(if hbar { 2 } else { 0 }),
+    };
+    let vbar_rect = (vbar && inner.width > 0).then(|| Rect {
+        x: inner.x + inner.width - 1,
+        y: inner.y,
+        width: 1,
+        height: text.height.max(1),
+    });
+    let hbar_rect = (hbar && inner.height > 0).then(|| Rect {
+        x: inner.x,
+        y: inner.y + inner.height - 1,
+        width: text.width.max(1),
+        height: 1,
+    });
+    (text, vbar_rect, hbar_rect)
+}
+
+/// Draw a vertical scrollbar into `track` (a 1-column rect inside the pane), only when the content
+/// overflows (`total > viewport`). Arrow glyphs dropped; thin line track + half-block thumb. No-op
+/// when everything fits — "a scrollbar only where there is something to be moved".
+fn draw_vscrollbar(frame: &mut Frame, track: Rect, total: usize, pos: usize, viewport: usize) {
     if viewport == 0 || total <= viewport {
         return;
     }
@@ -225,19 +249,14 @@ fn draw_vscrollbar(frame: &mut Frame, block_area: Rect, total: usize, pos: usize
             .end_symbol(None)
             .track_symbol(Some(VSCROLL_TRACK))
             .thumb_symbol(VSCROLL_THUMB),
-        block_area.inner(Margin {
-            vertical: 1,
-            horizontal: 0,
-        }),
+        track,
         &mut sb,
     );
 }
 
-/// Draw a horizontal scrollbar on the BOTTOM border of `block_area`, only when the content is wider
-/// than the viewport (`total > viewport`). Inset by one column each side so it never overwrites the
-/// corners; arrow glyphs dropped. Thin line glyphs (track `─`, thumb `━`) so the bottom border
-/// shows a bold segment rather than a thick `█` slab. A no-op when everything fits.
-fn draw_hscrollbar(frame: &mut Frame, block_area: Rect, total: usize, pos: usize, viewport: usize) {
+/// Draw a horizontal scrollbar into `track` (a 1-row rect inside the pane), only when the content
+/// is wider than it (`total > viewport`). Arrow glyphs dropped; thin line track + half-block thumb.
+fn draw_hscrollbar(frame: &mut Frame, track: Rect, total: usize, pos: usize, viewport: usize) {
     if viewport == 0 || total <= viewport {
         return;
     }
@@ -248,12 +267,56 @@ fn draw_hscrollbar(frame: &mut Frame, block_area: Rect, total: usize, pos: usize
             .end_symbol(None)
             .track_symbol(Some(HSCROLL_TRACK))
             .thumb_symbol(HSCROLL_THUMB),
-        block_area.inner(Margin {
-            vertical: 0,
-            horizontal: 1,
-        }),
+        track,
         &mut sb,
     );
+}
+
+/// The tree interior split into the text rect + optional in-pane scrollbar tracks. Overflow is
+/// decided against the *reserved* space — a vbar steals width that can then require an hbar, and an
+/// hbar steals height that can require a vbar — so a two-pass check settles which bars are needed.
+/// Shared by [`draw_tree`] and [`geometry`] so the drawn layout and the hit-test geometry agree.
+fn tree_bars(
+    inner: Rect,
+    nodes_len: usize,
+    max_row_width: usize,
+) -> (Rect, Option<Rect>, Option<Rect>) {
+    let v0 = nodes_len > inner.height as usize;
+    let h0 = max_row_width > inner.width as usize;
+    let needs_v = nodes_len > inner.height.saturating_sub(if h0 { 2 } else { 0 }) as usize;
+    let needs_h = max_row_width > inner.width.saturating_sub(if v0 { 2 } else { 0 }) as usize;
+    bar_layout(inner, needs_v, needs_h)
+}
+
+/// Split the content block interior into the notices strip (top) and the content area (below it,
+/// where the file + its scrollbars are drawn). Shared by [`draw_content`] and [`geometry`].
+fn content_notice_split(inner: Rect, notices_len: usize) -> (Rect, Rect) {
+    let max_notices = inner.height.saturating_sub(1).min(notices_len as u16);
+    let parts =
+        Layout::vertical([Constraint::Length(max_notices), Constraint::Min(0)]).split(inner);
+    (parts[0], parts[1])
+}
+
+/// The content area split into the text rect + optional in-pane scrollbar tracks. `max_line_width`
+/// is the widest raw content line; under `wrap` there is no horizontal overflow. Two-pass like
+/// [`tree_bars`]. Shared by [`draw_content`] and [`geometry`].
+fn content_bars(
+    content_area: Rect,
+    total_lines: usize,
+    max_line_width: usize,
+    wrap: bool,
+) -> (Rect, Option<Rect>, Option<Rect>) {
+    let max_w = if wrap { 0 } else { max_line_width };
+    let v0 = total_lines > content_area.height as usize;
+    let h0 = max_w > content_area.width as usize;
+    let needs_v = total_lines > content_area.height.saturating_sub(if h0 { 2 } else { 0 }) as usize;
+    let needs_h = max_w > content_area.width.saturating_sub(if v0 { 2 } else { 0 }) as usize;
+    bar_layout(content_area, needs_v, needs_h)
+}
+
+/// The widest raw content line, in display columns (for the content area's horizontal overflow).
+fn content_max_line_width(content: &Text<'static>) -> usize {
+    content.lines.iter().map(|l| l.width()).max().unwrap_or(0)
 }
 
 /// Border style for a column — highlighted when it holds focus.
@@ -279,41 +342,39 @@ fn draw_tree(frame: &mut Frame, area: Rect, state: &ViewState) {
         .enumerate()
         .map(|(i, node)| tree_row(node, i == state.selected))
         .collect();
-    // Scroll the tree so the selected row stays visible (#45), minimally from last frame's offset
-    // (`state.tree_scroll`) so selecting a row already in view doesn't jump the viewport. The
-    // offset is a pure function of the selection, node count, last offset, and the live interior
-    // height — so `geometry` recomputes the SAME value for hit-testing (clicks stay correct when
-    // scrolled). `Paragraph::scroll((y, 0))` clips the leading `y` rows off the top; the cast
-    // saturates so an absurd tree (>65535 rows above the fold) can't wrap the offset.
+    // Reserve an in-pane gutter for whichever scrollbars are needed, then render the rows into the
+    // (possibly shrunk) text rect. The vertical offset scrolls minimally from last frame's offset
+    // (#45) so selecting a row already in view doesn't jump the viewport; the horizontal offset
+    // lets long / deeply-nested rows be read sideways (no h-scroll keys — ←/→ are expand/collapse).
+    // `geometry` recomputes the SAME layout + offset, so hit-testing agrees with what is drawn.
+    let max_width = tree_rows_max_width(&state.nodes);
+    let (text, vbar, hbar) = tree_bars(inner, state.nodes.len(), max_width);
     let offset = sticky_scroll_offset(
         state.selected,
         state.nodes.len(),
-        inner.height as usize,
+        text.height as usize,
         state.tree_scroll as usize,
     );
-    // Horizontal scroll for long / deeply-nested rows (the tree has no h-scroll keys — ←/→ are
-    // expand/collapse — so this is driven by the wheel and by dragging the tree's h-scrollbar).
-    // Clamp to the widest row so it can never over-scroll past the content.
-    let max_width = tree_rows_max_width(&state.nodes);
-    let hmax = max_width.saturating_sub(inner.width as usize);
-    let hoff = (state.tree_hscroll as usize).min(hmax);
+    let hoff = (state.tree_hscroll as usize).min(max_width.saturating_sub(text.width as usize));
     frame.render_widget(
         Paragraph::new(rows).scroll((
             offset.min(u16::MAX as usize) as u16,
             hoff.min(u16::MAX as usize) as u16,
         )),
-        inner,
+        text,
     );
-    // A vertical scrollbar on the right border when there are more nodes than fit, and a
-    // horizontal one on the bottom border when the widest row overflows the column.
-    draw_vscrollbar(
-        frame,
-        area,
-        state.nodes.len(),
-        offset,
-        inner.height as usize,
-    );
-    draw_hscrollbar(frame, area, max_width, hoff, inner.width as usize);
+    if let Some(track) = vbar {
+        draw_vscrollbar(
+            frame,
+            track,
+            state.nodes.len(),
+            offset,
+            text.height as usize,
+        );
+    }
+    if let Some(track) = hbar {
+        draw_hscrollbar(frame, track, max_width, hoff, text.width as usize);
+    }
 }
 
 /// Draw the right column: a notices strip (if any) above the content pane. Returns the
@@ -331,58 +392,51 @@ fn draw_content(frame: &mut Frame, area: Rect, state: &ViewState) -> (u16, u16) 
     frame.render_widget(block, area);
 
     // A notice strip (truncation AC-13, fallback AC-25) sits above the content, bounded so
-    // it can never crowd out the file itself.
-    let max_notices = (inner.height.saturating_sub(1)).min(state.notices.len() as u16);
-    let parts =
-        Layout::vertical([Constraint::Length(max_notices), Constraint::Min(0)]).split(inner);
-
-    if max_notices > 0 {
+    // it can never crowd out the file itself; the file + its scrollbars fill the area below it.
+    let (notices_rect, content_area) = content_notice_split(inner, state.notices.len());
+    if notices_rect.height > 0 {
         let notice_lines: Vec<Line> = state
             .notices
             .iter()
             .map(|n| Line::styled(sanitize_label(n), Style::new().fg(Color::Yellow)))
             .collect();
-        frame.render_widget(Paragraph::new(notice_lines), parts[0]);
+        frame.render_widget(Paragraph::new(notice_lines), notices_rect);
     }
-    // Scroll the content vertically (AC: read a file beyond the first screenful). Wrap prose
-    // so long lines aren't clipped; keep diffs/code unwrapped to preserve their alignment.
+
+    // Reserve an in-pane gutter for whichever scrollbars overflow, then render the file into the
+    // (possibly shrunk) text rect. Counts come from the raw content lines — exact when unwrapped
+    // (code/diffs, the primary scroll case) and a close approximation under wrap; the horizontal
+    // bar is suppressed under wrap, where there is nothing to scroll sideways.
+    let total_lines = state.content.lines.len();
+    let max_width = content_max_line_width(&state.content);
+    let (text, vbar, hbar) = content_bars(content_area, total_lines, max_width, state.wrap);
+
     let mut content =
         Paragraph::new(state.content.clone()).scroll((state.content_scroll, state.content_hscroll));
     if state.wrap {
         content = content.wrap(Wrap { trim: false });
     }
-    frame.render_widget(content, parts[1]);
+    frame.render_widget(content, text);
 
-    // Scrollbars on the content block's borders, only where the file overflows its viewport.
-    // Counts are taken from the raw content lines — exact for the unwrapped case (code/diffs, the
-    // primary scroll use), and a close approximation under wrap. The horizontal bar is suppressed
-    // under wrap, where there is nothing to scroll sideways. `viewport` is the true content
-    // region (`parts[1]`), below the notices strip.
-    let total_lines = state.content.lines.len();
-    draw_vscrollbar(
-        frame,
-        area,
-        total_lines,
-        state.content_scroll as usize,
-        parts[1].height as usize,
-    );
-    if !state.wrap {
-        let max_width = state
-            .content
-            .lines
-            .iter()
-            .map(|l| l.width())
-            .max()
-            .unwrap_or(0);
-        draw_hscrollbar(
+    if let Some(track) = vbar {
+        draw_vscrollbar(
             frame,
-            area,
-            max_width,
-            state.content_hscroll as usize,
-            parts[1].width as usize,
+            track,
+            total_lines,
+            state.content_scroll as usize,
+            text.height as usize,
         );
     }
-    (parts[1].width, parts[1].height)
+    if let Some(track) = hbar {
+        draw_hscrollbar(
+            frame,
+            track,
+            max_width,
+            state.content_hscroll as usize,
+            text.width as usize,
+        );
+    }
+    (text.width, text.height)
 }
 
 /// Split the frame into the body (the two columns) and an optional one-row footer. The footer
@@ -456,7 +510,15 @@ pub struct PaneGeometry {
     /// The widest visible tree row, in columns — so the controller can clamp the tree's horizontal
     /// scroll and map a drag on the tree's horizontal scrollbar to an offset. `0` when no tree.
     pub tree_content_width: u16,
+    /// The tree's in-pane vertical / horizontal scrollbar tracks (1-cell rects), present only when
+    /// that bar is drawn. Hit-testing maps a press/drag on them to a scroll.
+    pub tree_vbar: Option<Rect>,
+    pub tree_hbar: Option<Rect>,
+    /// The content text interior (below the notices strip, minus any reserved scrollbar gutter).
     pub content_inner: Option<Rect>,
+    /// The content pane's in-pane scrollbar tracks (1-cell rects), present only when drawn.
+    pub content_vbar: Option<Rect>,
+    pub content_hbar: Option<Rect>,
     pub divider_x: Option<u16>,
 }
 
@@ -467,11 +529,19 @@ pub fn geometry(area: Rect, state: &ViewState) -> PaneGeometry {
     let (body, _footer) = body_and_footer(area, state);
     let (tree, content, divider_x) = columns(body, state);
     let inner = |r: Rect| Block::bordered().inner(r);
-    let tree_inner = tree.map(inner);
-    // The tree's scroll offset MUST match what `draw_tree` applies, or a click maps to the wrong
-    // node once the tree scrolls. Both derive it from the same pure `sticky_scroll_offset` over the
-    // live interior height and last frame's offset — so the drawn window and the hit-test window
-    // can never disagree. Saturating cast: an absurd >65535 offset clamps instead of wrapping.
+
+    // Tree: the SAME layout `draw_tree` computes (text rect + in-pane bar tracks), so a click maps
+    // to the row actually drawn and a press lands on the bar actually shown. The scroll offset is
+    // derived identically (over the reduced text height + last frame's offset). Saturating casts:
+    // an absurd >65535 value clamps instead of wrapping.
+    let max_width = tree_rows_max_width(&state.nodes);
+    let (tree_inner, tree_vbar, tree_hbar) = match tree.map(inner) {
+        Some(ti) => {
+            let (text, v, h) = tree_bars(ti, state.nodes.len(), max_width);
+            (Some(text), v, h)
+        }
+        None => (None, None, None),
+    };
     let tree_scroll = tree_inner.map_or(0, |t| {
         sticky_scroll_offset(
             state.selected,
@@ -481,20 +551,38 @@ pub fn geometry(area: Rect, state: &ViewState) -> PaneGeometry {
         )
         .min(u16::MAX as usize) as u16
     });
-    // The widest tree row, so the controller can clamp tree h-scroll + map a drag on the tree's
-    // h-scrollbar. Only meaningful when the tree is drawn.
     let tree_content_width = if tree_inner.is_some() {
-        tree_rows_max_width(&state.nodes).min(u16::MAX as usize) as u16
+        max_width.min(u16::MAX as usize) as u16
     } else {
         0
     };
+
+    // Content: notices split, then the same bar layout `draw_content` computes.
+    let (content_inner, content_vbar, content_hbar) = match content.map(inner) {
+        Some(ci) => {
+            let (_notices, content_area) = content_notice_split(ci, state.notices.len());
+            let (text, v, h) = content_bars(
+                content_area,
+                state.content.lines.len(),
+                content_max_line_width(&state.content),
+                state.wrap,
+            );
+            (Some(text), v, h)
+        }
+        None => (None, None, None),
+    };
+
     PaneGeometry {
         area_x: body.x,
         area_width: body.width,
         tree_inner,
         tree_scroll,
         tree_content_width,
-        content_inner: content.map(inner),
+        tree_vbar,
+        tree_hbar,
+        content_inner,
+        content_vbar,
+        content_hbar,
         divider_x,
     }
 }

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -54,6 +54,11 @@ pub struct ViewState {
     /// so selecting a row already in view (e.g. a mouse click) never jumps the viewport (#45). `0`
     /// on the first frame and whenever every node fits.
     pub tree_scroll: u16,
+    /// The tree's horizontal scroll offset, in columns — so a deeply-nested or long file name can
+    /// be read sideways when it overflows the tree column. Driven by the horizontal wheel and by
+    /// dragging the tree's horizontal scrollbar (the `←`/`→` keys are expand/collapse in the tree).
+    /// The Presenter clamps it to the widest row at draw, so it can never over-scroll.
+    pub tree_hscroll: u16,
     /// Wrap long content lines (prose: markdown / plain text) instead of truncating them.
     /// Off for diffs and code, whose column alignment must be preserved.
     pub wrap: bool,
@@ -140,6 +145,18 @@ fn row_color(node: &Node) -> Option<Color> {
             None => None,
         },
     }
+}
+
+/// The widest visible tree row, in display columns — drives the tree's horizontal scrollbar and
+/// the controller's horizontal-scroll clamp. Computed from the same [`tree_row`] the tree draws
+/// (selection-independent: the REVERSED highlight doesn't change a row's width), so the drawn
+/// rows and the hit-test/clamp can never disagree.
+fn tree_rows_max_width(nodes: &[Node]) -> usize {
+    nodes
+        .iter()
+        .map(|n| tree_row(n, false).width())
+        .max()
+        .unwrap_or(0)
 }
 
 /// Render one tree row: `<marker> <indent><glyph><name>`. Indentation grows with depth so
@@ -274,11 +291,21 @@ fn draw_tree(frame: &mut Frame, area: Rect, state: &ViewState) {
         inner.height as usize,
         state.tree_scroll as usize,
     );
+    // Horizontal scroll for long / deeply-nested rows (the tree has no h-scroll keys — ←/→ are
+    // expand/collapse — so this is driven by the wheel and by dragging the tree's h-scrollbar).
+    // Clamp to the widest row so it can never over-scroll past the content.
+    let max_width = tree_rows_max_width(&state.nodes);
+    let hmax = max_width.saturating_sub(inner.width as usize);
+    let hoff = (state.tree_hscroll as usize).min(hmax);
     frame.render_widget(
-        Paragraph::new(rows).scroll((offset.min(u16::MAX as usize) as u16, 0)),
+        Paragraph::new(rows).scroll((
+            offset.min(u16::MAX as usize) as u16,
+            hoff.min(u16::MAX as usize) as u16,
+        )),
         inner,
     );
-    // A vertical scrollbar on the right border when there are more nodes than fit.
+    // A vertical scrollbar on the right border when there are more nodes than fit, and a
+    // horizontal one on the bottom border when the widest row overflows the column.
     draw_vscrollbar(
         frame,
         area,
@@ -286,6 +313,7 @@ fn draw_tree(frame: &mut Frame, area: Rect, state: &ViewState) {
         offset,
         inner.height as usize,
     );
+    draw_hscrollbar(frame, area, max_width, hoff, inner.width as usize);
 }
 
 /// Draw the right column: a notices strip (if any) above the content pane. Returns the
@@ -425,6 +453,9 @@ pub struct PaneGeometry {
     /// the same value [`draw_tree`] scrolled by. Hit-testing adds it to map a screen row to the
     /// node actually drawn there. `0` when every node fits.
     pub tree_scroll: u16,
+    /// The widest visible tree row, in columns — so the controller can clamp the tree's horizontal
+    /// scroll and map a drag on the tree's horizontal scrollbar to an offset. `0` when no tree.
+    pub tree_content_width: u16,
     pub content_inner: Option<Rect>,
     pub divider_x: Option<u16>,
 }
@@ -450,11 +481,19 @@ pub fn geometry(area: Rect, state: &ViewState) -> PaneGeometry {
         )
         .min(u16::MAX as usize) as u16
     });
+    // The widest tree row, so the controller can clamp tree h-scroll + map a drag on the tree's
+    // h-scrollbar. Only meaningful when the tree is drawn.
+    let tree_content_width = if tree_inner.is_some() {
+        tree_rows_max_width(&state.nodes).min(u16::MAX as usize) as u16
+    } else {
+        0
+    };
     PaneGeometry {
         area_x: body.x,
         area_width: body.width,
         tree_inner,
         tree_scroll,
+        tree_content_width,
         content_inner: content.map(inner),
         divider_x,
     }

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -59,6 +59,10 @@ pub struct ViewState {
     /// dragging the tree's horizontal scrollbar (the `←`/`→` keys are expand/collapse in the tree).
     /// The Presenter clamps it to the widest row at draw, so it can never over-scroll.
     pub tree_hscroll: u16,
+    /// The content's total RENDERED row count — wrapped rows under `wrap`, raw lines otherwise (the
+    /// controller's wrapped-aware count). The content vertical scrollbar sizes/positions against
+    /// this so the thumb is correct under wrap, where raw `content.lines.len()` undercounts.
+    pub content_rows: u16,
     /// Wrap long content lines (prose: markdown / plain text) instead of truncating them.
     /// Off for diffs and code, whose column alignment must be preserved.
     pub wrap: bool,
@@ -297,19 +301,21 @@ fn content_notice_split(inner: Rect, notices_len: usize) -> (Rect, Rect) {
     (parts[0], parts[1])
 }
 
-/// The content area split into the text rect + optional in-pane scrollbar tracks. `max_line_width`
-/// is the widest raw content line; under `wrap` there is no horizontal overflow. Two-pass like
-/// [`tree_bars`]. Shared by [`draw_content`] and [`geometry`].
+/// The content area split into the text rect + optional in-pane scrollbar tracks. `total_rows` is
+/// the RENDERED row count (wrapped rows under `wrap`, raw lines otherwise) — so the vertical bar
+/// appears whenever the file truly overflows, including a few long lines that wrap past the
+/// viewport. `max_line_width` is the widest raw line; under `wrap` there is no horizontal overflow.
+/// Two-pass like [`tree_bars`]. Shared by [`draw_content`] and [`geometry`].
 fn content_bars(
     content_area: Rect,
-    total_lines: usize,
+    total_rows: usize,
     max_line_width: usize,
     wrap: bool,
 ) -> (Rect, Option<Rect>, Option<Rect>) {
     let max_w = if wrap { 0 } else { max_line_width };
-    let v0 = total_lines > content_area.height as usize;
+    let v0 = total_rows > content_area.height as usize;
     let h0 = max_w > content_area.width as usize;
-    let needs_v = total_lines > content_area.height.saturating_sub(if h0 { 2 } else { 0 }) as usize;
+    let needs_v = total_rows > content_area.height.saturating_sub(if h0 { 2 } else { 0 }) as usize;
     let needs_h = max_w > content_area.width.saturating_sub(if v0 { 2 } else { 0 }) as usize;
     bar_layout(content_area, needs_v, needs_h)
 }
@@ -364,11 +370,15 @@ fn draw_tree(frame: &mut Frame, area: Rect, state: &ViewState) {
         text,
     );
     if let Some(track) = vbar {
+        // The tree's vertical thumb tracks the CURSOR (selected index), not the viewport offset —
+        // the tree has no independent vertical scroll (its position follows the selection, #45), so
+        // dragging the bar scrubs the selection and the thumb must follow it. (The content vbar,
+        // which has a real offset, uses that — see `draw_content`.)
         draw_vscrollbar(
             frame,
             track,
             state.nodes.len(),
-            offset,
+            state.selected,
             text.height as usize,
         );
     }
@@ -404,12 +414,13 @@ fn draw_content(frame: &mut Frame, area: Rect, state: &ViewState) -> (u16, u16) 
     }
 
     // Reserve an in-pane gutter for whichever scrollbars overflow, then render the file into the
-    // (possibly shrunk) text rect. Counts come from the raw content lines — exact when unwrapped
-    // (code/diffs, the primary scroll case) and a close approximation under wrap; the horizontal
-    // bar is suppressed under wrap, where there is nothing to scroll sideways.
-    let total_lines = state.content.lines.len();
+    // (possibly shrunk) text rect. The VERTICAL extent is the controller's rendered row count
+    // (`content_rows`) — wrapped rows under wrap, raw lines otherwise — so the bar is correct even
+    // for a few long lines that wrap past the viewport. The horizontal bar uses the widest raw line
+    // and is suppressed under wrap, where there is nothing to scroll sideways.
+    let total_rows = state.content_rows as usize;
     let max_width = content_max_line_width(&state.content);
-    let (text, vbar, hbar) = content_bars(content_area, total_lines, max_width, state.wrap);
+    let (text, vbar, hbar) = content_bars(content_area, total_rows, max_width, state.wrap);
 
     let mut content =
         Paragraph::new(state.content.clone()).scroll((state.content_scroll, state.content_hscroll));
@@ -422,7 +433,7 @@ fn draw_content(frame: &mut Frame, area: Rect, state: &ViewState) -> (u16, u16) 
         draw_vscrollbar(
             frame,
             track,
-            total_lines,
+            total_rows,
             state.content_scroll as usize,
             text.height as usize,
         );
@@ -563,7 +574,7 @@ pub fn geometry(area: Rect, state: &ViewState) -> PaneGeometry {
             let (_notices, content_area) = content_notice_split(ci, state.notices.len());
             let (text, v, h) = content_bars(
                 content_area,
-                state.content.lines.len(),
+                state.content_rows as usize,
                 content_max_line_width(&state.content),
                 state.wrap,
             );

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -927,6 +927,7 @@ fn wide_geometry() -> PaneGeometry {
             width: 38,
             height: 20,
         }),
+        tree_scroll: 0,
         content_inner: Some(Rect {
             x: 41,
             y: 1,
@@ -935,6 +936,39 @@ fn wide_geometry() -> PaneGeometry {
         }),
         divider_x: Some(40),
     }
+}
+
+#[test]
+fn a_tree_click_maps_through_the_scroll_offset() {
+    // #45 coupling: once the tree scrolls (selection past the fold), a click on a visible row must
+    // select the node ACTUALLY drawn there — index `(row - tree_inner.y) + tree_scroll`. Without
+    // the offset, clicking the first visible row would wrongly select node 0 from the scrolled-off
+    // top of the list. `geometry()` feeds `tree_scroll` back; `hit_test` must add it.
+    let dir = TempDir::new();
+    for i in 0..40 {
+        std::fs::write(dir.path().join(format!("f{i:02}.txt")), "x").unwrap();
+    }
+    let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
+    // A short tree interior (height 5) scrolled down by 10, as geometry() feeds back when the
+    // selection sits past the fold.
+    let mut g = wide_geometry();
+    g.tree_inner = Some(Rect {
+        x: 1,
+        y: 1,
+        width: 38,
+        height: 5,
+    });
+    g.tree_scroll = 10;
+    ctrl.set_pane_geometry(g);
+
+    // Click the FIRST visible tree row (row == tree_inner.y == 1). With a scroll of 10 that row
+    // shows visible node index 10 (f10.txt), so the click must select node 10, not node 0.
+    ctrl.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 6, 1));
+    assert_eq!(
+        ctrl.tree().cursor(),
+        10,
+        "a click on the first visible row selects node (row-offset + tree_scroll)"
+    );
 }
 
 #[test]

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -929,12 +929,16 @@ fn wide_geometry() -> PaneGeometry {
         }),
         tree_scroll: 0,
         tree_content_width: 0,
+        tree_vbar: None,
+        tree_hbar: None,
         content_inner: Some(Rect {
             x: 41,
             y: 1,
             width: 58,
             height: 20,
         }),
+        content_vbar: None,
+        content_hbar: None,
         divider_x: Some(40),
     }
 }
@@ -981,12 +985,19 @@ fn dragging_the_tree_horizontal_scrollbar_scrolls_the_tree() {
     std::fs::write(dir.path().join("a.txt"), "x").unwrap();
     let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
     let mut g = wide_geometry(); // tree_inner x1 y1 w38 h20
-    g.tree_content_width = 138; // 100 wider than the 38-col tree → max h-scroll = 100
+    g.tree_content_width = 138; // 100 wider than the track → max h-scroll = 100
+    // The tree's horizontal scrollbar track (fed back by the presenter): the tree's bottom inner
+    // row, spanning the text columns [1, 39).
+    let hbar_row = 20;
+    g.tree_hbar = Some(Rect {
+        x: 1,
+        y: hbar_row,
+        width: 38,
+        height: 1,
+    });
     ctrl.set_pane_geometry(g);
 
-    // The tree hbar is on the tree's bottom border: row = tree_inner.y + height = 21, cols [1, 39).
-    let hbar_row = 1 + 20;
-    // Press at the far-right of the track (col 38 = tree_inner.x + width - 1) → max.
+    // Press at the far-right of the track (col 38 = track.x + width - 1) → max.
     ctrl.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 38, hbar_row));
     assert_eq!(
         ctrl.view_state().tree_hscroll,
@@ -1006,6 +1017,42 @@ fn dragging_the_tree_horizontal_scrollbar_scrolls_the_tree() {
 }
 
 #[test]
+fn dragging_the_tree_vertical_scrollbar_scrubs_the_selection() {
+    // The tree's vertical scrollbar is now draggable (it lives inside the pane, off the divider):
+    // pressing the bottom selects the last file, dragging to the top selects the first — the tree
+    // has no independent vertical offset, so the bar scrubs the selection through the list (#45).
+    let dir = TempDir::new();
+    for i in 0..20 {
+        std::fs::write(dir.path().join(format!("f{i:02}.txt")), "x").unwrap();
+    }
+    let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
+    let mut g = wide_geometry();
+    // The tree's vertical scrollbar track: a 1-col rect spanning the tree's text rows [1, 21).
+    g.tree_vbar = Some(Rect {
+        x: 37,
+        y: 1,
+        width: 1,
+        height: 20,
+    });
+    ctrl.set_pane_geometry(g);
+
+    // Press at the bottom of the track → the last of the 20 files (index 19).
+    ctrl.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 37, 20));
+    assert_eq!(
+        ctrl.tree().cursor(),
+        19,
+        "pressing the bottom of the tree vbar selects the last node"
+    );
+    // Drag to the top → the first file.
+    ctrl.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 37, 1));
+    assert_eq!(
+        ctrl.tree().cursor(),
+        0,
+        "dragging the tree vbar to the top selects the first node"
+    );
+}
+
+#[test]
 fn dragging_the_content_vertical_scrollbar_scrolls_the_content() {
     // The content pane's vertical scrollbar (right border) is draggable: press at the bottom jumps
     // toward max scroll, dragging to the top returns to 0.
@@ -1013,11 +1060,20 @@ fn dragging_the_content_vertical_scrollbar_scrolls_the_content() {
     std::fs::write(dir.path().join("a.txt"), "x\n").unwrap();
     let mut ctrl = controller_with_lines(dir.path(), 50);
     await_marker(&mut ctrl, "L0");
-    ctrl.set_content_viewport(58, 20); // matches wide_geometry; 50 lines / 20 visible → max 30
-    ctrl.set_pane_geometry(wide_geometry()); // content_inner x41 y1 w58 h20 → vbar col = 99
+    ctrl.set_content_viewport(58, 20); // 50 lines / 20 visible → max scroll 30
+    let mut g = wide_geometry();
+    // The content's vertical scrollbar track (fed back by the presenter): a 1-col rect in the
+    // content pane spanning its 20 text rows.
+    let vbar_col = 99;
+    g.content_vbar = Some(Rect {
+        x: vbar_col,
+        y: 1,
+        width: 1,
+        height: 20,
+    });
+    ctrl.set_pane_geometry(g);
 
-    let vbar_col = 41 + 58; // content_inner.x + width = the right border column
-    // Press at the bottom of the track (row 20 = c.y + height - 1) → max scroll.
+    // Press at the bottom of the track (row 20 = track.y + height - 1) → max scroll.
     ctrl.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), vbar_col, 20));
     assert_eq!(
         ctrl.view_state().content_scroll,

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -928,6 +928,7 @@ fn wide_geometry() -> PaneGeometry {
             height: 20,
         }),
         tree_scroll: 0,
+        tree_content_width: 0,
         content_inner: Some(Rect {
             x: 41,
             y: 1,
@@ -968,6 +969,67 @@ fn a_tree_click_maps_through_the_scroll_offset() {
         ctrl.tree().cursor(),
         10,
         "a click on the first visible row selects node (row-offset + tree_scroll)"
+    );
+}
+
+#[test]
+fn dragging_the_tree_horizontal_scrollbar_scrolls_the_tree() {
+    // The tree's horizontal scrollbar (bottom border) is draggable: press at the right end jumps
+    // to max h-scroll, dragging to the left end returns to 0. Synchronous — driven purely by the
+    // fed-back geometry (widest row vs tree width).
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.txt"), "x").unwrap();
+    let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
+    let mut g = wide_geometry(); // tree_inner x1 y1 w38 h20
+    g.tree_content_width = 138; // 100 wider than the 38-col tree → max h-scroll = 100
+    ctrl.set_pane_geometry(g);
+
+    // The tree hbar is on the tree's bottom border: row = tree_inner.y + height = 21, cols [1, 39).
+    let hbar_row = 1 + 20;
+    // Press at the far-right of the track (col 38 = tree_inner.x + width - 1) → max.
+    ctrl.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 38, hbar_row));
+    assert_eq!(
+        ctrl.view_state().tree_hscroll,
+        100,
+        "pressing the right end of the tree hbar jumps to max h-scroll"
+    );
+    // Drag to the left end → back to 0.
+    ctrl.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 1, hbar_row));
+    assert_eq!(
+        ctrl.view_state().tree_hscroll,
+        0,
+        "dragging the tree hbar to the left end scrolls back to 0"
+    );
+    // Release ends the drag (so the next press is a fresh interaction, not swallowed).
+    let fx = ctrl.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 1, hbar_row));
+    assert!(!fx.redraw, "the drag-release is inert (not a click)");
+}
+
+#[test]
+fn dragging_the_content_vertical_scrollbar_scrolls_the_content() {
+    // The content pane's vertical scrollbar (right border) is draggable: press at the bottom jumps
+    // toward max scroll, dragging to the top returns to 0.
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.txt"), "x\n").unwrap();
+    let mut ctrl = controller_with_lines(dir.path(), 50);
+    await_marker(&mut ctrl, "L0");
+    ctrl.set_content_viewport(58, 20); // matches wide_geometry; 50 lines / 20 visible → max 30
+    ctrl.set_pane_geometry(wide_geometry()); // content_inner x41 y1 w58 h20 → vbar col = 99
+
+    let vbar_col = 41 + 58; // content_inner.x + width = the right border column
+    // Press at the bottom of the track (row 20 = c.y + height - 1) → max scroll.
+    ctrl.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), vbar_col, 20));
+    assert_eq!(
+        ctrl.view_state().content_scroll,
+        30,
+        "pressing the bottom of the content vbar jumps to max scroll"
+    );
+    // Drag to the top of the track → 0.
+    ctrl.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), vbar_col, 1));
+    assert_eq!(
+        ctrl.view_state().content_scroll,
+        0,
+        "dragging the content vbar to the top scrolls back to 0"
     );
 }
 

--- a/tests/presenter.rs
+++ b/tests/presenter.rs
@@ -67,6 +67,7 @@ fn sample_state() -> ViewState {
         width: 100,
         content_scroll: 0,
         content_hscroll: 0,
+        tree_scroll: 0,
         wrap: false,
         split_pct: 40,
         zoomed: false,
@@ -453,6 +454,44 @@ fn content_pane_shows_a_vertical_scrollbar_when_content_overflows() {
 }
 
 #[test]
+fn content_vertical_scrollbar_thumb_reaches_the_bottom_at_max_scroll() {
+    // Review (codex): at the last scroll position the thumb must reach the bottom of the track —
+    // leaving track below it would falsely imply more content remains. The content pane's right
+    // border is the frame's rightmost column; with the block spanning the full height the track is
+    // inset by one row each end, so the bottom track cell is row h-2. At scroll 0 the thumb is at
+    // the top (not that bottom cell); at the max scroll it is.
+    let (w, h) = (100u16, 18u16);
+    let mut state = sample_state();
+    state.notices = vec![];
+    // 60 lines into a (h-2)=16-row viewport → max scroll 44.
+    state.content = to_text(
+        &(0..60)
+            .map(|i| format!("line {i}"))
+            .collect::<Vec<_>>()
+            .join("\n"),
+    );
+    state.wrap = false;
+    let bottom_track_row = h - 2;
+    let rightmost = w - 1;
+
+    state.content_scroll = 0;
+    let top = render_buffer(&state, w, h);
+    assert_ne!(
+        top.cell((rightmost, bottom_track_row)).unwrap().symbol(),
+        "█",
+        "at scroll 0 the thumb sits at the top, not the bottom track row"
+    );
+
+    state.content_scroll = 44; // the max scroll for this content/viewport
+    let bottom = render_buffer(&state, w, h);
+    assert_eq!(
+        bottom.cell((rightmost, bottom_track_row)).unwrap().symbol(),
+        "█",
+        "at max scroll the thumb reaches the bottom track row"
+    );
+}
+
+#[test]
 fn content_pane_shows_a_horizontal_scrollbar_for_a_too_wide_unwrapped_line() {
     // A line far wider than the content pane gets a horizontal scrollbar when NOT wrapped (so it
     // can be read sideways). The track is the DOUBLE horizontal (═), distinct from the block's
@@ -474,6 +513,60 @@ fn content_pane_shows_a_horizontal_scrollbar_for_a_too_wide_unwrapped_line() {
     assert!(
         !wrapped.contains('═'),
         "a wrapped line needs no horizontal scrollbar\n{wrapped}"
+    );
+}
+
+#[test]
+fn tree_scroll_is_sticky_when_the_selection_stays_visible() {
+    // #45 follow-up (review): selecting a row already on screen — e.g. a mouse click — must NOT
+    // move the viewport. Pre-fix the offset was a pure function of the cursor, so clicking a
+    // visible row in a scrolled tree snapped the view (and made a double-click land on the wrong
+    // row). With sticky scrolling, geometry reports the SAME offset when the selection is in view.
+    use herdr_file_viewer::presenter::geometry;
+    use ratatui::layout::Rect;
+    let area = Rect {
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 24,
+    };
+    let mut state = sample_state();
+    state.notices = vec![];
+    state.nodes = (0..40)
+        .map(|i| {
+            node(
+                &format!("/r/file-{i:02}.rs"),
+                NodeKind::File,
+                0,
+                false,
+                None,
+            )
+        })
+        .collect();
+    let t_height = geometry(area, &state)
+        .tree_inner
+        .expect("tree interior")
+        .height as usize;
+
+    // Currently scrolled down by 10; select a row INSIDE the visible window [10, 10+height).
+    state.tree_scroll = 10;
+    state.selected = 12;
+    assert!(
+        12 < 10 + t_height,
+        "precondition: the selection is within the current window"
+    );
+    assert_eq!(
+        geometry(area, &state).tree_scroll,
+        10,
+        "selecting a visible row keeps the offset — the tree does not jump"
+    );
+
+    // Selecting a row ABOVE the window scrolls minimally up to it (cursor at the top edge).
+    state.selected = 4;
+    assert_eq!(
+        geometry(area, &state).tree_scroll,
+        4,
+        "a selection above the window scrolls up just to it"
     );
 }
 

--- a/tests/presenter.rs
+++ b/tests/presenter.rs
@@ -396,12 +396,12 @@ fn geometry_reports_the_tree_scroll_offset_for_hit_testing() {
 #[test]
 fn tree_shows_a_vertical_scrollbar_only_when_it_overflows() {
     // The tree gets a vertical scrollbar exactly when there are more nodes than fit (#45 follow-up:
-    // "add a scrollbar where there is something to be moved"). The thumb is a HEAVY vertical line
-    // (┃), distinct from the light border (│) and absent elsewhere in these fixtures, so a
-    // frame-wide check is unambiguous: the only ┃ here is the tree scrollbar thumb.
+    // "add a scrollbar where there is something to be moved"). The thumb is a half-block bar
+    // (▐), distinct from the light border (│) and absent elsewhere in these fixtures, so a
+    // frame-wide check is unambiguous: the only ▐ here is the tree scrollbar thumb.
     let fits = render(&sample_state(), 100, 24); // 7 nodes in a 24-row frame → fits
     assert!(
-        !fits.contains('┃'),
+        !fits.contains('▐'),
         "a tree that fits shows no scrollbar\n{fits}"
     );
 
@@ -421,15 +421,15 @@ fn tree_shows_a_vertical_scrollbar_only_when_it_overflows() {
     many.selected = 0;
     let overflow = render(&many, 100, 24);
     assert!(
-        overflow.contains('┃'),
-        "an overflowing tree shows a scrollbar thumb (┃)\n{overflow}"
+        overflow.contains('▐'),
+        "an overflowing tree shows a scrollbar thumb (▐)\n{overflow}"
     );
 }
 
 #[test]
 fn content_pane_shows_a_vertical_scrollbar_when_content_overflows() {
     // The content pane gets a vertical scrollbar when it has more lines than the viewport is tall.
-    // The tree (7 nodes) does NOT overflow a 12-row frame, so the only ┃ is the content scrollbar.
+    // The tree (7 nodes) does NOT overflow a 12-row frame, so the only ▐ is the content scrollbar.
     let mut state = sample_state();
     state.notices = vec![];
     state.content = to_text(
@@ -440,15 +440,15 @@ fn content_pane_shows_a_vertical_scrollbar_when_content_overflows() {
     );
     let out = render(&state, 100, 12);
     assert!(
-        out.contains('┃'),
-        "overflowing content shows a vertical scrollbar (┃)\n{out}"
+        out.contains('▐'),
+        "overflowing content shows a vertical scrollbar (▐)\n{out}"
     );
 
     // A short file shows none.
     state.content = to_text("only\ntwo\n");
     let short = render(&state, 100, 12);
     assert!(
-        !short.contains('┃'),
+        !short.contains('▐'),
         "content that fits shows no vertical scrollbar\n{short}"
     );
 }
@@ -478,7 +478,7 @@ fn content_vertical_scrollbar_thumb_reaches_the_bottom_at_max_scroll() {
     let top = render_buffer(&state, w, h);
     assert_ne!(
         top.cell((rightmost, bottom_track_row)).unwrap().symbol(),
-        "┃",
+        "▐",
         "at scroll 0 the thumb sits at the top, not the bottom track row"
     );
 
@@ -486,7 +486,7 @@ fn content_vertical_scrollbar_thumb_reaches_the_bottom_at_max_scroll() {
     let bottom = render_buffer(&state, w, h);
     assert_eq!(
         bottom.cell((rightmost, bottom_track_row)).unwrap().symbol(),
-        "┃",
+        "▐",
         "at max scroll the thumb reaches the bottom track row"
     );
 }
@@ -494,7 +494,7 @@ fn content_vertical_scrollbar_thumb_reaches_the_bottom_at_max_scroll() {
 #[test]
 fn content_pane_shows_a_horizontal_scrollbar_for_a_too_wide_unwrapped_line() {
     // A line far wider than the content pane gets a horizontal scrollbar when NOT wrapped (so it
-    // can be read sideways). Its thumb is a HEAVY horizontal line (━), distinct from the block's
+    // can be read sideways). Its thumb is a half-block bar (▄), distinct from the block's
     // light border (─), so it is an unambiguous marker. Wrapping the same line removes the
     // overflow, so no horizontal scrollbar is drawn.
     let mut state = sample_state();
@@ -504,14 +504,14 @@ fn content_pane_shows_a_horizontal_scrollbar_for_a_too_wide_unwrapped_line() {
     state.wrap = false;
     let unwrapped = render(&state, 100, 24);
     assert!(
-        unwrapped.contains('━'),
-        "a too-wide unwrapped line shows a horizontal scrollbar (━)\n{unwrapped}"
+        unwrapped.contains('▄'),
+        "a too-wide unwrapped line shows a horizontal scrollbar (▄)\n{unwrapped}"
     );
 
     state.wrap = true;
     let wrapped = render(&state, 100, 24);
     assert!(
-        !wrapped.contains('━'),
+        !wrapped.contains('▄'),
         "a wrapped line needs no horizontal scrollbar\n{wrapped}"
     );
 }

--- a/tests/presenter.rs
+++ b/tests/presenter.rs
@@ -586,11 +586,18 @@ fn content_pane_shows_a_vertical_scrollbar_when_content_overflows() {
 #[test]
 fn content_vertical_scrollbar_thumb_reaches_the_bottom_at_max_scroll() {
     // Review (codex): at the last scroll position the thumb must reach the bottom of the track —
-    // leaving track below it would falsely imply more content remains. The bar now lives INSIDE the
-    // pane (a gutter column), so find it by its thumb glyph rather than the border position: the
-    // track is the column containing `▐`; its cells are `▐` (thumb) or `│` (track). At max scroll
-    // the bottom-most track cell is the thumb; at scroll 0 it is the track (thumb sits at the top).
+    // stopping short would falsely imply more content remains. The bar is thumb-only (no track
+    // line), so use its fed-back rect for the track extent and check where the thumb (`▐`) lands:
+    // at scroll 0 it includes the top row but not the bottom; at max scroll it reaches the bottom.
+    use herdr_file_viewer::presenter::geometry;
+    use ratatui::layout::Rect;
     let (w, h) = (100u16, 18u16);
+    let area = Rect {
+        x: 0,
+        y: 0,
+        width: w,
+        height: h,
+    };
     let mut state = sample_state();
     state.notices = vec![];
     // 60 lines into a 16-row text area → max scroll 44.
@@ -601,41 +608,31 @@ fn content_vertical_scrollbar_thumb_reaches_the_bottom_at_max_scroll() {
             .join("\n"),
     );
     state.wrap = false;
-
-    // The symbol of the bottom-most track cell in the vertical-scrollbar column of a render. The
-    // bar column is the one containing `▐`; its track cells are `▐` (thumb) or `│` (track).
-    let bottom_track_cell = |buf: &ratatui::buffer::Buffer| -> String {
-        let mut bar_col = None;
-        'find: for x in 0..w {
-            for y in 0..h {
-                if buf.cell((x, y)).is_some_and(|c| c.symbol() == "▐") {
-                    bar_col = Some(x);
-                    break 'find;
-                }
-            }
-        }
-        let col = bar_col.expect("a vertical scrollbar (▐) is drawn");
-        let bottom = (0..h)
-            .filter(|&y| {
-                buf.cell((col, y))
-                    .is_some_and(|c| c.symbol() == "▐" || c.symbol() == "│")
-            })
-            .max()
-            .expect("the track has cells");
-        buf.cell((col, bottom)).unwrap().symbol().to_string()
+    let track = geometry(area, &state)
+        .content_vbar
+        .expect("content vbar present");
+    let thumb_rows = |buf: &ratatui::buffer::Buffer| -> Vec<u16> {
+        (track.y..track.y + track.height)
+            .filter(|&y| buf.cell((track.x, y)).is_some_and(|c| c.symbol() == "▐"))
+            .collect()
     };
 
     state.content_scroll = 0;
-    assert_eq!(
-        bottom_track_cell(&render_buffer(&state, w, h)),
-        "│",
-        "at scroll 0 the bottom of the track is plain track (thumb is at the top)"
+    let top = thumb_rows(&render_buffer(&state, w, h));
+    assert!(
+        top.contains(&track.y),
+        "thumb is at the top of the track at scroll 0"
     );
+    assert!(
+        !top.contains(&(track.y + track.height - 1)),
+        "thumb is NOT at the bottom at scroll 0"
+    );
+
     state.content_scroll = 44; // the max scroll for this content/viewport
-    assert_eq!(
-        bottom_track_cell(&render_buffer(&state, w, h)),
-        "▐",
-        "at max scroll the thumb reaches the bottom of the track"
+    let bottom = thumb_rows(&render_buffer(&state, w, h));
+    assert!(
+        bottom.contains(&(track.y + track.height - 1)),
+        "thumb reaches the bottom of the track at max scroll"
     );
 }
 

--- a/tests/presenter.rs
+++ b/tests/presenter.rs
@@ -396,12 +396,12 @@ fn geometry_reports_the_tree_scroll_offset_for_hit_testing() {
 #[test]
 fn tree_shows_a_vertical_scrollbar_only_when_it_overflows() {
     // The tree gets a vertical scrollbar exactly when there are more nodes than fit (#45 follow-up:
-    // "add a scrollbar where there is something to be moved"). The thumb is the FULL block (█),
-    // which appears nowhere else in these fixtures (the sample content is "fn main()", no █), so a
-    // frame-wide check is unambiguous: the only █ here is the tree scrollbar.
+    // "add a scrollbar where there is something to be moved"). The thumb is a HEAVY vertical line
+    // (┃), distinct from the light border (│) and absent elsewhere in these fixtures, so a
+    // frame-wide check is unambiguous: the only ┃ here is the tree scrollbar thumb.
     let fits = render(&sample_state(), 100, 24); // 7 nodes in a 24-row frame → fits
     assert!(
-        !fits.contains('█'),
+        !fits.contains('┃'),
         "a tree that fits shows no scrollbar\n{fits}"
     );
 
@@ -421,15 +421,15 @@ fn tree_shows_a_vertical_scrollbar_only_when_it_overflows() {
     many.selected = 0;
     let overflow = render(&many, 100, 24);
     assert!(
-        overflow.contains('█'),
-        "an overflowing tree shows a scrollbar thumb (█)\n{overflow}"
+        overflow.contains('┃'),
+        "an overflowing tree shows a scrollbar thumb (┃)\n{overflow}"
     );
 }
 
 #[test]
 fn content_pane_shows_a_vertical_scrollbar_when_content_overflows() {
     // The content pane gets a vertical scrollbar when it has more lines than the viewport is tall.
-    // The tree (7 nodes) does NOT overflow a 12-row frame, so the only █ is the content scrollbar.
+    // The tree (7 nodes) does NOT overflow a 12-row frame, so the only ┃ is the content scrollbar.
     let mut state = sample_state();
     state.notices = vec![];
     state.content = to_text(
@@ -440,15 +440,15 @@ fn content_pane_shows_a_vertical_scrollbar_when_content_overflows() {
     );
     let out = render(&state, 100, 12);
     assert!(
-        out.contains('█'),
-        "overflowing content shows a vertical scrollbar (█)\n{out}"
+        out.contains('┃'),
+        "overflowing content shows a vertical scrollbar (┃)\n{out}"
     );
 
     // A short file shows none.
     state.content = to_text("only\ntwo\n");
     let short = render(&state, 100, 12);
     assert!(
-        !short.contains('█'),
+        !short.contains('┃'),
         "content that fits shows no vertical scrollbar\n{short}"
     );
 }
@@ -478,7 +478,7 @@ fn content_vertical_scrollbar_thumb_reaches_the_bottom_at_max_scroll() {
     let top = render_buffer(&state, w, h);
     assert_ne!(
         top.cell((rightmost, bottom_track_row)).unwrap().symbol(),
-        "█",
+        "┃",
         "at scroll 0 the thumb sits at the top, not the bottom track row"
     );
 
@@ -486,7 +486,7 @@ fn content_vertical_scrollbar_thumb_reaches_the_bottom_at_max_scroll() {
     let bottom = render_buffer(&state, w, h);
     assert_eq!(
         bottom.cell((rightmost, bottom_track_row)).unwrap().symbol(),
-        "█",
+        "┃",
         "at max scroll the thumb reaches the bottom track row"
     );
 }
@@ -494,8 +494,8 @@ fn content_vertical_scrollbar_thumb_reaches_the_bottom_at_max_scroll() {
 #[test]
 fn content_pane_shows_a_horizontal_scrollbar_for_a_too_wide_unwrapped_line() {
     // A line far wider than the content pane gets a horizontal scrollbar when NOT wrapped (so it
-    // can be read sideways). The track is the DOUBLE horizontal (═), distinct from the block's
-    // single-line border (─), so it is an unambiguous marker. Wrapping the same line removes the
+    // can be read sideways). Its thumb is a HEAVY horizontal line (━), distinct from the block's
+    // light border (─), so it is an unambiguous marker. Wrapping the same line removes the
     // overflow, so no horizontal scrollbar is drawn.
     let mut state = sample_state();
     state.notices = vec![];
@@ -504,14 +504,14 @@ fn content_pane_shows_a_horizontal_scrollbar_for_a_too_wide_unwrapped_line() {
     state.wrap = false;
     let unwrapped = render(&state, 100, 24);
     assert!(
-        unwrapped.contains('═'),
-        "a too-wide unwrapped line shows a horizontal scrollbar (═)\n{unwrapped}"
+        unwrapped.contains('━'),
+        "a too-wide unwrapped line shows a horizontal scrollbar (━)\n{unwrapped}"
     );
 
     state.wrap = true;
     let wrapped = render(&state, 100, 24);
     assert!(
-        !wrapped.contains('═'),
+        !wrapped.contains('━'),
         "a wrapped line needs no horizontal scrollbar\n{wrapped}"
     );
 }

--- a/tests/presenter.rs
+++ b/tests/presenter.rs
@@ -259,6 +259,225 @@ fn content_pane_applies_the_vertical_scroll_offset() {
 }
 
 #[test]
+fn tree_scrolls_to_keep_selection_visible() {
+    // #45: with more nodes than fit the tree interior, moving the selection toward the end must
+    // scroll the tree window so the selected row stays visible. Pre-fix the tree rendered every
+    // node into the fixed interior with no scroll offset, so a selection past the fold never
+    // reached the buffer — the reported bug ("I can see files being selected but the tree
+    // doesn't move"). Mirrors the picker's keeps-cursor-visible test.
+    use herdr_file_viewer::presenter::geometry;
+    use ratatui::layout::Rect;
+    use ratatui::style::Modifier;
+    let mut state = sample_state();
+    state.notices = vec![];
+    // 40 files — far more than fit the ~22-row tree interior at 100x24.
+    state.nodes = (0..40)
+        .map(|i| {
+            node(
+                &format!("/r/file-{i:02}.rs"),
+                NodeKind::File,
+                0,
+                false,
+                None,
+            )
+        })
+        .collect();
+    state.selected = 37; // near the end
+
+    let area = Rect {
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 24,
+    };
+    let buf = render_buffer(&state, area.width, area.height);
+    // Scope the search to the TREE interior. The content pane's block title is the SELECTED
+    // node's name ("file-37.rs"), so a frame-wide search would false-match there even when the
+    // tree never scrolled — the bug. Bounding to `tree_inner` asserts the row is in the tree.
+    let t = geometry(area, &state).tree_inner.expect("tree interior");
+
+    // The selected row's distinctive name must be present in the tree (the window scrolled to it)...
+    let needle = "file-37";
+    let mut found_at: Option<(u16, u16)> = None;
+    'scan: for y in t.y..(t.y + t.height) {
+        for x in t.x..(t.x + t.width) {
+            let matches = needle.chars().enumerate().all(|(i, ch)| {
+                let cx = x + i as u16;
+                cx < t.x + t.width
+                    && buf
+                        .cell((cx, y))
+                        .is_some_and(|c| c.symbol() == ch.to_string())
+            });
+            if matches {
+                found_at = Some((x, y));
+                break 'scan;
+            }
+        }
+    }
+    let (cx, cy) =
+        found_at.expect("the selected tree row (file-37) must be visible after scrolling");
+    // ...and it carries the REVERSED selection highlight, so it reads as selected.
+    assert!(
+        buf.cell((cx, cy))
+            .unwrap()
+            .modifier
+            .contains(Modifier::REVERSED),
+        "the visible selected row must be REVERSED-highlighted"
+    );
+    // And an early node has scrolled off the top of the tree.
+    let mut early_in_tree = false;
+    for y in t.y..(t.y + t.height) {
+        for x in t.x..(t.x + t.width) {
+            if "file-00".chars().enumerate().all(|(i, ch)| {
+                let cx = x + i as u16;
+                cx < t.x + t.width
+                    && buf
+                        .cell((cx, y))
+                        .is_some_and(|c| c.symbol() == ch.to_string())
+            }) {
+                early_in_tree = true;
+            }
+        }
+    }
+    assert!(
+        !early_in_tree,
+        "early nodes (file-00) scroll off the top when the selection is near the end"
+    );
+}
+
+#[test]
+fn geometry_reports_the_tree_scroll_offset_for_hit_testing() {
+    // #45 coupling: the geometry fed back to the controller carries the SAME scroll offset
+    // draw_tree applied, so a click maps to the node drawn on that row. It is 0 when every node
+    // fits, and when overflowing it keeps the selection inside the visible window.
+    use herdr_file_viewer::presenter::geometry;
+    use ratatui::layout::Rect;
+    let area = Rect {
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 24,
+    };
+
+    // Few nodes: no scroll.
+    assert_eq!(
+        geometry(area, &sample_state()).tree_scroll,
+        0,
+        "tree_scroll is 0 when every node fits the interior"
+    );
+
+    // Many nodes, selection near the end: the window scrolls and keeps the selection visible.
+    let mut many = sample_state();
+    many.notices = vec![];
+    many.nodes = (0..40)
+        .map(|i| {
+            node(
+                &format!("/r/file-{i:02}.rs"),
+                NodeKind::File,
+                0,
+                false,
+                None,
+            )
+        })
+        .collect();
+    many.selected = 37;
+    let g = geometry(area, &many);
+    let t = g.tree_inner.expect("tree interior");
+    assert!(g.tree_scroll > 0, "an overflowing tree scrolls");
+    let off = g.tree_scroll as usize;
+    assert!(
+        off <= many.selected && many.selected < off + t.height as usize,
+        "the selection (37) stays within the visible window [{off}, {})",
+        off + t.height as usize
+    );
+}
+
+#[test]
+fn tree_shows_a_vertical_scrollbar_only_when_it_overflows() {
+    // The tree gets a vertical scrollbar exactly when there are more nodes than fit (#45 follow-up:
+    // "add a scrollbar where there is something to be moved"). The thumb is the FULL block (█),
+    // which appears nowhere else in these fixtures (the sample content is "fn main()", no █), so a
+    // frame-wide check is unambiguous: the only █ here is the tree scrollbar.
+    let fits = render(&sample_state(), 100, 24); // 7 nodes in a 24-row frame → fits
+    assert!(
+        !fits.contains('█'),
+        "a tree that fits shows no scrollbar\n{fits}"
+    );
+
+    let mut many = sample_state();
+    many.notices = vec![];
+    many.nodes = (0..40)
+        .map(|i| {
+            node(
+                &format!("/r/file-{i:02}.rs"),
+                NodeKind::File,
+                0,
+                false,
+                None,
+            )
+        })
+        .collect();
+    many.selected = 0;
+    let overflow = render(&many, 100, 24);
+    assert!(
+        overflow.contains('█'),
+        "an overflowing tree shows a scrollbar thumb (█)\n{overflow}"
+    );
+}
+
+#[test]
+fn content_pane_shows_a_vertical_scrollbar_when_content_overflows() {
+    // The content pane gets a vertical scrollbar when it has more lines than the viewport is tall.
+    // The tree (7 nodes) does NOT overflow a 12-row frame, so the only █ is the content scrollbar.
+    let mut state = sample_state();
+    state.notices = vec![];
+    state.content = to_text(
+        &(0..60)
+            .map(|i| format!("line{i}"))
+            .collect::<Vec<_>>()
+            .join("\n"),
+    );
+    let out = render(&state, 100, 12);
+    assert!(
+        out.contains('█'),
+        "overflowing content shows a vertical scrollbar (█)\n{out}"
+    );
+
+    // A short file shows none.
+    state.content = to_text("only\ntwo\n");
+    let short = render(&state, 100, 12);
+    assert!(
+        !short.contains('█'),
+        "content that fits shows no vertical scrollbar\n{short}"
+    );
+}
+
+#[test]
+fn content_pane_shows_a_horizontal_scrollbar_for_a_too_wide_unwrapped_line() {
+    // A line far wider than the content pane gets a horizontal scrollbar when NOT wrapped (so it
+    // can be read sideways). The track is the DOUBLE horizontal (═), distinct from the block's
+    // single-line border (─), so it is an unambiguous marker. Wrapping the same line removes the
+    // overflow, so no horizontal scrollbar is drawn.
+    let mut state = sample_state();
+    state.notices = vec![];
+    state.content = to_text(&"x".repeat(300)); // far wider than the ~58-col content pane
+
+    state.wrap = false;
+    let unwrapped = render(&state, 100, 24);
+    assert!(
+        unwrapped.contains('═'),
+        "a too-wide unwrapped line shows a horizontal scrollbar (═)\n{unwrapped}"
+    );
+
+    state.wrap = true;
+    let wrapped = render(&state, 100, 24);
+    assert!(
+        !wrapped.contains('═'),
+        "a wrapped line needs no horizontal scrollbar\n{wrapped}"
+    );
+}
+
+#[test]
 fn wrapping_shows_more_of_a_long_line_than_truncating() {
     // A line far wider than the content pane: wrapped, it spills onto further rows; not
     // wrapped, it is truncated to a single row. So the wrapped render shows strictly more of

--- a/tests/presenter.rs
+++ b/tests/presenter.rs
@@ -491,6 +491,72 @@ fn tree_shows_a_horizontal_scrollbar_and_scrolls_long_rows() {
 }
 
 #[test]
+fn scrollbars_are_inside_the_pane_with_a_one_column_gap() {
+    // The bars live INSIDE the box (a reserved gutter), not on the border, with a one-cell gap
+    // between the text and the bar. Asserted structurally via geometry: the vertical bar is a
+    // 1-col track exactly one column right of the text's right edge (the gap), spanning the text
+    // rows; the horizontal bar is one row below the text's bottom edge.
+    use herdr_file_viewer::presenter::geometry;
+    use ratatui::layout::Rect;
+    let area = Rect {
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 24,
+    };
+    let mut state = sample_state();
+    state.notices = vec![];
+    // Overflow both ways: many rows (vbar) + one very wide row (hbar).
+    state.nodes = (0..40)
+        .map(|i| {
+            node(
+                &format!("/r/file-{i:02}.rs"),
+                NodeKind::File,
+                0,
+                false,
+                None,
+            )
+        })
+        .collect();
+    state.nodes[0] = node(
+        &format!("/r/{}", "w".repeat(80)),
+        NodeKind::File,
+        0,
+        false,
+        None,
+    );
+    state.selected = 0;
+
+    let g = geometry(area, &state);
+    let t = g.tree_inner.expect("tree text rect");
+    let v = g
+        .tree_vbar
+        .expect("tree vbar present when overflowing vertically");
+    let h = g
+        .tree_hbar
+        .expect("tree hbar present when overflowing horizontally");
+
+    assert_eq!(v.width, 1, "the vertical bar is one column wide");
+    assert_eq!(
+        v.x,
+        t.x + t.width + 1,
+        "exactly one gap column between the text and the vertical bar (bar is inside, not on the border)"
+    );
+    assert_eq!(v.height, t.height, "the vertical bar spans the text rows");
+
+    assert_eq!(h.height, 1, "the horizontal bar is one row tall");
+    assert_eq!(
+        h.y,
+        t.y + t.height + 1,
+        "exactly one gap row between the text and the horizontal bar"
+    );
+    assert_eq!(
+        h.x, t.x,
+        "the horizontal bar starts at the text's left edge"
+    );
+}
+
+#[test]
 fn content_pane_shows_a_vertical_scrollbar_when_content_overflows() {
     // The content pane gets a vertical scrollbar when it has more lines than the viewport is tall.
     // The tree (7 nodes) does NOT overflow a 12-row frame, so the only ▐ is the content scrollbar.
@@ -520,14 +586,14 @@ fn content_pane_shows_a_vertical_scrollbar_when_content_overflows() {
 #[test]
 fn content_vertical_scrollbar_thumb_reaches_the_bottom_at_max_scroll() {
     // Review (codex): at the last scroll position the thumb must reach the bottom of the track —
-    // leaving track below it would falsely imply more content remains. The content pane's right
-    // border is the frame's rightmost column; with the block spanning the full height the track is
-    // inset by one row each end, so the bottom track cell is row h-2. At scroll 0 the thumb is at
-    // the top (not that bottom cell); at the max scroll it is.
+    // leaving track below it would falsely imply more content remains. The bar now lives INSIDE the
+    // pane (a gutter column), so find it by its thumb glyph rather than the border position: the
+    // track is the column containing `▐`; its cells are `▐` (thumb) or `│` (track). At max scroll
+    // the bottom-most track cell is the thumb; at scroll 0 it is the track (thumb sits at the top).
     let (w, h) = (100u16, 18u16);
     let mut state = sample_state();
     state.notices = vec![];
-    // 60 lines into a (h-2)=16-row viewport → max scroll 44.
+    // 60 lines into a 16-row text area → max scroll 44.
     state.content = to_text(
         &(0..60)
             .map(|i| format!("line {i}"))
@@ -535,23 +601,41 @@ fn content_vertical_scrollbar_thumb_reaches_the_bottom_at_max_scroll() {
             .join("\n"),
     );
     state.wrap = false;
-    let bottom_track_row = h - 2;
-    let rightmost = w - 1;
+
+    // The symbol of the bottom-most track cell in the vertical-scrollbar column of a render. The
+    // bar column is the one containing `▐`; its track cells are `▐` (thumb) or `│` (track).
+    let bottom_track_cell = |buf: &ratatui::buffer::Buffer| -> String {
+        let mut bar_col = None;
+        'find: for x in 0..w {
+            for y in 0..h {
+                if buf.cell((x, y)).is_some_and(|c| c.symbol() == "▐") {
+                    bar_col = Some(x);
+                    break 'find;
+                }
+            }
+        }
+        let col = bar_col.expect("a vertical scrollbar (▐) is drawn");
+        let bottom = (0..h)
+            .filter(|&y| {
+                buf.cell((col, y))
+                    .is_some_and(|c| c.symbol() == "▐" || c.symbol() == "│")
+            })
+            .max()
+            .expect("the track has cells");
+        buf.cell((col, bottom)).unwrap().symbol().to_string()
+    };
 
     state.content_scroll = 0;
-    let top = render_buffer(&state, w, h);
-    assert_ne!(
-        top.cell((rightmost, bottom_track_row)).unwrap().symbol(),
-        "▐",
-        "at scroll 0 the thumb sits at the top, not the bottom track row"
-    );
-
-    state.content_scroll = 44; // the max scroll for this content/viewport
-    let bottom = render_buffer(&state, w, h);
     assert_eq!(
-        bottom.cell((rightmost, bottom_track_row)).unwrap().symbol(),
+        bottom_track_cell(&render_buffer(&state, w, h)),
+        "│",
+        "at scroll 0 the bottom of the track is plain track (thumb is at the top)"
+    );
+    state.content_scroll = 44; // the max scroll for this content/viewport
+    assert_eq!(
+        bottom_track_cell(&render_buffer(&state, w, h)),
         "▐",
-        "at max scroll the thumb reaches the bottom track row"
+        "at max scroll the thumb reaches the bottom of the track"
     );
 }
 

--- a/tests/presenter.rs
+++ b/tests/presenter.rs
@@ -68,6 +68,7 @@ fn sample_state() -> ViewState {
         content_scroll: 0,
         content_hscroll: 0,
         tree_scroll: 0,
+        tree_hscroll: 0,
         wrap: false,
         split_pct: 40,
         zoomed: false,
@@ -423,6 +424,69 @@ fn tree_shows_a_vertical_scrollbar_only_when_it_overflows() {
     assert!(
         overflow.contains('▐'),
         "an overflowing tree shows a scrollbar thumb (▐)\n{overflow}"
+    );
+}
+
+#[test]
+fn tree_shows_a_horizontal_scrollbar_and_scrolls_long_rows() {
+    // The tree gets a horizontal scrollbar (▄ thumb on the bottom border) + horizontal scroll when
+    // the widest row overflows the column — so a long / deeply-nested name can be read sideways.
+    // `tree_hscroll` clips the leading columns, like the content pane. Assertions are scoped to the
+    // TREE column: the content pane's block title is the selected node's name, so a frame-wide
+    // check would false-match the head there regardless of the tree's horizontal scroll.
+    use herdr_file_viewer::presenter::geometry;
+    use ratatui::layout::Rect;
+    let area = Rect {
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 24,
+    };
+    let mut state = sample_state();
+    state.notices = vec![];
+    let long = format!("START_{}_END", "x".repeat(60));
+    state.nodes = vec![node(&format!("/r/{long}"), NodeKind::File, 0, false, None)];
+    state.selected = 0;
+
+    // The text inside the tree column (interior + its borders), one line per row.
+    let tree_region = |st: &ViewState| -> String {
+        let buf = render_buffer(st, area.width, area.height);
+        let t = geometry(area, st).tree_inner.expect("tree interior");
+        let mut s = String::new();
+        for y in t.y..(t.y + t.height) {
+            for x in t.x..(t.x + t.width) {
+                s.push_str(buf.cell((x, y)).map_or(" ", |c| c.symbol()));
+            }
+            s.push('\n');
+        }
+        s
+    };
+
+    state.tree_hscroll = 0;
+    let head_region = tree_region(&state);
+    let full = render(&state, area.width, area.height);
+    assert!(
+        full.contains('▄'),
+        "an overflowing tree shows a horizontal scrollbar (▄)\n{full}"
+    );
+    assert!(
+        head_region.contains("START_"),
+        "the row head shows in the tree at hscroll 0\n{head_region}"
+    );
+    assert!(
+        !head_region.contains("_END"),
+        "the row tail is off-screen in the tree at hscroll 0\n{head_region}"
+    );
+
+    state.tree_hscroll = 45;
+    let tail_region = tree_region(&state);
+    assert!(
+        tail_region.contains("_END"),
+        "scrolling right reveals the row tail in the tree\n{tail_region}"
+    );
+    assert!(
+        !tail_region.contains("START_"),
+        "the head is clipped in the tree once scrolled right\n{tail_region}"
     );
 }
 

--- a/tests/presenter.rs
+++ b/tests/presenter.rs
@@ -69,6 +69,7 @@ fn sample_state() -> ViewState {
         content_hscroll: 0,
         tree_scroll: 0,
         tree_hscroll: 0,
+        content_rows: 3, // the fixture content is three lines
         wrap: false,
         split_pct: 40,
         zoomed: false,
@@ -568,6 +569,7 @@ fn content_pane_shows_a_vertical_scrollbar_when_content_overflows() {
             .collect::<Vec<_>>()
             .join("\n"),
     );
+    state.content_rows = 60; // the controller's rendered-row count drives the vertical bar
     let out = render(&state, 100, 12);
     assert!(
         out.contains('▐'),
@@ -576,10 +578,82 @@ fn content_pane_shows_a_vertical_scrollbar_when_content_overflows() {
 
     // A short file shows none.
     state.content = to_text("only\ntwo\n");
+    state.content_rows = 2;
     let short = render(&state, 100, 12);
     assert!(
         !short.contains('▐'),
         "content that fits shows no vertical scrollbar\n{short}"
+    );
+}
+
+#[test]
+fn content_vertical_scrollbar_is_driven_by_rendered_rows_not_raw_lines() {
+    // Review (codex/opus/kimi/glm): under wrap, the vertical bar must reflect WRAPPED rows, not raw
+    // lines — else a file with few but long lines that wraps past the viewport gets no bar. The
+    // presenter sizes the bar from `content_rows` (the controller's rendered-row count), so a single
+    // raw line with a large content_rows shows a bar, and a small content_rows shows none.
+    let mut state = sample_state();
+    state.notices = vec![];
+    state.content = to_text(&"word ".repeat(400)); // ONE raw line
+    state.wrap = true;
+
+    state.content_rows = 60; // wraps to ~60 rows >> the ~22-row viewport
+    let overflow = render(&state, 100, 24);
+    assert!(
+        overflow.contains('▐'),
+        "a single long line that wraps past the viewport shows a vertical scrollbar\n{overflow}"
+    );
+
+    state.content_rows = 5; // wraps to only 5 rows → fits
+    let fits = render(&state, 100, 24);
+    assert!(
+        !fits.contains('▐'),
+        "no vertical bar when the wrapped rows fit (despite content_scroll units)\n{fits}"
+    );
+}
+
+#[test]
+fn tree_vertical_thumb_tracks_the_selection() {
+    // Review (codex/glm): the tree's vertical thumb reflects the CURSOR position, so dragging it
+    // (which scrubs the selection) makes the thumb follow — rather than the thumb being driven by
+    // the viewport offset while the drag moves the cursor (they'd diverge). With many nodes, a low
+    // selection puts the thumb near the top; a high selection puts it near the bottom.
+    use herdr_file_viewer::presenter::geometry;
+    use ratatui::layout::Rect;
+    let area = Rect {
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 24,
+    };
+    let mut state = sample_state();
+    state.notices = vec![];
+    state.nodes = (0..40)
+        .map(|i| {
+            node(
+                &format!("/r/file-{i:02}.rs"),
+                NodeKind::File,
+                0,
+                false,
+                None,
+            )
+        })
+        .collect();
+    let track = geometry(area, &state).tree_vbar.expect("tree vbar present");
+    let thumb_top = |st: &ViewState| -> u16 {
+        let buf = render_buffer(st, area.width, area.height);
+        (track.y..track.y + track.height)
+            .find(|&y| buf.cell((track.x, y)).is_some_and(|c| c.symbol() == "▐"))
+            .expect("a thumb cell")
+    };
+
+    state.selected = 0;
+    let low = thumb_top(&state);
+    state.selected = 39;
+    let high = thumb_top(&state);
+    assert!(
+        high > low,
+        "the thumb moves down as the selection moves down (tracks the cursor): sel0={low} sel39={high}"
     );
 }
 
@@ -608,6 +682,7 @@ fn content_vertical_scrollbar_thumb_reaches_the_bottom_at_max_scroll() {
             .join("\n"),
     );
     state.wrap = false;
+    state.content_rows = 60; // the rendered-row count drives the vertical bar
     let track = geometry(area, &state)
         .content_vbar
         .expect("content vbar present");

--- a/tests/presenter_narrow.rs
+++ b/tests/presenter_narrow.rs
@@ -35,6 +35,7 @@ fn state(width: u16, focus: Focus) -> ViewState {
         width,
         content_scroll: 0,
         content_hscroll: 0,
+        tree_scroll: 0,
         wrap: false,
         split_pct: 40,
         zoomed: false,

--- a/tests/presenter_narrow.rs
+++ b/tests/presenter_narrow.rs
@@ -36,6 +36,7 @@ fn state(width: u16, focus: Focus) -> ViewState {
         content_scroll: 0,
         content_hscroll: 0,
         tree_scroll: 0,
+        tree_hscroll: 0,
         wrap: false,
         split_pct: 40,
         zoomed: false,

--- a/tests/presenter_narrow.rs
+++ b/tests/presenter_narrow.rs
@@ -37,6 +37,7 @@ fn state(width: u16, focus: Focus) -> ViewState {
         content_hscroll: 0,
         tree_scroll: 0,
         tree_hscroll: 0,
+        content_rows: 1, // the fixture content is one line
         wrap: false,
         split_pct: 40,
         zoomed: false,


### PR DESCRIPTION
## Fixes the tree-scroll bug (#45) and adds scrollbars

### The bug (#45, reported by @julianduque)
With more files than fit the pane, the tree stayed pinned to the top: the selection highlight kept moving but the viewport never followed, so once the cursor passed the last visible row you were selecting files you couldn't see.

**Root cause:** `draw_tree` rendered every node into a `Paragraph` with no scroll offset (always anchored at row 0). Rows past the interior height were simply clipped. The picker overlay already solved exactly this — the tree just never adopted it.

### The fix
- **Tree follows the selection.** `draw_tree` now applies a vertical scroll offset via the shared `scroll_offset(cursor, len, visible)` helper (generalized from the picker's `picker_scroll_offset`), so the selected row is always on screen.
- **Clicks stay correct when scrolled.** The offset is fed back to the controller via a new `PaneGeometry.tree_scroll`, and `hit_test` adds it — so a mouse click maps to the row *actually drawn* there. `geometry()` and `draw_tree` derive the offset from the same pure function, preserving the "drawn layout and hit-test geometry never disagree" invariant.

### Scrollbars (requested in review)
Scrollbars now appear **only where there is something to scroll** (`ratatui::widgets::Scrollbar` — already a transitive dep, no new Cargo dependency):
- **Tree** — a vertical bar when there are more nodes than fit.
- **Content** — a vertical bar when the file is taller than the pane, and a horizontal bar when an unwrapped line is wider than the pane.

They sit on the pane borders (track + thumb, no arrow glyphs) and are a no-op when everything fits. The picker overlay is intentionally left as-is (it already keeps its cursor in view and shows a key-hint footer).

### Tests
Test-first (red→green) throughout. New tests:
- `tree_scrolls_to_keep_selection_visible` — the reported bug, scoped to the tree interior.
- `geometry_reports_the_tree_scroll_offset_for_hit_testing` + `a_tree_click_maps_through_the_scroll_offset` — the click-mapping coupling.
- `tree_shows_a_vertical_scrollbar_only_when_it_overflows`, `content_pane_shows_a_vertical_scrollbar_when_content_overflows`, `content_pane_shows_a_horizontal_scrollbar_for_a_too_wide_unwrapped_line`.

Full suite **341 passing**; `cargo fmt --check`, `clippy -D warnings`, and `cargo build --release` all clean.

### Docs
CHANGELOG (`Unreleased` → `Fixed` + `Added`), README feature list, and ARCHITECTURE presenter row all updated in this PR.

Closes #45
