### PR TITLE
fix(install): match prebuilt by version so a main ahead of the tag still gets a binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- **Installing now reuses the latest released binary even when `main` is ahead of the tag.** The
+  install step (`scripts/fetch-or-build.sh`) matches the prebuilt by **version** rather than by exact
+  commit, so landing a PR no longer forces new users to compile while a release is pending — they get
+  the last released, SHA-256-verified binary instead. A version with no published release still falls
+  back to building from source, and when the checkout is ahead of the release it's installing, the
+  install prints a note saying the binary doesn't yet include the unreleased source.
+
 ## [1.5.0] - 2026-06-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ right into the tree. It opens beside whatever you're doing and never touches you
 ## Quick start
 
 ```bash
-# 1. Install the plugin (tagged releases download a prebuilt binary; otherwise builds from source):
+# 1. Install the plugin (downloads a prebuilt binary for released versions; otherwise builds from source):
 herdr plugin install smarzban/herdr-file-viewer
 
 # 2. (recommended) install the renderers, so markdown / diffs / code are styled, not plain text:

--- a/docs/install.md
+++ b/docs/install.md
@@ -2,11 +2,13 @@
 
 Requirements: **herdr 0.7.0+**, on **Linux** or **macOS**.
 
-> **No Rust toolchain needed for tagged releases.** `herdr plugin install smarzban/herdr-file-viewer`
+> **No Rust toolchain needed when a prebuilt exists.** `herdr plugin install smarzban/herdr-file-viewer`
 > downloads a prebuilt, SHA-256-verified binary for your platform (macOS arm64/x86_64, Linux x86_64).
-> If no matching prebuilt is available — an unsupported platform, or installing from a `main` that is
-> ahead of the latest release — it automatically builds from source with `cargo` instead (Rust 1.96+).
-> The install command is the same either way.
+> The prebuilt is matched by **version**, so you get it even when `main` is ahead of the latest tag —
+> you'll receive the most recent released binary (a note tells you when newer, unreleased changes
+> aren't in it yet). It builds from source with `cargo` (Rust 1.96+) only when there's no matching
+> prebuilt at all — an unsupported platform, or a version that hasn't been released yet. The install
+> command is the same either way.
 
 **Install through herdr** — herdr runs the manifest's `[[build]]` step at install time, either
 downloading a prebuilt binary or compiling from source, producing `./target/release/herdr-file-viewer`,

--- a/scripts/fetch-or-build.sh
+++ b/scripts/fetch-or-build.sh
@@ -1,12 +1,15 @@
 #!/bin/sh
 # fetch-or-build.sh — herdr [[build]] step for herdr-file-viewer.
 #
-# Fast path: download the prebuilt binary that matches THIS source's version + platform from the
-# GitHub release, verify its SHA-256, and install it at target/release/herdr-file-viewer.
-# Fallback: on ANY miss (source is not the released commit, no asset for this version,
-# network/download error, checksum mismatch, unmapped platform, no curl/wget) print a clear notice
-# and build from source with cargo — identical to the pre-prebuilt behavior, so installing never
-# gets harder than before.
+# Fast path: download the prebuilt binary that matches THIS source's declared version + platform
+# from the GitHub release, verify its SHA-256, and install it at target/release/herdr-file-viewer.
+# The match is by VERSION, not by exact commit: a checkout that is AHEAD of the matching release
+# (e.g. main has merged work that isn't tagged yet) still uses that released binary, so landing a
+# PR no longer forces new users to compile while a release is pending. Integrity is unchanged — the
+# binary is still SHA-256 verified — and a version with no published release still 404s to source.
+# Fallback: on ANY miss (no asset for this version, network/download error, checksum mismatch,
+# unmapped platform, no curl/wget) print a clear notice and build from source with cargo — identical
+# to the pre-prebuilt behavior, so installing never gets harder than before.
 #
 # Paths and the release base URL are overridable via env (FV_REPO_ROOT / FV_CARGO_TOML / FV_OUT /
 # FV_BASE_URL) so the logic is exercised by a hermetic test with stubbed uname/curl/cargo/git.
@@ -88,21 +91,26 @@ asset="herdr-file-viewer-$triple"
 tmpdir=$(mktemp -d 2>/dev/null) || fallback "could not create a temp dir"
 trap 'rm -rf "$tmpdir"' EXIT
 
-# --- gate: this checkout must be EXACTLY the commit the v$version release was built from ----
-# `herdr plugin install` clones a git work tree at the chosen commit but usually WITHOUT local tags,
-# so we cannot resolve the release tag locally. Instead we compare the checkout's HEAD to the commit
-# recorded in the release's COMMIT asset (a plain HTTPS download; `git rev-parse HEAD` is a safe
-# local ref read — no remote, no config-driven command execution). Between releases this repo's main
-# sits at the last released version while its HEAD has advanced past the tag; this check makes the
-# prebuilt fire only when the source IS the released commit, otherwise we build from source. When the
-# checkout is not a git work tree (e.g. an unpacked tarball) ahead-ness is undefined, so we proceed
-# on the version as before.
+# --- version-only match (no commit-exactness gate) -----------------------------------------
+# The prebuilt is used whenever a release exists for the version this source DECLARES — even when
+# the checkout is ahead of that release's commit (e.g. main has merged work that isn't tagged yet).
+# This decouples "merge a PR" from "cut a release": new installs keep getting the last released,
+# SHA-256-verified binary instead of being forced to compile. A version with no matching release
+# still falls back to source, because the asset download further below 404s — so we can never
+# silently install a binary whose version differs from this source.
+#
+# For transparency only (never a failure): if this is a git work tree and we can read both HEAD and
+# the release's published COMMIT marker, note when the checkout is ahead — the binary is the released
+# v$version while the working tree may carry newer, unreleased source. `git rev-parse HEAD` is a safe
+# local ref read; the COMMIT fetch is best-effort and its absence is not an error.
+ahead_note=""
 if have git && git -C "$repo_root" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   head_rev=$(git -C "$repo_root" rev-parse HEAD 2>/dev/null || echo nohead)
-  download "$base_url/v$version/COMMIT" "$tmpdir/COMMIT" || fallback "release commit marker not available for v$version"
-  release_commit=$(tr -d '[:space:]' < "$tmpdir/COMMIT" 2>/dev/null)
-  if [ -z "$release_commit" ] || [ "$head_rev" != "$release_commit" ]; then
-    fallback "checkout ($head_rev) is not the v$version release commit ($release_commit) — building from source"
+  if download "$base_url/v$version/COMMIT" "$tmpdir/COMMIT" 2>/dev/null; then
+    release_commit=$(tr -d '[:space:]' < "$tmpdir/COMMIT" 2>/dev/null)
+    if [ -n "$release_commit" ] && [ "$head_rev" != "$release_commit" ]; then
+      ahead_note=" Note: this checkout ($head_rev) is ahead of the v$version release commit ($release_commit), so newer unreleased source is not in this binary."
+    fi
   fi
 fi
 
@@ -127,5 +135,5 @@ fi
 chmod +x "$tmpbin"
 mkdir -p "$(dirname "$out")"
 mv -f "$tmpbin" "$out" || fallback "could not install the verified binary to $out"
-echo "herdr-file-viewer: installed prebuilt v$version ($triple), verified SHA-256."
+echo "herdr-file-viewer: installed prebuilt v$version ($triple), verified SHA-256.$ahead_note"
 exit 0

--- a/tests/fetch_or_build.rs
+++ b/tests/fetch_or_build.rs
@@ -142,9 +142,9 @@ fn run_impl(
         "#!/bin/sh\necho FAKE_CARGO_BUILD \"$@\"\nexit 0\n",
     );
 
-    // The release-tag gate inspects FV_REPO_ROOT as a git work tree. By default point it at the
-    // (non-git) temp root so the gate is skipped and the platform/download/verify logic is what's
-    // under test; the gate's own tests pass a real git repo here.
+    // The ahead-note logic inspects FV_REPO_ROOT as a git work tree. By default point it at the
+    // (non-git) temp root so it is skipped and the platform/download/verify logic is what's under
+    // test; the git-checkout tests pass a real git repo here.
     let fv_repo_root: &Path = repo_root.unwrap_or(root.as_path());
     let path = format!("{}:{}", stub.display(), std::env::var("PATH").unwrap());
     let output = Command::new("sh")
@@ -182,7 +182,7 @@ fn run(os: &str, arch: &str, version: &str, serve_binary: bool, corrupt_sums: bo
 
 /// Throwaway git repo at `dir` with a single commit and NO tag — exactly like herdr's install
 /// checkout (a work tree at the cloned commit, without local tags). Returns the HEAD commit SHA,
-/// which the COMMIT-gate compares against the release's published marker.
+/// which the ahead-note logic compares against the release's published COMMIT marker.
 fn make_git_repo(dir: &Path) -> String {
     fs::create_dir_all(dir).unwrap();
     let g = |args: &[&str]| -> std::process::Output {
@@ -319,11 +319,10 @@ fn script_preserves_the_cargo_source_build_fallback() {
     );
 }
 
-// Regression test for the v1.2.0 install failure: herdr's checkout is a git work tree at the
-// release commit but WITHOUT local tags. The gate must confirm the match via the published COMMIT
-// marker (HEAD == COMMIT), not a local tag ref, and use the prebuilt.
+// Matching commit: when the checkout IS the released commit, the prebuilt installs cleanly and
+// (because HEAD == COMMIT) no "ahead" note is emitted.
 #[test]
-fn gate_uses_prebuilt_when_head_matches_the_release_commit() {
+fn uses_prebuilt_when_head_matches_the_release_commit() {
     let gitdir = tmp("gitrepo-match");
     let head = make_git_repo(&gitdir); // tagless work tree, like herdr's install checkout
     let o = run_impl(
@@ -341,22 +340,21 @@ fn gate_uses_prebuilt_when_head_matches_the_release_commit() {
         o.stdout,
         o.stderr
     );
+    assert!(!o.fell_back(), "must not build from source");
     assert!(
-        !o.fell_back(),
-        "must not build from source when HEAD is the released commit"
-    );
-    assert!(
-        o.urls.iter().any(|u| u.ends_with("/v1.2.0/COMMIT")),
-        "gate must fetch the COMMIT marker; urls: {:?}",
-        o.urls
+        !o.stdout.contains("ahead of"),
+        "no ahead-note when the checkout IS the released commit; stdout: {}",
+        o.stdout
     );
     let _ = fs::remove_dir_all(&gitdir);
 }
 
-// When the checkout's HEAD differs from the release commit (e.g. main has advanced past the tag),
-// the gate must fall back to a source build and never install the stale binary.
+// Version-only behavior: when the checkout's HEAD is AHEAD of the release commit (e.g. main has
+// merged work that isn't tagged yet), the prebuilt for the declared version is STILL installed —
+// landing a PR no longer forces new users to compile — and a transparency note records that the
+// working tree carries newer, unreleased source than the binary.
 #[test]
-fn gate_falls_back_when_head_differs_from_the_release_commit() {
+fn uses_prebuilt_when_head_is_ahead_of_the_release_commit() {
     let gitdir = tmp("gitrepo-ahead");
     let _head = make_git_repo(&gitdir);
     let other = "0000000000000000000000000000000000000000"; // a commit this checkout is NOT at
@@ -370,16 +368,51 @@ fn gate_falls_back_when_head_differs_from_the_release_commit() {
         Some(other),
     );
     assert!(
-        o.fell_back(),
-        "HEAD != release commit must build from source\nstdout:{}\nstderr:{}",
+        o.installed_prebuilt(),
+        "HEAD ahead of the release commit must still use the prebuilt\nstdout:{}\nstderr:{}",
         o.stdout,
         o.stderr
     );
-    assert!(o.placed.is_none(), "must not install the stale binary");
     assert!(
-        !o.urls.iter().any(|u| u.contains("herdr-file-viewer-")),
-        "the gate must fire before the binary download; urls: {:?}",
+        !o.fell_back(),
+        "must not build from source merely because the checkout is ahead of the tag"
+    );
+    assert_eq!(
+        o.placed.as_deref(),
+        Some(&b"#!/bin/sh\necho prebuilt-viewer\n"[..]),
+        "the verified prebuilt must be installed"
+    );
+    assert!(
+        o.urls
+            .iter()
+            .any(|u| u.contains("herdr-file-viewer-x86_64-unknown-linux-musl")),
+        "the binary download must happen (no commit gate before it); urls: {:?}",
         o.urls
     );
+    assert!(
+        o.stdout.contains("ahead of"),
+        "must note that the checkout is ahead of the release commit; stdout: {}",
+        o.stdout
+    );
+    let _ = fs::remove_dir_all(&gitdir);
+}
+
+// A version with NO published release still falls back to source even from a git checkout — the
+// asset download 404s, so we never silently install a binary whose version differs from the source.
+#[test]
+fn version_with_no_release_still_falls_back_from_a_git_checkout() {
+    let gitdir = tmp("gitrepo-norelease");
+    let head = make_git_repo(&gitdir);
+    let o = run_impl(
+        "Linux",
+        "x86_64",
+        "9.9.9",
+        false, // serve_binary = false → the asset 404s
+        false,
+        Some(&gitdir),
+        Some(&head),
+    );
+    assert!(o.fell_back(), "stdout: {}\nstderr: {}", o.stdout, o.stderr);
+    assert!(o.placed.is_none(), "must not install anything");
     let _ = fs::remove_dir_all(&gitdir);
 }

--- a/tests/release_workflow.rs
+++ b/tests/release_workflow.rs
@@ -49,8 +49,8 @@ fn guards_the_tag_against_the_crate_version() {
 #[test]
 fn publishes_a_commit_marker() {
     let w = workflow();
-    // The install gate compares the checkout's HEAD to this marker (herdr's checkout lacks tags),
-    // so the release must publish the built commit as a COMMIT asset.
+    // The install script reads this marker to note when a checkout is ahead of the release it's
+    // installing (herdr's checkout lacks tags), so the release must publish the built commit.
     assert!(
         w.contains("release/COMMIT") && w.contains("GITHUB_SHA"),
         "release must publish a COMMIT marker (the GITHUB_SHA it was built from)"


### PR DESCRIPTION
## Problem

The install step (`scripts/fetch-or-build.sh`) gated the prebuilt binary on `HEAD == ` the release's `COMMIT` marker. So the moment `main` advanced past the last tag, **every `herdr plugin install` was forced to compile from source** (Rust 1.96+).

That coupled *"merge a PR"* to *"cut a release"*: you couldn't land a few features and batch them into a single release without pushing new users onto a slow source build in the gap.

## Change

Match the prebuilt by the **version the source declares** rather than by exact commit:

- A checkout **ahead** of the matching release now installs the last released, SHA-256-verified binary instead of compiling.
- A version with **no published release** still 404s and falls back to source — so we can never silently install a binary whose version differs from the source.
- **SHA-256 verification and the `cargo` fallback are unchanged.** Only the freshness gate is relaxed; integrity is identical.
- The `COMMIT` marker is downgraded from a hard gate to an informational *"your checkout is ahead of the release"* note printed on success.

### The one thing to keep honest
If a change ever alters how a launcher script or the manifest **invokes the binary** (the `--launch-decision` handshake in `open-file-viewer.sh`, or the launch `command` in `herdr-plugin.toml`), bump the version in that same commit so installs fall back to source until released. Pure-Rust changes — the vast majority — are unaffected.

## Does this need a release?

**No.** `fetch-or-build.sh` runs from the `main` checkout at install time, not from the binary, so the new behavior is live as soon as it merges and works against the **existing v1.5.0 assets**. Version stays `1.5.0`; the CHANGELOG note rides under `Unreleased` until the next feature release. This PR is its own proof: once merged, `main` is ahead of `v1.5.0`, and a fresh install will fetch the v1.5.0 prebuilt (with the ahead-note) instead of compiling.

## Tests

- `tests/fetch_or_build.rs`: the old "falls back when HEAD differs from the release commit" test is replaced by `uses_prebuilt_when_head_is_ahead_of_the_release_commit`; added `version_with_no_release_still_falls_back_from_a_git_checkout`. All 10 pass.
- `tests/release_workflow.rs`: still asserts the release publishes a `COMMIT` marker (now used for the note). 5 pass.

## Post-merge check
Per the "green local suite ≠ green real install" lesson: after merging, run `herdr plugin install smarzban/herdr-file-viewer` once and confirm it grabs the v1.5.0 prebuilt with the ahead-note rather than compiling.

## Files
- `scripts/fetch-or-build.sh` — version-only match + ahead note
- `tests/fetch_or_build.rs`, `tests/release_workflow.rs` — test updates
- `README.md`, `docs/install.md` — corrected main-ahead wording
- `CHANGELOG.md` — `Unreleased` section