### PR TITLE
docs: backfill go-to-file (f) and the tree root/branch border

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -33,6 +33,10 @@ is unit-testable with stubs.
 | `render` | Produce the content-pane text: classify the file, delegate styling to an external CLI, and **neutralize escape sequences** before display. |
 | `presenter` | Draw the two-column (or zoomed / narrow) layout with ratatui; scroll the tree to keep the selection in view (and horizontally for long rows) and draw scrollbars where a pane overflows; report the content viewport + tree scroll offset + widest tree row + pane geometry back, so the controller can hit-test a tree click and map a scrollbar drag. |
 | `picker` | The modal worktree-switcher overlay state (rows, cursor, horizontal scroll) drawn over the layout; captures its own nav / confirm / cancel keys while open. |
+| `finder` | The modal go-to-file finder overlay state (query, ranked matches, cursor, scroll) drawn over the layout; captures its own keys while open and navigates the tree selection on confirm. |
+| `fuzzy` | A pure fuzzy matcher: rank file paths against a typed query (the finder's scoring), no I/O. |
+| `index` | Build the flat, `.gitignore`-aware list of repo file paths the finder searches. |
+| `prompt` | A reusable single-line text-input buffer (push / backspace / clear) backing the finder query — and future keyboard prompts. |
 | `input` | Map crossterm key events → intents. |
 | `intent` | The closed set of user intents (one exhaustive enum). |
 | `controller` | Orchestrate intents → state changes; hold the ephemeral session state; dispatch renders to the worker; map mouse events (clicks, wheel, divider + scrollbar drags) against the fed-back geometry; on a worktree switch, rebuild the root-bound services through a provider factory and respawn the render worker. |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+### Added
+- **Go to file (`f`).** Open a fuzzy finder over every file in the tree and jump straight to one by
+  name — type to filter, `↑` / `↓` to move, `Enter` to open, `Esc` to cancel; `←` / `→` (or the
+  horizontal wheel) scroll long result rows, and the result list has a draggable scrollbar.
+  Read-only navigation; it never modifies a file. ([#51](https://github.com/smarzban/herdr-file-viewer/pull/51))
+- **The tree names its root and branch.** The tree column's top border shows the root directory's
+  name and its bottom border the current git branch (omitted outside a git repo / on a detached
+  HEAD), with long names middle-ellipsized to fit — so you can always see *which* directory and
+  branch you're viewing. ([#52](https://github.com/smarzban/herdr-file-viewer/pull/52))
+
 ### Changed
 - **Installing now reuses the latest released binary even when `main` is ahead of the tag.** The
   install step (`scripts/fetch-or-build.sh`) matches the prebuilt by **version** rather than by exact
@@ -13,6 +23,11 @@ All notable changes to this project are documented here. The format is based on
   the last released, SHA-256-verified binary instead. A version with no published release still falls
   back to building from source, and when the checkout is ahead of the release it's installing, the
   install prints a note saying the binary doesn't yet include the unreleased source.
+
+### Fixed
+- **The worktree picker's `←` now responds immediately after over-scrolling right.** The picker's
+  horizontal scroll offset is clamped to the measured maximum each frame (mirroring the file
+  finder), so it can't park past the widest row and swallow the first few `←` presses. ([#52](https://github.com/smarzban/herdr-file-viewer/pull/52))
 
 ## [1.5.0] - 2026-06-25
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,12 @@ right into the tree. It opens beside whatever you're doing and never touches you
 
 - **Tree, scoped to your work** — rooted at the worktree root inside a git repo, else the
   launch directory. Honors `.gitignore` (toggle to reveal ignored files), and a separate toggle
-  (`.`) hides dot-prefixed "hidden" files when a directory is full of them.
+  (`.`) hides dot-prefixed "hidden" files when a directory is full of them. The tree's top border
+  names the root directory and its bottom border shows the current branch, so you always know
+  *where* and *on what branch* you're looking.
+- **Jump to any file** — press `f` to open a fuzzy finder over every file in the tree
+  (`.gitignore`-aware); type to filter, `↑` / `↓` to move, and `Enter` to open — far faster than
+  scrolling the tree in a large repo.
 - **Switch worktree on the fly** — press `W` to re-root the viewer at another git worktree of
   the repo without relaunching; it pre-selects the worktree a herdr agent is working in, so you
   can jump straight to it. Read-only — it changes only *what you're viewing*, never the branch
@@ -108,6 +113,7 @@ you only add the keybinding. The [keys](#keys) are below; deeper detail lives in
 | `b` | Toggle the diff baseline (base branch ⇄ `HEAD`) |
 | `v` | Cycle the content view mode |
 | `e` | Open the selected file in `$EDITOR` |
+| `f` | **Go to file** — open a fuzzy finder over every file in the tree; type to filter, `↑` / `↓` move, `Enter` opens the selected file, `Esc` cancels (`←` / `→` scroll long paths) |
 | `y` | Copy the selected file's **repo-relative** path to the clipboard (e.g. `src/app.rs`) |
 | `Y` | Copy the selected file's **absolute** path to the clipboard |
 | `Tab` | Move focus between the tree and content columns |
@@ -220,7 +226,7 @@ A few things on the way:
 
 - **In-app help overlay** — a `?` key to show every keybinding (and setup tips) without leaving the viewer.
 - **Settings & customization** — a config file for keymaps, the default split, themes, and your own renderer/editor commands.
-- **Go to file** — fuzzy-find a file by name and jump straight to it.
+- **In-file navigation** — `/` to search within the open file and `:` to jump to a line.
 
 **Hit a bug, or want a feature?** Please [open an issue](https://github.com/smarzban/herdr-file-viewer/issues) — bug reports and feature requests are very welcome.
 


### PR DESCRIPTION
## What & why

Two already-merged, user-facing features shipped **without their docs**, so `main`'s docs misrepresent the viewer:

- **Go to file** (the `f` fuzzy finder, #51) — never reached the README **Keys** table or feature list, isn't in `ARCHITECTURE.md`, and was still listed as **upcoming** in the Roadmap.
- **The tree's root-name / branch border** (#52) — undocumented.

This is a small, docs-only backfill so the docs match what's on `main` (the project's "docs land in the feature PR" rule, applied retroactively).

## Changes

- **README**
  - Add the `f` row to the **Keys** table.
  - Add a *"Jump to any file"* feature bullet, and note the tree's root-name/branch borders on the tree bullet.
  - Replace the stale *"Go to file"* Roadmap item with the genuinely-next *"In-file navigation"* (`/` search, `:` go-to-line).
- **CHANGELOG** (`[Unreleased]`)
  - **Added:** go-to-file (`f`); the tree root/branch border.
  - **Fixed:** the worktree picker's `←` hscroll clamp (#52).
- **ARCHITECTURE** — add the `finder` / `fuzzy` / `index` / `prompt` module rows.

## Notes

- **Docs only** — no code change; CI is green by construction.
- Does **not** document `/`-search or `:`-go-to-line (in-file navigation) — those aren't on `main` yet; they'll bring their own docs.
