### PR TITLE
release: v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.5.0] - 2026-06-25
 
 ### Added
 - **Scrollbars** appear on the tree and content panes whenever there's more to see than fits — a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -574,7 +574,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "herdr-file-viewer"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "ansi-to-tui",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "herdr-file-viewer"
-version = "1.4.0"
+version = "1.5.0"
 edition = "2024"
 rust-version = "1.96"
 description = "A git-aware, read-only file viewer that runs as a herdr TUI pane"

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -6,7 +6,7 @@
 
 id = "herdr-file-viewer"
 name = "herdr-file-viewer"
-version = "1.4.0"
+version = "1.5.0"
 description = "A git-aware, read-only file viewer: a keyboard-driven TUI in a herdr split pane."
 min_herdr_version = "0.7.0"
 platforms = ["linux", "macos"]


### PR DESCRIPTION
Cuts **v1.5.0**, combining both merged feature PRs into one release.

- Bumps the version in all three files: `Cargo.toml`, `Cargo.lock`, `herdr-plugin.toml`.
- Finalizes the `## [1.5.0]` CHANGELOG entry (Added / Fixed).

Covers:
- **#47** — tree scroll fix (#45) + in-pane draggable scrollbars (tree + content, vertical + horizontal) + horizontal tree scroll. Review-gate ✅ pass.
- **#48** — hide-dotfiles `.` toggle (#46). Review-gate ✅ pass.

No code changes beyond the version bump; both features are already on `main`.
