### PR TITLE
feat: in-file navigation — go to line (`:`) [Phase 1 of 2]

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -37,6 +37,7 @@ is unit-testable with stubs.
 | `fuzzy` | A pure fuzzy matcher: rank file paths against a typed query (the finder's scoring), no I/O. |
 | `index` | Build the flat, `.gitignore`-aware list of repo file paths the finder searches. |
 | `prompt` | A reusable single-line text-input buffer (push / backspace / clear) backing the finder query — and future keyboard prompts. |
+| `infile` | In-file-navigation modal state: which bottom prompt is open (go-to-line now; in-file search later), its `prompt` input buffer, and the content-scroll snapshot for cancel-restore. |
 | `input` | Map crossterm key events → intents. |
 | `intent` | The closed set of user intents (one exhaustive enum). |
 | `controller` | Orchestrate intents → state changes; hold the ephemeral session state; dispatch renders to the worker; map mouse events (clicks, wheel, divider + scrollbar drags) against the fed-back geometry; on a worktree switch, rebuild the root-bound services through a provider factory and respawn the render worker. |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ All notable changes to this project are documented here. The format is based on
 ## [Unreleased]
 
 ### Added
-- **Go to line (`:`).** Press `:` in the syntax/content view to open a prompt and jump the content
-  pane to a source line by number — `Enter` jumps (out-of-range clamps to the last line), `Esc`
-  cancels. In a rendered-markdown or diff view (where a source line has no 1:1 display row) `:` shows
-  a one-line "unavailable" notice instead of opening the prompt. Read-only navigation. (The first
-  half of in-file navigation; in-file search follows.)
+- **Go to line (`:`).** Press `:` to open a prompt and jump the content pane to a source line by
+  number — `Enter` jumps (out-of-range clamps to the last line), `Esc` cancels. Works in every view:
+  in a rendered-markdown or diff view (where a source line has no 1:1 display row) confirming switches
+  the file to the line-numbered content view and jumps there. Read-only navigation. (The first half of
+  in-file navigation; in-file search follows.)
 - **Go to file (`f`).** Open a fuzzy finder over every file in the tree and jump straight to one by
   name — type to filter, `↑` / `↓` to move, `Enter` to open, `Esc` to cancel; `←` / `→` (or the
   horizontal wheel) scroll long result rows, and the result list has a draggable scrollbar.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project are documented here. The format is based on
 ## [Unreleased]
 
 ### Added
+- **Go to line (`:`).** Press `:` in the syntax/content view to open a prompt and jump the content
+  pane to a source line by number — `Enter` jumps (out-of-range clamps to the last line), `Esc`
+  cancels. In a rendered-markdown or diff view (where a source line has no 1:1 display row) `:` shows
+  a one-line "unavailable" notice instead of opening the prompt. Read-only navigation. (The first
+  half of in-file navigation; in-file search follows.)
 - **Go to file (`f`).** Open a fuzzy finder over every file in the tree and jump straight to one by
   name — type to filter, `↑` / `↓` to move, `Enter` to open, `Esc` to cancel; `←` / `→` (or the
   horizontal wheel) scroll long result rows, and the result list has a draggable scrollbar.

--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ right into the tree. It opens beside whatever you're doing and never touches you
 - **Jump to any file** — press `f` to open a fuzzy finder over every file in the tree
   (`.gitignore`-aware); type to filter, `↑` / `↓` to move, and `Enter` to open — far faster than
   scrolling the tree in a large repo.
-- **Go to a line** — press `:` and type a line number to jump the content pane straight there
-  (in the syntax/content view); out-of-range clamps to the last line.
+- **Go to a line** — press `:` and type a line number to jump the content pane straight there;
+  in a rendered-markdown or diff view it switches to the line-numbered content view to make the
+  jump. Out-of-range clamps to the last line.
 - **Switch worktree on the fly** — press `W` to re-root the viewer at another git worktree of
   the repo without relaunching; it pre-selects the worktree a herdr agent is working in, so you
   can jump straight to it. Read-only — it changes only *what you're viewing*, never the branch
@@ -116,7 +117,7 @@ you only add the keybinding. The [keys](#keys) are below; deeper detail lives in
 | `v` | Cycle the content view mode |
 | `e` | Open the selected file in `$EDITOR` |
 | `f` | **Go to file** — open a fuzzy finder over every file in the tree; type to filter, `↑` / `↓` move, `Enter` opens the selected file, `Esc` cancels (`←` / `→` scroll long paths) |
-| `:` | **Go to line** — open a prompt and jump the content pane to a source line by number (`Enter` jumps, `Esc` cancels; out-of-range clamps to the last line). Available in the syntax/content view; in a rendered-markdown or diff view it shows a one-line "unavailable" notice |
+| `:` | **Go to line** — open a prompt and jump the content pane to a source line by number (`Enter` jumps, `Esc` cancels; out-of-range clamps to the last line). Works in any view; in a rendered-markdown or diff view, confirming switches to the line-numbered content view and jumps there |
 | `y` | Copy the selected file's **repo-relative** path to the clipboard (e.g. `src/app.rs`) |
 | `Y` | Copy the selected file's **absolute** path to the clipboard |
 | `Tab` | Move focus between the tree and content columns |

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ right into the tree. It opens beside whatever you're doing and never touches you
 - **Jump to any file** — press `f` to open a fuzzy finder over every file in the tree
   (`.gitignore`-aware); type to filter, `↑` / `↓` to move, and `Enter` to open — far faster than
   scrolling the tree in a large repo.
+- **Go to a line** — press `:` and type a line number to jump the content pane straight there
+  (in the syntax/content view); out-of-range clamps to the last line.
 - **Switch worktree on the fly** — press `W` to re-root the viewer at another git worktree of
   the repo without relaunching; it pre-selects the worktree a herdr agent is working in, so you
   can jump straight to it. Read-only — it changes only *what you're viewing*, never the branch
@@ -114,6 +116,7 @@ you only add the keybinding. The [keys](#keys) are below; deeper detail lives in
 | `v` | Cycle the content view mode |
 | `e` | Open the selected file in `$EDITOR` |
 | `f` | **Go to file** — open a fuzzy finder over every file in the tree; type to filter, `↑` / `↓` move, `Enter` opens the selected file, `Esc` cancels (`←` / `→` scroll long paths) |
+| `:` | **Go to line** — open a prompt and jump the content pane to a source line by number (`Enter` jumps, `Esc` cancels; out-of-range clamps to the last line). Available in the syntax/content view; in a rendered-markdown or diff view it shows a one-line "unavailable" notice |
 | `y` | Copy the selected file's **repo-relative** path to the clipboard (e.g. `src/app.rs`) |
 | `Y` | Copy the selected file's **absolute** path to the clipboard |
 | `Tab` | Move focus between the tree and content columns |
@@ -226,7 +229,7 @@ A few things on the way:
 
 - **In-app help overlay** — a `?` key to show every keybinding (and setup tips) without leaving the viewer.
 - **Settings & customization** — a config file for keymaps, the default split, themes, and your own renderer/editor commands.
-- **In-file navigation** — `/` to search within the open file and `:` to jump to a line.
+- **In-file search** — `/` to search within the open file and `n` / `N` to cycle matches (the `:` go-to-line jump has shipped).
 
 **Hit a bug, or want a feature?** Please [open an issue](https://github.com/smarzban/herdr-file-viewer/issues) — bug reports and feature requests are very welcome.
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -157,6 +157,20 @@ fn event_loop(terminal: &mut DefaultTerminal, controller: &mut Controller) -> io
                     }
                     dirty |= fx.redraw;
                 }
+                // While a bottom prompt (go-to-line) is open, route every key press to handle_prompt_key so
+                // digits/printables edit the prompt instead of firing viewer intents (AC-21). Mutually exclusive
+                // with the finder arm above — only one modal is ever open.
+                Event::Key(key) if key.kind == KeyEventKind::Press && controller.prompt_open() => {
+                    let fx = controller.handle_prompt_key(key);
+                    if fx.clear {
+                        let _ = terminal.clear();
+                        dirty = true;
+                    }
+                    if fx.quit {
+                        return Ok(());
+                    }
+                    dirty |= fx.redraw;
+                }
                 Event::Key(key)
                     if key.kind == KeyEventKind::Press
                         && let Some(intent) = input::map_key(key) =>

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -19,6 +19,7 @@
 use crate::finder::FinderState;
 use crate::git::{Baseline, Status};
 use crate::herdr::HerdrCli;
+use crate::infile::{PromptMode, PromptState};
 use crate::intent::Intent;
 use crate::picker::PickerState;
 use crate::presenter::{FinderView, Focus, PaneGeometry, PickerRowView, PickerView, ViewState};
@@ -240,6 +241,10 @@ pub struct Controller {
     /// (OpenFinder intent); closed by confirm/cancel (T-7) and by [`re_root`](Self::re_root) (a
     /// re-root invalidates the old-root candidate list).
     finder: Option<FinderState>,
+    /// The open in-file-nav bottom prompt (go-to-line), or `None` when closed. While `Some`, the run
+    /// loop routes raw keys to `handle_prompt_key` (T-4). Closed by confirm/cancel (T-3) and by a
+    /// re-root / new render. Mutually exclusive with the picker/finder modals.
+    prompt: Option<PromptState>,
     /// The herdr query channel for the agent-active overlay (AC-3), injected post-construction
     /// via [`set_host`](Self::set_host). `None` until then ⇒ a git-only picker (AC-15).
     /// Session-level — survives a re-root unchanged.
@@ -329,6 +334,7 @@ impl Controller {
             status_rx: None,
             picker: None,
             finder: None,
+            prompt: None,
             herdr: None,
             our_workspace_id: None,
             base_branch,
@@ -801,6 +807,11 @@ impl Controller {
         if self.finder.is_some() {
             return Effects::noop();
         }
+        // A prompt is modal too: the run loop routes raw keys to handle_prompt_key while it is open, so
+        // handle() should not be reached. Guard structurally — symmetric with the finder guard.
+        if self.prompt.is_some() {
+            return Effects::noop();
+        }
         match intent {
             Intent::NavUp => self.navigate(-1),
             Intent::NavDown => self.navigate(1),
@@ -824,6 +835,7 @@ impl Controller {
             Intent::DismissUpdate => self.dismiss_update(),
             Intent::SwitchWorktree => self.open_worktree_picker(),
             Intent::OpenFinder => self.open_finder(),
+            Intent::OpenGoToLine => self.open_go_to_line(),
             Intent::Close => self.close_or_unzoom(),
         }
     }
@@ -1790,6 +1802,28 @@ impl Controller {
     /// Whether the go-to-file finder overlay is currently open.
     pub fn finder_open(&self) -> bool {
         self.finder.is_some()
+    }
+
+    /// Open the go-to-line prompt (AC-1) — but only in a source-mapped (syntax/content) view, where a
+    /// source line maps 1:1 to a display row. In a transformed view (RenderedMarkdown / Diff /
+    /// FullDiff, or nothing selected) there is no source-line→row map, so emit a one-line unavailable
+    /// notice and open nothing (AC-7). Snapshots the current content scroll into the prompt state.
+    fn open_go_to_line(&mut self) -> Effects {
+        if self.selected_view_mode() == Some(ViewMode::SyntaxContent) {
+            self.prompt = Some(PromptState {
+                mode: PromptMode::GoToLine,
+                input: crate::prompt::PromptInput::new(),
+                saved_scroll: self.content_scroll,
+            });
+        } else {
+            self.action_notice = Some("Go to line is unavailable in this view".into());
+        }
+        Effects::redraw()
+    }
+
+    /// Whether an in-file-nav bottom prompt is currently open.
+    pub fn prompt_open(&self) -> bool {
+        self.prompt.is_some()
     }
 
     /// The full candidate list loaded when the finder was opened, or an empty slice when

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -242,8 +242,10 @@ pub struct Controller {
     /// re-root invalidates the old-root candidate list).
     finder: Option<FinderState>,
     /// The open in-file-nav bottom prompt (go-to-line), or `None` when closed. While `Some`, the run
-    /// loop routes raw keys to `handle_prompt_key` (T-4). Closed by confirm/cancel (T-3) and by a
-    /// re-root / new render. Mutually exclusive with the picker/finder modals.
+    /// loop routes raw keys to `handle_prompt_key` (T-4) and the mouse is inert ([`handle_mouse`]
+    /// returns early), so the selection can't change under an open prompt. Closed by confirm/cancel
+    /// (T-3) and by [`re_root`](Self::re_root) (symmetric with the picker/finder teardown).
+    /// Mutually exclusive with the picker/finder modals.
     prompt: Option<PromptState>,
     /// The herdr query channel for the agent-active overlay (AC-3), injected post-construction
     /// via [`set_host`](Self::set_host). `None` until then ⇒ a git-only picker (AC-15).
@@ -268,6 +270,12 @@ pub struct Controller {
     /// it is queued against the dispatched render's seq and applied by [`poll`] (AC-7). `None` when no
     /// jump is pending; superseded (cleared) by any newer render dispatch.
     pending_goto: Option<(u64, usize)>,
+    /// The seq of the render result currently held in [`content`](Self::content), bumped by [`poll`]
+    /// each time it applies a result. Equal to `latest_seq` exactly when the latest dispatched render
+    /// has landed; lagging while one is in flight. Lets a synchronous go-to-line jump tell "content is
+    /// current" from "a render is still coming" — so `:N` only jumps in-place when the source-mapped
+    /// content is actually applied, and otherwise queues against the in-flight render (AC-3/AC-7).
+    applied_seq: u64,
 }
 
 impl Controller {
@@ -342,6 +350,7 @@ impl Controller {
             finder: None,
             prompt: None,
             pending_goto: None,
+            applied_seq: 0,
             herdr: None,
             our_workspace_id: None,
             base_branch,
@@ -484,6 +493,10 @@ impl Controller {
         // exclusive and re_root only fires via picker-confirm), but kept structural so a future
         // re-root trigger can't strand a finder. (review-gate R1: G2)
         self.finder = None;
+        // Close the go-to-line prompt too (symmetric teardown). Unreachable today — the prompt is
+        // modal and re_root only fires via picker-confirm — but kept structural so a future re-root
+        // trigger can't strand an open prompt over a freshly re-rooted tree.
+        self.prompt = None;
         self.last_click = None;
 
         // PREFERENCES ARE CARRIED (AC-12) — deliberately NOT reset: show_ignored, hide_hidden,
@@ -934,6 +947,13 @@ impl Controller {
         // Modal: while the picker is open the mouse is fully inert — the picker is
         // keyboard-only. This mirrors the keyboard modal gate in `handle`. (review-gate R1, E)
         if self.picker.is_some() {
+            return Effects::noop();
+        }
+        // The go-to-line prompt is keyboard-only too: the run loop routes only KEY events to
+        // `handle_prompt_key`, so without this guard a click/wheel would still reach the tree/content
+        // beneath and change the selection mid-prompt — then a confirm would jump (or auto-switch) the
+        // WRONG file, or strand a bogus override on a directory. Make the mouse inert, like the picker.
+        if self.prompt.is_some() {
             return Effects::noop();
         }
         // The finder is also a modal overlay, but it IS mouse-interactive: wheel scrolls the
@@ -1396,17 +1416,23 @@ impl Controller {
             .saturating_sub(self.content_height)
     }
 
-    /// Scroll the content pane so 1-based source line `line_1based` is visible, landing the
-    /// line near the top of the viewport. The line is clamped to `[1, rendered_line_count()]`
-    /// (below 1 → line 1; above the last → the last line), then the offset is clamped to
-    /// `[0, max_content_scroll()]` so a near-the-end line shows the last screenful (the target
-    /// is still within view). In a source-mapped (SyntaxContent) view a source line maps 1:1 to
-    /// a display row, so `content_scroll` (display rows) indexes source lines directly. (AC-3, AC-4)
+    /// Scroll the content pane so 1-based source line `line_1based` is visible, landing the line near
+    /// the top of the viewport. The source line is clamped to `[1, source_line_count]` (below 1 →
+    /// line 1; above the last → the last line), mapped to its display-row offset, then that offset is
+    /// clamped to `[0, max_content_scroll()]` so a near-the-end line shows the last screenful (the
+    /// target stays within view). Without wrap a source line maps 1:1 to a display row, so the offset
+    /// is `line-1`; with wrap on (the `w` override wraps every mode) earlier long lines occupy several
+    /// rows, so the offset is the cumulative wrapped-row count of the lines BEFORE the target — the
+    /// same mapping the wrapped-row total uses, so `:N` lands on source line N either way. (AC-3, AC-4)
     pub fn scroll_to_line(&mut self, line_1based: usize) {
-        let last = self.rendered_line_count() as usize;
-        let line = line_1based.max(1).min(last.max(1));
-        let target = (line - 1) as u16;
-        self.content_scroll = target.min(self.max_content_scroll());
+        let source_lines = self.content.lines.len();
+        let line = line_1based.max(1).min(source_lines.max(1));
+        let offset = if self.effective_wrap() {
+            self.wrapped_rows_before(line - 1)
+        } else {
+            line - 1
+        };
+        self.content_scroll = (offset.min(u16::MAX as usize) as u16).min(self.max_content_scroll());
     }
 
     /// How many rows the content occupies once laid out, so the vertical scroll clamps to the
@@ -1427,19 +1453,29 @@ impl Controller {
     /// vertical scrollbar must size/position against — raw `lines.len()` undercounts under wrap.
     fn rendered_line_count_for(&self, wrap: bool) -> u16 {
         let count = if wrap {
-            let w = self.content_width.max(1) as usize;
-            self.content
-                .lines
-                .iter()
-                .map(|l| {
-                    let text: String = l.spans.iter().map(|s| s.content.as_ref()).collect();
-                    wrapped_rows(&text, w).max(l.width().max(1).div_ceil(w))
-                })
-                .sum::<usize>()
+            self.wrapped_rows_before(self.content.lines.len())
         } else {
             self.content.lines.len()
         };
         count.min(u16::MAX as usize) as u16
+    }
+
+    /// Cumulative display rows the first `n` content (source) lines occupy at the current content
+    /// width when wrapping is on (each line is ≥ 1 row). Shared by [`rendered_line_count_for`] (with
+    /// `n` = the whole line count → the wrapped-row total) and [`scroll_to_line`] (with `n` = line-1 →
+    /// the display-row offset of a source line), so the scroll clamp and the go-to-line target are
+    /// computed by the SAME wrapping logic and therefore always agree (AC-3/AC-4).
+    fn wrapped_rows_before(&self, n: usize) -> usize {
+        let w = self.content_width.max(1) as usize;
+        self.content
+            .lines
+            .iter()
+            .take(n)
+            .map(|l| {
+                let text: String = l.spans.iter().map(|s| s.content.as_ref()).collect();
+                wrapped_rows(&text, w).max(l.width().max(1).div_ceil(w))
+            })
+            .sum::<usize>()
     }
 
     /// Scroll the content pane horizontally by `delta` columns, clamped to `[0, max]`.
@@ -1897,21 +1933,35 @@ impl Controller {
                     .map(|p| p.input.query().to_string())
                     .unwrap_or_default();
                 self.prompt = None; // confirm always closes (AC-5 empty also closes)
+                // A new confirm supersedes any auto-switch jump still queued from an earlier confirm,
+                // so the older line can't overwrite this one when its render lands.
+                self.pending_goto = None;
                 if !q.is_empty() {
                     // The buffer holds only ASCII digits (non-digits are rejected above), so a
                     // parse failure can only be an overflow → treat as "beyond the last line";
                     // scroll_to_line clamps usize::MAX to the last line (AC-4).
                     let n = q.parse::<usize>().unwrap_or(usize::MAX);
-                    if self.selected_view_mode() == Some(ViewMode::SyntaxContent) {
-                        // Already source-mapped: the content is current, jump synchronously (AC-3).
+                    let source_mapped = self.selected_view_mode() == Some(ViewMode::SyntaxContent);
+                    if source_mapped && self.applied_seq == self.latest_seq {
+                        // Source-mapped AND the displayed content is the latest render → the line→row
+                        // mapping is valid now, so jump synchronously (AC-3).
                         self.scroll_to_line(n);
-                    } else if let Some(path) = self.tree.selected().map(|n| n.path.clone()) {
-                        // Transformed view (markdown / diff): a source line has no display row here,
-                        // so switch this file to the source-mapped content view and jump once the
-                        // re-render lands (AC-7). The new content renders off-thread, so the jump is
-                        // queued against the dispatched render's seq and applied by `poll`.
-                        self.overrides.insert(path, ViewMode::SyntaxContent);
-                        self.dispatch_render();
+                    } else if let Some(path) = self
+                        .tree
+                        .selected()
+                        .filter(|node| node.kind == NodeKind::File)
+                        .map(|node| node.path.clone())
+                    {
+                        // Either a transformed view (a source line has no display row here) or a
+                        // source render still in flight (the override reports SyntaxContent before its
+                        // render lands — jumping now would clamp against stale content). Queue the jump
+                        // for the render that carries the source-mapped content, and only (re)dispatch
+                        // when we must actually switch the view mode (AC-7); `poll` applies the queued
+                        // jump once the matching render lands.
+                        if !source_mapped {
+                            self.overrides.insert(path, ViewMode::SyntaxContent);
+                            self.dispatch_render();
+                        }
                         self.pending_goto = Some((self.latest_seq, n));
                     }
                 }
@@ -2185,6 +2235,7 @@ impl Controller {
             if seq == self.latest_seq {
                 self.content = result.content;
                 self.content_notices = result.notices;
+                self.applied_seq = seq; // the displayed content is now this render (go-to-line guard)
                 applied = true;
                 // A queued go-to-line jump (auto-switch from a transformed view, AC-7) applies once
                 // ITS render lands: now that the source-mapped content is in, scroll to the line.

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -1374,6 +1374,19 @@ impl Controller {
             .saturating_sub(self.content_height)
     }
 
+    /// Scroll the content pane so 1-based source line `line_1based` is visible, landing the
+    /// line near the top of the viewport. The line is clamped to `[1, rendered_line_count()]`
+    /// (below 1 → line 1; above the last → the last line), then the offset is clamped to
+    /// `[0, max_content_scroll()]` so a near-the-end line shows the last screenful (the target
+    /// is still within view). In a source-mapped (SyntaxContent) view a source line maps 1:1 to
+    /// a display row, so `content_scroll` (display rows) indexes source lines directly. (AC-3, AC-4)
+    pub fn scroll_to_line(&mut self, line_1based: usize) {
+        let last = self.rendered_line_count() as usize;
+        let line = line_1based.max(1).min(last.max(1));
+        let target = (line - 1) as u16;
+        self.content_scroll = target.min(self.max_content_scroll());
+    }
+
     /// How many rows the content occupies once laid out, so the vertical scroll clamps to the
     /// real last row. Without wrapping each source line is one (truncated) row. With wrapping a
     /// line spans multiple rows: ratatui's exact `line_count` is private, and an arithmetic

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -262,6 +262,12 @@ pub struct Controller {
     /// at construction and on each re-root and cached here — never queried per-frame, since the
     /// branch can only change by a re-root, not by navigation.
     current_branch: Option<String>,
+    /// A queued go-to-line jump awaiting its re-render: `(render seq, 1-based source line)`. Set when
+    /// `:` confirms in a **transformed** view (RenderedMarkdown / Diff / FullDiff) — the view is
+    /// switched to the source-mapped content view and the jump can't run until that render lands, so
+    /// it is queued against the dispatched render's seq and applied by [`poll`] (AC-7). `None` when no
+    /// jump is pending; superseded (cleared) by any newer render dispatch.
+    pending_goto: Option<(u64, usize)>,
 }
 
 impl Controller {
@@ -335,6 +341,7 @@ impl Controller {
             picker: None,
             finder: None,
             prompt: None,
+            pending_goto: None,
             herdr: None,
             our_workspace_id: None,
             base_branch,
@@ -725,7 +732,7 @@ impl Controller {
                 .unwrap_or_default(),
             branch: self.current_branch.clone(),
             prompt: self.prompt.as_ref().map(|p| match p.mode {
-                crate::infile::PromptMode::GoToLine => format!(":{}", p.input.query()),
+                crate::infile::PromptMode::GoToLine => format!("Go to line: {}", p.input.query()),
             }),
         }
     }
@@ -1807,19 +1814,21 @@ impl Controller {
         self.finder.is_some()
     }
 
-    /// Open the go-to-line prompt (AC-1) — but only in a source-mapped (syntax/content) view, where a
-    /// source line maps 1:1 to a display row. In a transformed view (RenderedMarkdown / Diff /
-    /// FullDiff, or nothing selected) there is no source-line→row map, so emit a one-line unavailable
-    /// notice and open nothing (AC-7). Snapshots the current content scroll into the prompt state.
+    /// Open the go-to-line prompt (AC-1). Opens whenever a **file** is selected, in any view: in a
+    /// source-mapped (SyntaxContent) view the confirm jumps directly; in a transformed view
+    /// (RenderedMarkdown / Diff / FullDiff) — where a source line has no 1:1 display row — the confirm
+    /// switches this file to the source-mapped content view and jumps once it re-renders (AC-7). With
+    /// nothing / a directory selected there is no file to address, so emit a one-line notice and open
+    /// nothing. Snapshots the current content scroll into the prompt state.
     fn open_go_to_line(&mut self) -> Effects {
-        if self.selected_view_mode() == Some(ViewMode::SyntaxContent) {
+        if self.selected_view_mode().is_some() {
             self.prompt = Some(PromptState {
                 mode: PromptMode::GoToLine,
                 input: crate::prompt::PromptInput::new(),
                 saved_scroll: self.content_scroll,
             });
         } else {
-            self.action_notice = Some("Go to line is unavailable in this view".into());
+            self.action_notice = Some("Go to line: select a file first".into());
         }
         Effects::redraw()
     }
@@ -1827,6 +1836,13 @@ impl Controller {
     /// Whether an in-file-nav bottom prompt is currently open.
     pub fn prompt_open(&self) -> bool {
         self.prompt.is_some()
+    }
+
+    /// The pending auto-switch go-to-line target (1-based source line), or `None`. Set when `:`
+    /// confirms in a transformed view (the jump waits for the source-mapped re-render); cleared by
+    /// `poll` once that render lands and the jump applies (AC-7). Exposed for tests.
+    pub fn pending_goto_line(&self) -> Option<usize> {
+        self.pending_goto.map(|(_, line)| line)
     }
 
     /// The current go-to-line prompt buffer, or `""` when no prompt is open. Exposed for tests
@@ -1886,7 +1902,18 @@ impl Controller {
                     // parse failure can only be an overflow → treat as "beyond the last line";
                     // scroll_to_line clamps usize::MAX to the last line (AC-4).
                     let n = q.parse::<usize>().unwrap_or(usize::MAX);
-                    self.scroll_to_line(n); // AC-3 / AC-4
+                    if self.selected_view_mode() == Some(ViewMode::SyntaxContent) {
+                        // Already source-mapped: the content is current, jump synchronously (AC-3).
+                        self.scroll_to_line(n);
+                    } else if let Some(path) = self.tree.selected().map(|n| n.path.clone()) {
+                        // Transformed view (markdown / diff): a source line has no display row here,
+                        // so switch this file to the source-mapped content view and jump once the
+                        // re-render lands (AC-7). The new content renders off-thread, so the jump is
+                        // queued against the dispatched render's seq and applied by `poll`.
+                        self.overrides.insert(path, ViewMode::SyntaxContent);
+                        self.dispatch_render();
+                        self.pending_goto = Some((self.latest_seq, n));
+                    }
                 }
                 Effects::redraw()
             }
@@ -2118,6 +2145,10 @@ impl Controller {
         // previous file's scroll offsets.
         self.content_scroll = 0;
         self.content_hscroll = 0;
+        // A new render supersedes any queued go-to-line jump from an OLDER render (e.g. the user
+        // navigated away before an auto-switch render landed). The auto-switch path sets its own
+        // `pending_goto` AFTER calling this, so its jump survives; only stale ones are cleared.
+        self.pending_goto = None;
 
         let Some(node) = self.tree.selected() else {
             return self.clear_content();
@@ -2155,6 +2186,14 @@ impl Controller {
                 self.content = result.content;
                 self.content_notices = result.notices;
                 applied = true;
+                // A queued go-to-line jump (auto-switch from a transformed view, AC-7) applies once
+                // ITS render lands: now that the source-mapped content is in, scroll to the line.
+                if let Some((pseq, line)) = self.pending_goto
+                    && pseq == seq
+                {
+                    self.scroll_to_line(line);
+                    self.pending_goto = None;
+                }
             }
             // else: a superseded selection's render — drop it.
         }

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -724,6 +724,9 @@ impl Controller {
                 .map(|s| s.to_string_lossy().into_owned())
                 .unwrap_or_default(),
             branch: self.current_branch.clone(),
+            prompt: self.prompt.as_ref().map(|p| match p.mode {
+                crate::infile::PromptMode::GoToLine => format!(":{}", p.input.query()),
+            }),
         }
     }
 

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -1826,6 +1826,75 @@ impl Controller {
         self.prompt.is_some()
     }
 
+    /// The current go-to-line prompt buffer, or `""` when no prompt is open. Exposed for tests
+    /// (AC-2) and the Presenter's bottom prompt line (T-4). Mirrors `finder_query()`.
+    pub fn prompt_query(&self) -> &str {
+        self.prompt.as_ref().map(|p| p.input.query()).unwrap_or("")
+    }
+
+    /// Route a key event while a bottom-prompt modal is open. The run loop (T-4) calls this
+    /// instead of the normal key→intent map while `prompt_open()`. Dispatches by the prompt's
+    /// mode. (AC-2…AC-6)
+    pub fn handle_prompt_key(&mut self, key: KeyEvent) -> Effects {
+        // `PromptMode` is `Copy`; read it and drop the borrow before the per-mode handler runs.
+        let Some(mode) = self.prompt.as_ref().map(|p| p.mode) else {
+            return Effects::noop();
+        };
+        match mode {
+            PromptMode::GoToLine => self.go_to_line_key(key),
+        }
+    }
+
+    /// Go-to-line prompt key handling: digits build the line number, non-digit printables are
+    /// ignored (AC-2); Backspace deletes; Enter jumps (clamped, AC-3/AC-4) or — when empty —
+    /// just closes with no jump (AC-5); Esc closes leaving the scroll unchanged (AC-6). Confirm
+    /// and cancel both close the prompt. Go-to-line is not incremental, so the content scroll
+    /// only ever moves on a non-empty Enter.
+    fn go_to_line_key(&mut self, key: KeyEvent) -> Effects {
+        match key.code {
+            // Only accept ASCII digits with no modifier other than SHIFT (consistent with the
+            // finder's printable-char gate).
+            KeyCode::Char(c)
+                if c.is_ascii_digit()
+                    && key.modifiers.difference(KeyModifiers::SHIFT).is_empty() =>
+            {
+                if let Some(p) = self.prompt.as_mut() {
+                    p.input.push(c);
+                }
+                Effects::redraw()
+            }
+            // A non-digit printable is ignored — the buffer is unchanged, no repaint. (AC-2)
+            KeyCode::Char(_) => Effects::noop(),
+            KeyCode::Backspace => {
+                if let Some(p) = self.prompt.as_mut() {
+                    p.input.backspace();
+                }
+                Effects::redraw()
+            }
+            KeyCode::Enter => {
+                let q = self
+                    .prompt
+                    .as_ref()
+                    .map(|p| p.input.query().to_string())
+                    .unwrap_or_default();
+                self.prompt = None; // confirm always closes (AC-5 empty also closes)
+                if !q.is_empty() {
+                    // The buffer holds only ASCII digits (non-digits are rejected above), so a
+                    // parse failure can only be an overflow → treat as "beyond the last line";
+                    // scroll_to_line clamps usize::MAX to the last line (AC-4).
+                    let n = q.parse::<usize>().unwrap_or(usize::MAX);
+                    self.scroll_to_line(n); // AC-3 / AC-4
+                }
+                Effects::redraw()
+            }
+            KeyCode::Esc => {
+                self.prompt = None; // cancel: close, scroll unchanged (AC-6)
+                Effects::redraw()
+            }
+            _ => Effects::noop(),
+        }
+    }
+
     /// The full candidate list loaded when the finder was opened, or an empty slice when
     /// the finder is closed. Exposed for tests (T-5); the Presenter/T-8 read via `finder()`.
     pub fn finder_candidates(&self) -> &[String] {

--- a/src/infile.rs
+++ b/src/infile.rs
@@ -1,0 +1,21 @@
+//! In-file navigation modal state — the bottom-prompt modal (go-to-line now; search added in a
+//! later phase). Ephemeral, in-memory only (AC-N3).
+
+use crate::prompt::PromptInput;
+
+/// Which in-file-nav prompt is open.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PromptMode {
+    /// Jump the content pane to a source line by number (`:`).
+    GoToLine,
+}
+
+/// State for the open bottom-prompt modal: the mode, the editable buffer, and the content scroll
+/// snapshot taken when the prompt opened (for Esc-restore in the incremental search added later;
+/// go-to-line never scrolls while typing, so its Esc simply closes).
+#[derive(Debug)]
+pub struct PromptState {
+    pub mode: PromptMode,
+    pub input: PromptInput,
+    pub saved_scroll: u16,
+}

--- a/src/input.rs
+++ b/src/input.rs
@@ -30,6 +30,7 @@ pub fn map_key(key: KeyEvent) -> Option<Intent> {
         KeyCode::Char('v') => Some(Intent::CycleView),
         KeyCode::Char('e') => Some(Intent::OpenInEditor),
         KeyCode::Char('f') => Some(Intent::OpenFinder),
+        KeyCode::Char(':') => Some(Intent::OpenGoToLine),
         KeyCode::Char('y') => Some(Intent::CopyRepoPath),
         KeyCode::Char('Y') => Some(Intent::CopyAbsPath),
         KeyCode::Char('W') => Some(Intent::SwitchWorktree),
@@ -72,6 +73,7 @@ mod tests {
         (KeyCode::Char('v'), Intent::CycleView),
         (KeyCode::Char('e'), Intent::OpenInEditor),
         (KeyCode::Char('f'), Intent::OpenFinder),
+        (KeyCode::Char(':'), Intent::OpenGoToLine),
         (KeyCode::Char('y'), Intent::CopyRepoPath),
         (KeyCode::Char('Y'), Intent::CopyAbsPath),
         (KeyCode::Char('W'), Intent::SwitchWorktree),
@@ -184,6 +186,21 @@ mod tests {
         );
         assert_eq!(
             map_key(KeyEvent::new(KeyCode::Char('f'), KeyModifiers::ALT)),
+            None
+        );
+    }
+
+    #[test]
+    fn colon_maps_to_open_go_to_line_and_modifier_chords_are_inert() {
+        // `:` opens the go-to-line prompt (AC-1, AC-N6). Ctrl-: / Alt-: must not fire an intent.
+        // (Shift is allowed — `:` is a shifted char on many layouts — so do not assert Shift is None.)
+        assert_eq!(map_key(k(KeyCode::Char(':'))), Some(Intent::OpenGoToLine));
+        assert_eq!(
+            map_key(KeyEvent::new(KeyCode::Char(':'), KeyModifiers::CONTROL)),
+            None
+        );
+        assert_eq!(
+            map_key(KeyEvent::new(KeyCode::Char(':'), KeyModifiers::ALT)),
             None
         );
     }

--- a/src/intent.rs
+++ b/src/intent.rs
@@ -66,6 +66,12 @@ pub enum Intent {
     /// typing a fuzzy query. Read-only — it navigates the viewer's selection; it never
     /// modifies any file (AC-1, AC-N1, AC-N3).
     OpenFinder,
+    /// Open the go-to-line prompt to scroll the content pane to a source line by number.
+    /// Read-only navigation — it only moves the in-pane scroll; no file or git mutation
+    /// (AC-1, AC-N1). Available only in a source-mapped (syntax/content) view; in a
+    /// transformed view it shows an unavailable notice and opens nothing (AC-7). Opened only
+    /// by the explicit `:` key — no event hook (AC-N6).
+    OpenGoToLine,
     /// Close the viewer and return control to the prior pane (AC-20).
     Close,
 }
@@ -73,7 +79,7 @@ pub enum Intent {
 impl Intent {
     /// Every intent variant — lets the dispatcher and tests enumerate the closed set so
     /// keyboard-completeness (AC-18) and the no-edit invariant (AC-N3) stay checkable.
-    pub const ALL: [Intent; 23] = [
+    pub const ALL: [Intent; 24] = [
         Intent::NavUp,
         Intent::NavDown,
         Intent::Expand,
@@ -96,6 +102,7 @@ impl Intent {
         Intent::DismissUpdate,
         Intent::SwitchWorktree,
         Intent::OpenFinder,
+        Intent::OpenGoToLine,
         Intent::Close,
     ];
 }
@@ -135,6 +142,7 @@ mod tests {
                 | Intent::DismissUpdate
                 | Intent::SwitchWorktree
                 | Intent::OpenFinder
+                | Intent::OpenGoToLine
                 | Intent::Close => false,
             };
             assert!(
@@ -167,6 +175,14 @@ mod tests {
         assert!(
             Intent::ALL.contains(&Intent::OpenFinder),
             "Intent::ALL must contain OpenFinder"
+        );
+    }
+
+    #[test]
+    fn open_go_to_line_is_in_all() {
+        assert!(
+            Intent::ALL.contains(&Intent::OpenGoToLine),
+            "Intent::ALL must contain OpenGoToLine"
         );
     }
 }

--- a/src/intent.rs
+++ b/src/intent.rs
@@ -68,9 +68,11 @@ pub enum Intent {
     OpenFinder,
     /// Open the go-to-line prompt to scroll the content pane to a source line by number.
     /// Read-only navigation — it only moves the in-pane scroll; no file or git mutation
-    /// (AC-1, AC-N1). Available only in a source-mapped (syntax/content) view; in a
-    /// transformed view it shows an unavailable notice and opens nothing (AC-7). Opened only
-    /// by the explicit `:` key — no event hook (AC-N6).
+    /// (AC-1, AC-N1). Opens for any selected **file**, in every view: in a source-mapped
+    /// (syntax/content) view the jump is immediate; in a transformed view (rendered-markdown /
+    /// diff / full-diff) confirming auto-switches the file to the source-mapped view and jumps
+    /// once it re-renders (AC-7, revised). With nothing / a directory selected it shows a notice
+    /// and opens nothing. Opened only by the explicit `:` key — no event hook (AC-N6).
     OpenGoToLine,
     /// Close the viewer and return control to the prior pane (AC-20).
     Close,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod git;
 pub mod herdr;
 pub mod host;
 pub mod index;
+pub mod infile;
 pub mod input;
 pub mod intent;
 pub mod launch;

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -82,8 +82,8 @@ pub struct ViewState {
     /// `None` ⇒ no overlay.
     pub finder: Option<FinderView>,
     /// When `Some`, a one-row prompt is drawn across the very bottom of the viewer showing the active
-    /// in-file-nav prompt (e.g. `:42` for go-to-line). `None` ⇒ no prompt open. The Controller builds
-    /// the display string (mode lead + buffer) so the Presenter stays mode-agnostic. (AC-1)
+    /// in-file-nav prompt (e.g. `Go to line: 42`). `None` ⇒ no prompt open. The Controller builds the
+    /// display string (label + buffer) so the Presenter stays mode-agnostic. (AC-1)
     pub prompt: Option<String>,
     /// The tree root's directory basename (e.g. `"herdr-plugin"`), shown as the tree column's
     /// top-border title so the user can see *which* directory the tree is rooted at — mirroring
@@ -585,7 +585,7 @@ fn body_footer_prompt(area: Rect, state: &ViewState) -> (Rect, Option<Rect>, Opt
     (body, banner, prompt)
 }
 
-/// Draw the one-row bottom prompt (`:42` / later `/term`). Sanitized (AC-27) and clipped to its row.
+/// Draw the one-row bottom prompt (`Go to line: 42` / later search). Sanitized (AC-27), clipped to its row.
 fn draw_prompt_line(frame: &mut Frame, area: Rect, prompt: &str) {
     let line = Line::styled(
         sanitize_label(prompt),

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -81,6 +81,10 @@ pub struct ViewState {
     /// When `Some`, the go-to-file finder overlay is drawn on top of the columns (AC-1).
     /// `None` ⇒ no overlay.
     pub finder: Option<FinderView>,
+    /// When `Some`, a one-row prompt is drawn across the very bottom of the viewer showing the active
+    /// in-file-nav prompt (e.g. `:42` for go-to-line). `None` ⇒ no prompt open. The Controller builds
+    /// the display string (mode lead + buffer) so the Presenter stays mode-agnostic. (AC-1)
+    pub prompt: Option<String>,
     /// The tree root's directory basename (e.g. `"herdr-plugin"`), shown as the tree column's
     /// top-border title so the user can see *which* directory the tree is rooted at — mirroring
     /// how the content pane titles itself from the selected node. Truncated with an ellipsis if
@@ -566,6 +570,30 @@ fn draw_update_footer(frame: &mut Frame, area: Rect, banner: &str) {
     frame.render_widget(Paragraph::new(line), area);
 }
 
+/// Carve the optional one-row bottom prompt off the very bottom, then the optional update-banner
+/// footer off what remains (so the prompt sits below the banner). Reuses [`body_and_footer`] for
+/// the banner so a frame with NO prompt lays out exactly as before. Shared by [`draw`] and
+/// [`geometry`] so the body rect they use can never disagree.
+fn body_footer_prompt(area: Rect, state: &ViewState) -> (Rect, Option<Rect>, Option<Rect>) {
+    let (above_prompt, prompt) = if state.prompt.is_some() && area.height >= 2 {
+        let parts = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(area);
+        (parts[0], Some(parts[1]))
+    } else {
+        (area, None)
+    };
+    let (body, banner) = body_and_footer(above_prompt, state);
+    (body, banner, prompt)
+}
+
+/// Draw the one-row bottom prompt (`:42` / later `/term`). Sanitized (AC-27) and clipped to its row.
+fn draw_prompt_line(frame: &mut Frame, area: Rect, prompt: &str) {
+    let line = Line::styled(
+        sanitize_label(prompt),
+        Style::new().fg(Color::Black).bg(Color::Gray),
+    );
+    frame.render_widget(Paragraph::new(line), area);
+}
+
 /// Below this pane width the viewer drops to a single, focused column (AC-21).
 const NARROW_SPLIT: u16 = 80;
 
@@ -652,7 +680,7 @@ pub struct PaneGeometry {
 /// renders, so a click is never mapped against stale geometry. The interior of a bordered
 /// block is its area inset by one cell on each side (the title does not change it).
 pub fn geometry(area: Rect, state: &ViewState) -> PaneGeometry {
-    let (body, _footer) = body_and_footer(area, state);
+    let (body, _footer, _prompt) = body_footer_prompt(area, state);
     let (tree, content, divider_x) = columns(body, state);
     let inner = |r: Rect| Block::bordered().inner(r);
 
@@ -751,9 +779,12 @@ pub fn geometry(area: Rect, state: &ViewState) -> PaneGeometry {
 /// taken from the **live frame width** (via [`columns`]), so it can never disagree with the
 /// geometry it is drawn into (a stale `state.width` cannot desync the layout).
 pub fn draw(frame: &mut Frame, state: &ViewState) -> (u16, u16) {
-    let (body, footer) = body_and_footer(frame.area(), state);
+    let (body, footer, prompt_area) = body_footer_prompt(frame.area(), state);
     if let (Some(area), Some(banner)) = (footer, state.update_banner.as_deref()) {
         draw_update_footer(frame, area, banner);
+    }
+    if let (Some(area), Some(prompt)) = (prompt_area, state.prompt.as_deref()) {
+        draw_prompt_line(frame, area, prompt);
     }
     let (tree, content, _divider) = columns(body, state);
     if let Some(area) = tree {

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -4705,10 +4705,10 @@ fn open_go_to_line_opens_the_prompt_in_a_source_mapped_view() {
 }
 
 #[test]
-fn open_go_to_line_is_unavailable_in_transformed_views() {
-    // AC-7: in a transformed view (RenderedMarkdown, Diff, FullDiff) the prompt must NOT open;
-    // instead an unavailable notice is set and scroll is unchanged.
-    // Also covers gate finding L2: FullDiff must be treated as non-source-mapped.
+fn open_go_to_line_opens_the_prompt_in_transformed_views_too() {
+    // AC-7 (revised): `:` opens the prompt whenever a FILE is selected — in a transformed view
+    // (RenderedMarkdown, Diff, FullDiff) too. No "unavailable" notice; the view is NOT switched yet
+    // (the switch happens on confirm — see the jump test below). Covers gate finding L2 (FullDiff).
 
     // --- RenderedMarkdown ---
     {
@@ -4721,16 +4721,21 @@ fn open_go_to_line_is_unavailable_in_transformed_views() {
             Some(ViewMode::RenderedMarkdown),
             "precondition: a .md file is in RenderedMarkdown"
         );
-        let _fx = ctrl.handle(Intent::OpenGoToLine);
+        ctrl.handle(Intent::OpenGoToLine);
         assert!(
-            !ctrl.prompt_open(),
-            "AC-7: prompt must NOT open in RenderedMarkdown"
+            ctrl.prompt_open(),
+            "AC-7: `:` opens the prompt in RenderedMarkdown"
         );
         assert!(
-            ctrl.action_notice().is_some(),
-            "AC-7: unavailable notice set in RenderedMarkdown"
+            ctrl.action_notice().is_none(),
+            "no unavailable notice — the prompt opens"
         );
-        assert_eq!(ctrl.content_scroll(), 0, "scroll unchanged");
+        assert_eq!(
+            ctrl.selected_view_mode(),
+            Some(ViewMode::RenderedMarkdown),
+            "the view is unchanged until confirm"
+        );
+        assert_eq!(ctrl.content_scroll(), 0, "scroll unchanged on open");
     }
 
     // --- Diff ---
@@ -4751,13 +4756,13 @@ fn open_go_to_line_is_unavailable_in_transformed_views() {
             Some(ViewMode::Diff),
             "precondition: a changed .rs file is in Diff"
         );
-        let _fx = ctrl.handle(Intent::OpenGoToLine);
-        assert!(!ctrl.prompt_open(), "AC-7: prompt must NOT open in Diff");
+        ctrl.handle(Intent::OpenGoToLine);
+        assert!(ctrl.prompt_open(), "AC-7: `:` opens the prompt in Diff");
         assert!(
-            ctrl.action_notice().is_some(),
-            "AC-7: unavailable notice set in Diff"
+            ctrl.action_notice().is_none(),
+            "no unavailable notice in Diff"
         );
-        assert_eq!(ctrl.content_scroll(), 0, "scroll unchanged");
+        assert_eq!(ctrl.content_scroll(), 0, "scroll unchanged on open");
     }
 
     // --- FullDiff (gate finding L2) ---
@@ -4773,29 +4778,21 @@ fn open_go_to_line_is_unavailable_in_transformed_views() {
         };
         let (mut ctrl, _, _) = controller(dir.path(), true, git, false);
 
-        // Diff → (CycleView) → FullDiff
-        assert_eq!(
-            ctrl.selected_view_mode(),
-            Some(ViewMode::Diff),
-            "precondition: a changed file starts in Diff"
-        );
-        ctrl.handle(Intent::CycleView);
+        ctrl.handle(Intent::CycleView); // Diff → FullDiff
         assert_eq!(
             ctrl.selected_view_mode(),
             Some(ViewMode::FullDiff),
             "precondition: one CycleView reaches FullDiff"
         );
-
-        let _fx = ctrl.handle(Intent::OpenGoToLine);
+        ctrl.handle(Intent::OpenGoToLine);
         assert!(
-            !ctrl.prompt_open(),
-            "AC-7 / gate L2: prompt must NOT open in FullDiff"
+            ctrl.prompt_open(),
+            "AC-7 / gate L2: `:` opens the prompt in FullDiff"
         );
         assert!(
-            ctrl.action_notice().is_some(),
-            "AC-7 / gate L2: unavailable notice set in FullDiff"
+            ctrl.action_notice().is_none(),
+            "no unavailable notice in FullDiff"
         );
-        assert_eq!(ctrl.content_scroll(), 0, "scroll unchanged");
     }
 }
 
@@ -4955,5 +4952,89 @@ fn open_go_to_line_is_unavailable_when_no_file_is_selected() {
     assert!(
         ctrl.action_notice().is_some(),
         "AC-7 edge: an unavailable notice is set when a directory is selected"
+    );
+}
+
+/// A git controller whose single file `file` is reported CHANGED (so its default view is Diff, a
+/// transformed view), with `n` numbered lines of content — for exercising the go-to-line auto-switch
+/// from a transformed view to the source-mapped content view.
+fn changed_controller_with_lines(root: &Path, file: &str, n: usize) -> Controller {
+    let mut changed = BTreeMap::new();
+    changed.insert(PathBuf::from(file), Status::Modified);
+    let git = StubGit {
+        status: changed.clone(),
+        changed,
+        ..StubGit::default()
+    };
+    let git: Arc<dyn GitService> = Arc::new(git);
+    let components = Components {
+        providers: Box::new(move |_resolved| RootProviders {
+            git: Arc::clone(&git),
+            content: Box::new(LinesContent { n }),
+        }),
+        editor: Box::new(StubEditor {
+            fail: false,
+            opened: Arc::new(Mutex::new(Vec::new())),
+        }),
+        clipboard: Box::new(common::RecordingClipboard::default()),
+    };
+    Controller::new(
+        common::resolved(root.to_path_buf(), true),
+        Baseline::Head,
+        components,
+    )
+}
+
+#[test]
+fn go_to_line_in_a_transformed_view_switches_to_content_and_jumps() {
+    // AC-7 (revised): confirming `:N` in a transformed view (here Diff) switches the file to the
+    // source-mapped content view and jumps to source line N once the re-render lands.
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.txt"), "x\n").unwrap();
+    let mut ctrl = changed_controller_with_lines(dir.path(), "a.txt", 50);
+    await_marker(&mut ctrl, "L0"); // initial render (changed → Diff; LinesContent ignores mode)
+    ctrl.set_content_viewport(40, 10); // 50 lines, 10 tall → max_content_scroll = 40
+
+    assert_eq!(
+        ctrl.selected_view_mode(),
+        Some(ViewMode::Diff),
+        "precondition: the changed file is in Diff (a transformed view)"
+    );
+
+    // Open the prompt (opens in any view), type 25, Enter.
+    ctrl.handle(Intent::OpenGoToLine);
+    assert!(ctrl.prompt_open());
+    for c in "25".chars() {
+        ctrl.handle_prompt_key(key(KeyCode::Char(c)));
+    }
+    ctrl.handle_prompt_key(key(KeyCode::Enter));
+
+    // Confirm auto-switched the view to source-mapped content and queued the jump for the re-render.
+    assert!(!ctrl.prompt_open(), "Enter closes the prompt");
+    assert_eq!(
+        ctrl.selected_view_mode(),
+        Some(ViewMode::SyntaxContent),
+        "AC-7: confirm auto-switched to the source-mapped content view"
+    );
+    assert_eq!(
+        ctrl.pending_goto_line(),
+        Some(25),
+        "the jump is queued against the dispatched re-render"
+    );
+
+    // Pump poll() until the queued render lands and the jump applies.
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while ctrl.pending_goto_line().is_some() {
+        ctrl.poll();
+        assert!(
+            Instant::now() < deadline,
+            "the auto-switch jump never applied"
+        );
+        std::thread::sleep(Duration::from_millis(5));
+    }
+    assert_eq!(
+        ctrl.content_scroll(),
+        24,
+        "after the switch render, jumped to line 25 (offset 24)"
     );
 }

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -5038,3 +5038,219 @@ fn go_to_line_in_a_transformed_view_switches_to_content_and_jumps() {
         "after the switch render, jumped to line 25 (offset 24)"
     );
 }
+
+// review-gate Round 1 — regression tests for the findings fixed in R1.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mouse_is_inert_while_the_go_to_line_prompt_is_open() {
+    // R1 (HIGH, 5 models): the go-to-line prompt is keyboard-only and modal — the run loop routes
+    // only KEY events to it. Without a guard in handle_mouse, a click/wheel would still reach the
+    // tree beneath and change the selection, so a subsequent Enter would jump/auto-switch the WRONG
+    // file. The mouse must be inert while the prompt is open (mirroring the picker's modal guard).
+    let dir = TempDir::new();
+    for i in 0..6 {
+        std::fs::write(dir.path().join(format!("f{i:02}.txt")), "x\n").unwrap();
+    }
+    let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
+    ctrl.set_pane_geometry(wide_geometry());
+    assert_eq!(ctrl.tree().cursor(), 0, "cursor starts on f00.txt");
+
+    ctrl.handle(Intent::OpenGoToLine);
+    assert!(ctrl.prompt_open(), "prompt opens on the selected file");
+
+    // A left click on another tree row (row 4 → visible node 3) must be swallowed.
+    let fx = ctrl.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 6, 4));
+    assert!(
+        !fx.redraw,
+        "a click under an open prompt is inert (no redraw)"
+    );
+    assert_eq!(
+        ctrl.tree().cursor(),
+        0,
+        "the click must NOT move the selection while the prompt is open"
+    );
+    assert!(
+        ctrl.prompt_open(),
+        "the prompt stays open after an inert click"
+    );
+
+    // A scroll-wheel over the tree is inert too.
+    let fx = ctrl.handle_mouse(mouse(MouseEventKind::ScrollDown, 6, 3));
+    assert!(!fx.redraw, "a scroll under an open prompt is inert");
+    assert_eq!(
+        ctrl.tree().cursor(),
+        0,
+        "scroll does not move the selection under the prompt"
+    );
+}
+
+/// A content provider for the go-to-line wrap test: 5 long, space-free lines (`W0…`, 25 cols → 3
+/// rows each at width 10) then 5 short lines (`S5`..`S9`, 1 row each). With wrap on, source line 6
+/// (`S5`) sits at display row 15, not row 5 — so the wrap-aware mapping and the naive `line-1`
+/// disagree, which is exactly what the test pins down.
+struct WrapLines;
+impl ContentProvider for WrapLines {
+    fn render(&self, _path: &Path, _mode: ViewMode, _raw_diff: Option<&str>) -> RenderResult {
+        let mut lines: Vec<String> = (0..5).map(|i| format!("W{i}{}", "x".repeat(23))).collect();
+        lines.extend((5..10).map(|i| format!("S{i}")));
+        RenderResult {
+            content: Text::raw(lines.join("\n")),
+            notices: Vec::new(),
+        }
+    }
+}
+
+fn controller_with_wrap_lines(root: &Path) -> Controller {
+    let components = Components {
+        providers: Box::new(move |_resolved| RootProviders {
+            git: Arc::new(StubGit::default()),
+            content: Box::new(WrapLines),
+        }),
+        editor: Box::new(StubEditor {
+            fail: false,
+            opened: Arc::new(Mutex::new(Vec::new())),
+        }),
+        clipboard: Box::new(common::RecordingClipboard::default()),
+    };
+    Controller::new(
+        common::resolved(root.to_path_buf(), false),
+        Baseline::Head,
+        components,
+    )
+}
+
+#[test]
+fn go_to_line_maps_source_line_to_wrapped_row_offset_when_wrap_is_on() {
+    // R1 (MEDIUM, 4 models): with the `w` wrap override on, a source line no longer maps 1:1 to a
+    // display row — earlier long lines wrap into several rows. `:N` must land on source line N (its
+    // cumulative wrapped-row offset), not display row N-1, or the target falls off-screen. (AC-3
+    // under wrap.) 5 W-lines × 3 rows = 15, so source line 6 (the first S-line) is at row 15.
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.txt"), "x\n").unwrap();
+    let mut ctrl = controller_with_wrap_lines(dir.path());
+    await_marker(&mut ctrl, "S9"); // 5 long (W) + 5 short (S) lines rendered
+    ctrl.set_content_viewport(10, 5); // width 10 → each 25-char W line wraps to 3 rows
+
+    // Wrap OFF: source line 6 maps 1:1 → display row 5.
+    ctrl.scroll_to_line(6);
+    assert_eq!(
+        ctrl.content_scroll(),
+        5,
+        "wrap off: source line 6 = display row 5 (1:1)"
+    );
+
+    // Wrap ON (the `w` key): the 5 W-lines each occupy 3 rows, so source line 6 sits at row 15.
+    ctrl.handle(Intent::ToggleWrap);
+    ctrl.scroll_to_line(6);
+    assert_eq!(
+        ctrl.content_scroll(),
+        15,
+        "wrap on: source line 6 lands at its wrapped-row offset (15), not display row 5"
+    );
+    assert_ne!(
+        ctrl.content_scroll(),
+        5,
+        "the wrap-aware mapping must differ from the naive line-1"
+    );
+}
+
+#[test]
+fn go_to_line_queues_the_jump_when_a_source_render_is_still_in_flight() {
+    // R1 (MEDIUM): if a source file's render hasn't landed yet, selected_view_mode() reports
+    // SyntaxContent from the path while self.content is still stale. Confirming `:N` must NOT clamp
+    // against the stale content — it queues against the in-flight render (applied_seq != latest_seq)
+    // and the jump applies once that render lands.
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.txt"), "x\n").unwrap();
+    let mut ctrl = controller_with_lines(dir.path(), 50);
+    // Deliberately do NOT await_marker: the initial render is still in flight.
+    ctrl.set_content_viewport(40, 10);
+    assert_eq!(
+        ctrl.selected_view_mode(),
+        Some(ViewMode::SyntaxContent),
+        "source-mapped by path even before its render lands"
+    );
+
+    ctrl.handle(Intent::OpenGoToLine);
+    for c in "25".chars() {
+        ctrl.handle_prompt_key(key(KeyCode::Char(c)));
+    }
+    ctrl.handle_prompt_key(key(KeyCode::Enter));
+    assert_eq!(
+        ctrl.pending_goto_line(),
+        Some(25),
+        "the jump is queued against the in-flight render, not clamped against stale content"
+    );
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while ctrl.pending_goto_line().is_some() {
+        ctrl.poll();
+        assert!(Instant::now() < deadline, "the queued jump never applied");
+        std::thread::sleep(Duration::from_millis(5));
+    }
+    assert_eq!(
+        ctrl.content_scroll(),
+        24,
+        "after the render lands, jumped to line 25 (offset 24)"
+    );
+}
+
+#[test]
+fn go_to_line_second_confirm_supersedes_an_in_flight_auto_switch_jump() {
+    // R1 (MEDIUM): confirming `:` in a transformed view auto-switches (override → Syntax) and queues
+    // a jump against the switch render; selected_view_mode() then reports SyntaxContent immediately.
+    // A SECOND confirm before that render lands must WIN — the older queued line must not overwrite
+    // it when the render arrives.
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.txt"), "x\n").unwrap();
+    let mut ctrl = changed_controller_with_lines(dir.path(), "a.txt", 50);
+    await_marker(&mut ctrl, "L0"); // initial Diff render landed
+    ctrl.set_content_viewport(40, 10);
+    assert_eq!(
+        ctrl.selected_view_mode(),
+        Some(ViewMode::Diff),
+        "starts in a transformed view"
+    );
+
+    // First confirm — :10 → auto-switch + queue (render in flight).
+    ctrl.handle(Intent::OpenGoToLine);
+    for c in "10".chars() {
+        ctrl.handle_prompt_key(key(KeyCode::Char(c)));
+    }
+    ctrl.handle_prompt_key(key(KeyCode::Enter));
+    assert_eq!(
+        ctrl.pending_goto_line(),
+        Some(10),
+        "first confirm queued line 10"
+    );
+    assert_eq!(
+        ctrl.selected_view_mode(),
+        Some(ViewMode::SyntaxContent),
+        "auto-switched the view (override)"
+    );
+
+    // Second confirm BEFORE polling — :30 must supersede the queued 10.
+    ctrl.handle(Intent::OpenGoToLine);
+    for c in "30".chars() {
+        ctrl.handle_prompt_key(key(KeyCode::Char(c)));
+    }
+    ctrl.handle_prompt_key(key(KeyCode::Enter));
+    assert_eq!(
+        ctrl.pending_goto_line(),
+        Some(30),
+        "the second confirm supersedes the queued jump (30, not 10)"
+    );
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while ctrl.pending_goto_line().is_some() {
+        ctrl.poll();
+        assert!(Instant::now() < deadline, "the queued jump never applied");
+        std::thread::sleep(Duration::from_millis(5));
+    }
+    assert_eq!(
+        ctrl.content_scroll(),
+        29,
+        "lands on line 30 (offset 29) — the LAST confirm wins, not line 10"
+    );
+}

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -4675,3 +4675,126 @@ fn ac_n6_open_finder_intent_does_open_the_finder() {
         "AC-N6: Intent::OpenFinder must open the finder"
     );
 }
+
+#[test]
+fn open_go_to_line_opens_the_prompt_in_a_source_mapped_view() {
+    // AC-1: in a source-mapped (SyntaxContent) view, OpenGoToLine opens the prompt.
+    // An unchanged, non-markdown .rs file renders as SyntaxContent (the policy default).
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.rs"), "fn main() {}\n").unwrap();
+    let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
+
+    assert_eq!(
+        ctrl.selected_view_mode(),
+        Some(ViewMode::SyntaxContent),
+        "precondition: an unchanged .rs file is in SyntaxContent"
+    );
+    assert!(!ctrl.prompt_open(), "prompt starts closed");
+
+    let fx = ctrl.handle(Intent::OpenGoToLine);
+    assert!(
+        ctrl.prompt_open(),
+        "AC-1: prompt opens in a source-mapped view"
+    );
+    assert!(fx.redraw, "opening the prompt signals a redraw");
+    assert_eq!(ctrl.content_scroll(), 0, "content scroll unchanged");
+    assert!(
+        ctrl.action_notice().is_none(),
+        "no unavailable notice in a source-mapped view"
+    );
+}
+
+#[test]
+fn open_go_to_line_is_unavailable_in_transformed_views() {
+    // AC-7: in a transformed view (RenderedMarkdown, Diff, FullDiff) the prompt must NOT open;
+    // instead an unavailable notice is set and scroll is unchanged.
+    // Also covers gate finding L2: FullDiff must be treated as non-source-mapped.
+
+    // --- RenderedMarkdown ---
+    {
+        let dir = TempDir::new();
+        std::fs::write(dir.path().join("notes.md"), "# Hello\n").unwrap();
+        let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
+
+        assert_eq!(
+            ctrl.selected_view_mode(),
+            Some(ViewMode::RenderedMarkdown),
+            "precondition: a .md file is in RenderedMarkdown"
+        );
+        let _fx = ctrl.handle(Intent::OpenGoToLine);
+        assert!(
+            !ctrl.prompt_open(),
+            "AC-7: prompt must NOT open in RenderedMarkdown"
+        );
+        assert!(
+            ctrl.action_notice().is_some(),
+            "AC-7: unavailable notice set in RenderedMarkdown"
+        );
+        assert_eq!(ctrl.content_scroll(), 0, "scroll unchanged");
+    }
+
+    // --- Diff ---
+    {
+        let dir = TempDir::new();
+        std::fs::write(dir.path().join("changed.rs"), "fn main() {}\n").unwrap();
+        let mut changed = BTreeMap::new();
+        changed.insert(PathBuf::from("changed.rs"), Status::Modified);
+        let git = StubGit {
+            status: changed.clone(),
+            changed,
+            ..StubGit::default()
+        };
+        let (mut ctrl, _, _) = controller(dir.path(), true, git, false);
+
+        assert_eq!(
+            ctrl.selected_view_mode(),
+            Some(ViewMode::Diff),
+            "precondition: a changed .rs file is in Diff"
+        );
+        let _fx = ctrl.handle(Intent::OpenGoToLine);
+        assert!(!ctrl.prompt_open(), "AC-7: prompt must NOT open in Diff");
+        assert!(
+            ctrl.action_notice().is_some(),
+            "AC-7: unavailable notice set in Diff"
+        );
+        assert_eq!(ctrl.content_scroll(), 0, "scroll unchanged");
+    }
+
+    // --- FullDiff (gate finding L2) ---
+    {
+        let dir = TempDir::new();
+        std::fs::write(dir.path().join("changed.rs"), "fn main() {}\n").unwrap();
+        let mut changed = BTreeMap::new();
+        changed.insert(PathBuf::from("changed.rs"), Status::Modified);
+        let git = StubGit {
+            status: changed.clone(),
+            changed,
+            ..StubGit::default()
+        };
+        let (mut ctrl, _, _) = controller(dir.path(), true, git, false);
+
+        // Diff → (CycleView) → FullDiff
+        assert_eq!(
+            ctrl.selected_view_mode(),
+            Some(ViewMode::Diff),
+            "precondition: a changed file starts in Diff"
+        );
+        ctrl.handle(Intent::CycleView);
+        assert_eq!(
+            ctrl.selected_view_mode(),
+            Some(ViewMode::FullDiff),
+            "precondition: one CycleView reaches FullDiff"
+        );
+
+        let _fx = ctrl.handle(Intent::OpenGoToLine);
+        assert!(
+            !ctrl.prompt_open(),
+            "AC-7 / gate L2: prompt must NOT open in FullDiff"
+        );
+        assert!(
+            ctrl.action_notice().is_some(),
+            "AC-7 / gate L2: unavailable notice set in FullDiff"
+        );
+        assert_eq!(ctrl.content_scroll(), 0, "scroll unchanged");
+    }
+}

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -659,6 +659,41 @@ fn nav_scrolls_the_content_pane_when_focused_and_clamps_both_ends() {
 }
 
 #[test]
+fn scroll_to_line_brings_the_target_line_into_view_and_clamps_out_of_range() {
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.txt"), "x\n").unwrap();
+    let mut ctrl = controller_with_lines(dir.path(), 50);
+    await_marker(&mut ctrl, "L0");
+    ctrl.set_content_viewport(40, 10); // 50 lines, 10 tall → max_content_scroll = 40
+
+    // a line already near the top: line 1 lands at the top
+    ctrl.scroll_to_line(1);
+    assert_eq!(ctrl.content_scroll(), 0, "line 1 at the top");
+
+    // a mid-file line lands near the top (offset = line-1), still well within the clamp
+    ctrl.scroll_to_line(25);
+    let off = ctrl.content_scroll();
+    assert!(
+        off <= 24 && 24 < off + 10,
+        "line 25 is within the 10-row viewport"
+    );
+    assert_eq!(off, 24, "lands the target near the top");
+
+    // below 1 clamps to line 1 (AC-4)
+    ctrl.scroll_to_line(0);
+    assert_eq!(ctrl.content_scroll(), 0, "0 clamps to line 1");
+
+    // above the last clamps to the last line → last screenful (AC-4); line 50 still visible
+    ctrl.scroll_to_line(1000);
+    let off = ctrl.content_scroll();
+    assert_eq!(off, 40, "beyond the last line shows the last screenful");
+    assert!(
+        off <= 49 && 49 < off + 10,
+        "the last line (50) is within the viewport"
+    );
+}
+
+#[test]
 fn selecting_a_different_file_resets_the_scroll_to_the_top() {
     let dir = TempDir::new();
     std::fs::write(dir.path().join("a.txt"), "x\n").unwrap();

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -4798,3 +4798,162 @@ fn open_go_to_line_is_unavailable_in_transformed_views() {
         assert_eq!(ctrl.content_scroll(), 0, "scroll unchanged");
     }
 }
+
+// T-3 — Go-to-line keystroke + confirm + cancel (AC-2..AC-6, AC-7 edge)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn go_to_line_builds_the_number_from_digits_and_ignores_non_digits() {
+    // AC-2: digit keys push to the buffer; non-digit printables are silently ignored.
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.txt"), "x\n").unwrap();
+    let mut ctrl = controller_with_lines(dir.path(), 50);
+    await_marker(&mut ctrl, "L0");
+    ctrl.set_content_viewport(40, 10);
+    ctrl.handle(Intent::OpenGoToLine);
+    assert!(ctrl.prompt_open());
+
+    ctrl.handle_prompt_key(key(KeyCode::Char('4')));
+    ctrl.handle_prompt_key(key(KeyCode::Char('a'))); // non-digit: ignored
+    ctrl.handle_prompt_key(key(KeyCode::Char('2')));
+    assert_eq!(
+        ctrl.prompt_query(),
+        "42",
+        "digits build the number, non-digits ignored"
+    );
+    // Backspace deletes the last digit
+    ctrl.handle_prompt_key(key(KeyCode::Backspace));
+    assert_eq!(ctrl.prompt_query(), "4");
+}
+
+#[test]
+fn go_to_line_enter_jumps_to_the_line_and_clamps_out_of_range() {
+    // AC-3: Enter with a valid line number scrolls the content to that line (near the top).
+    // AC-4: a line number beyond the last line is clamped to the last screenful.
+    // 50 lines, viewport 10 → max_content_scroll = 40.
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.txt"), "x\n").unwrap();
+    let mut ctrl = controller_with_lines(dir.path(), 50);
+    await_marker(&mut ctrl, "L0");
+    ctrl.set_content_viewport(40, 10);
+
+    // Jump to line 25 (1-based): content_scroll should be 24 (line 25 near top).
+    ctrl.handle(Intent::OpenGoToLine);
+    assert!(ctrl.prompt_open());
+    ctrl.handle_prompt_key(key(KeyCode::Char('2')));
+    ctrl.handle_prompt_key(key(KeyCode::Char('5')));
+    ctrl.handle_prompt_key(key(KeyCode::Enter));
+    assert!(!ctrl.prompt_open(), "Enter closes the prompt");
+    assert_eq!(
+        ctrl.content_scroll(),
+        24,
+        "line 25 lands at offset 24 (near top, AC-3)"
+    );
+
+    // Re-open and type "1000" — beyond the last line → clamped to max_content_scroll (40, AC-4).
+    ctrl.handle(Intent::OpenGoToLine);
+    assert!(ctrl.prompt_open());
+    for c in "1000".chars() {
+        ctrl.handle_prompt_key(key(KeyCode::Char(c)));
+    }
+    ctrl.handle_prompt_key(key(KeyCode::Enter));
+    assert!(
+        !ctrl.prompt_open(),
+        "Enter closes the prompt after out-of-range"
+    );
+    assert_eq!(
+        ctrl.content_scroll(),
+        40,
+        "out-of-range clamps to last screenful (AC-4)"
+    );
+}
+
+#[test]
+fn go_to_line_empty_enter_closes_without_jumping() {
+    // AC-5: Enter with an empty buffer closes the prompt and leaves the scroll unchanged.
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.txt"), "x\n").unwrap();
+    let mut ctrl = controller_with_lines(dir.path(), 50);
+    await_marker(&mut ctrl, "L0");
+    ctrl.set_content_viewport(40, 10);
+
+    ctrl.handle(Intent::OpenGoToLine);
+    assert!(ctrl.prompt_open());
+    assert_eq!(ctrl.content_scroll(), 0, "scroll starts at 0");
+
+    // Enter with no digits typed: close, no scroll.
+    ctrl.handle_prompt_key(key(KeyCode::Enter));
+    assert!(!ctrl.prompt_open(), "empty Enter closes the prompt (AC-5)");
+    assert_eq!(
+        ctrl.content_scroll(),
+        0,
+        "scroll unchanged on empty Enter (AC-5)"
+    );
+}
+
+#[test]
+fn go_to_line_esc_closes_without_jumping() {
+    // AC-6: Esc closes the prompt and leaves content_scroll unchanged.
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.txt"), "x\n").unwrap();
+    let mut ctrl = controller_with_lines(dir.path(), 50);
+    await_marker(&mut ctrl, "L0");
+    ctrl.set_content_viewport(40, 10);
+
+    ctrl.handle(Intent::OpenGoToLine);
+    assert!(ctrl.prompt_open());
+    // Type some digits to prove Esc discards them.
+    ctrl.handle_prompt_key(key(KeyCode::Char('3')));
+    ctrl.handle_prompt_key(key(KeyCode::Char('7')));
+    assert_eq!(ctrl.prompt_query(), "37");
+    ctrl.handle_prompt_key(key(KeyCode::Esc));
+    assert!(!ctrl.prompt_open(), "Esc closes the prompt (AC-6)");
+    assert_eq!(ctrl.content_scroll(), 0, "scroll unchanged on Esc (AC-6)");
+}
+
+#[test]
+fn open_go_to_line_is_unavailable_when_no_file_is_selected() {
+    // AC-7 edge: when the cursor sits on a directory, selected_view_mode() is None →
+    // open_go_to_line fires the unavailable notice and leaves the prompt closed.
+    // Build a tree whose first (and only non-hidden) node is a subdirectory.
+    // The tree lists alphabetically: "adir/" sorts before any file we might add,
+    // and since the cursor starts at index 0, the first node (the directory) is selected.
+    let dir = TempDir::new();
+    std::fs::create_dir(dir.path().join("adir")).unwrap();
+    // Add a file so the controller_with_lines render worker has something to render,
+    // but the tree cursor starts at "adir/" (index 0, a directory).
+    std::fs::write(dir.path().join("z.txt"), "content\n").unwrap();
+
+    // Use the plain `controller()` helper (not controller_with_lines) — we only need
+    // the directory-selection behaviour, not a specific rendered line count.
+    let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
+
+    // Confirm the first visible node is a directory (precondition).
+    let nodes = ctrl.tree().visible_nodes();
+    assert!(
+        !nodes.is_empty(),
+        "tree must have at least one visible node"
+    );
+    let first = &nodes[0];
+    assert_eq!(
+        first.path.file_name().unwrap().to_str().unwrap(),
+        "adir",
+        "precondition: first node is the subdirectory"
+    );
+    // Cursor starts at 0 → the directory is selected → selected_view_mode() is None.
+    assert_eq!(
+        ctrl.selected_view_mode(),
+        None,
+        "precondition: directory has no view mode"
+    );
+
+    ctrl.handle(Intent::OpenGoToLine);
+    assert!(
+        !ctrl.prompt_open(),
+        "AC-7 edge: prompt must NOT open when a directory is selected"
+    );
+    assert!(
+        ctrl.action_notice().is_some(),
+        "AC-7 edge: an unavailable notice is set when a directory is selected"
+    );
+}

--- a/tests/e2e_keyboard.rs
+++ b/tests/e2e_keyboard.rs
@@ -282,3 +282,108 @@ fn worktree_picker_switches_root_by_keyboard_and_exits_cleanly() {
         other => panic!("expected a clean exit, got {other:?}"),
     }
 }
+
+/// T-5 — go-to-line e2e: `:` opens the line-number prompt on a source-mapped (SyntaxContent) file;
+/// typing a line number and Enter scrolls the content to that line (AC-3 jump + AC-21 routing);
+/// pressing `:` on a RenderedMarkdown file shows the "unavailable" notice without opening a prompt
+/// (AC-7).
+///
+/// Routing proof (AC-21): after opening the prompt with `:`, we send `j` (NavDown in the normal
+/// viewer key-map) and then `40`. If routing were broken, `j` would move the tree cursor onto
+/// `notes.md`, and the subsequent jump would target the wrong file — so `DEEPMARKER` (source line
+/// 40 of `long.txt`) would never appear.
+///
+/// Anchor robustness: the content pane is `bat`-rendered with a line-number gutter, and ratatui
+/// redraws only changed cells — so a marker whose characters coincidentally match the cells it
+/// overwrites gets split across cursor-move escapes in the pty stream (an earlier `DEEPMARK040`
+/// fragmented because its trailing `0` matched). `DEEPMARKER` is **all letters** and the filler
+/// lines are `L<NN>`, so every column of the marker differs from whatever sat there before the
+/// scroll → ratatui writes the row in one contiguous run and `expect("DEEPMARKER")` is reliable.
+/// `DEEPMARKER` is on line 40, below the initial viewport, so it only appears after the jump.
+#[test]
+fn go_to_line_jumps_to_a_source_line_and_is_unavailable_in_markdown() {
+    let dir = TempDir::new();
+    let p = dir.path();
+    init_repo_with_commit(p);
+
+    // long.txt: 60 lines. Line 1 = TOPMARK001 (launch anchor, drawn into blank cells); line 40 =
+    // DEEPMARKER (the jump target, all-letters so it redraws contiguously); every other line is
+    // a short `L<NN>` filler that differs from DEEPMARKER in every column.
+    let mut lines = Vec::with_capacity(60);
+    for i in 1u32..=60 {
+        if i == 1 {
+            lines.push("TOPMARK001".to_string());
+        } else if i == 40 {
+            lines.push("DEEPMARKER".to_string());
+        } else {
+            lines.push(format!("L{i:02}"));
+        }
+    }
+    std::fs::write(p.join("long.txt"), lines.join("\n") + "\n").unwrap();
+
+    // notes.md: RenderedMarkdown view-mode → `:` is unavailable.
+    std::fs::write(p.join("notes.md"), "# MDHEADERMARK\nSome note text.\n").unwrap();
+
+    // Commit both so view-policy picks the right modes: long.txt → SyntaxContent (`:` works);
+    // notes.md → RenderedMarkdown (`:` unavailable). `long.txt` sorts before `notes.md`, so the
+    // cursor starts on long.txt at launch.
+    git(p, &["add", "long.txt", "notes.md"]);
+    git(p, &["commit", "-q", "-m", "go-to-line test files"]);
+
+    let mut cmd = viewer_command(p);
+    cmd.env("EDITOR", "true");
+    let mut s = Session::spawn(cmd).expect("spawn the viewer in a pty");
+    s.set_expect_timeout(Some(Duration::from_secs(15)));
+
+    // Step 1: initial draw — tree lists long.txt, its top content is shown.
+    s.expect("long.txt")
+        .expect("tree should list long.txt on launch");
+    s.expect("TOPMARK001")
+        .expect("long.txt top content should be visible on launch");
+
+    // Step 2: open the go-to-line prompt (long.txt is SyntaxContent, so `:` opens it). Give the
+    // event loop a beat to open the prompt before the next key, so `j` lands inside the prompt and
+    // not as a NavDown on the tree.
+    s.send(":").expect("send `:` to open the go-to-line prompt");
+    std::thread::sleep(Duration::from_millis(300));
+
+    // Step 3: AC-21 routing proof — `j` (NavDown in normal mode) must be swallowed by the open
+    // prompt (a non-digit, ignored), NOT navigate the tree.
+    s.send("j")
+        .expect("send `j` — must be swallowed by the prompt, not fire NavDown");
+
+    // Step 4: type the line number. The prompt now holds "40" (j was ignored).
+    s.send("40").expect("send the line-number digits");
+
+    // Step 5: confirm — the content scrolls so source line 40 (DEEPMARKER) is visible. This is the
+    // AC-3 jump proof AND confirms AC-21 routing: if `j` had escaped the prompt and selected
+    // notes.md, there would be no DEEPMARKER to show.
+    s.send("\r").expect("send Enter to confirm the jump");
+    s.expect("DEEPMARKER").expect(
+        "AC-3/AC-21: after Enter the content pane scrolls to source line 40 (DEEPMARKER visible)",
+    );
+
+    // Step 6: AC-7 live — the prompt is closed and focus is still the tree; `j` now NavDowns onto
+    // notes.md (RenderedMarkdown), where `:` must show the unavailable notice and open no prompt.
+    s.send("j").expect("send NavDown to move to notes.md");
+    s.expect("MDHEADERMARK")
+        .expect("notes.md is now selected and its content is shown");
+    s.send(":").expect("send `:` on the markdown file");
+    s.expect("unavailable")
+        .expect("AC-7: `:` on a RenderedMarkdown file shows the unavailable notice");
+
+    // Step 7: clean exit (no prompt is open on the markdown file). The Esc-no-jump path is proven
+    // rigorously by the T-3 unit tests; this e2e covers the live routing/jump/notice flow.
+    s.send("q").expect("send close");
+    s.expect(Eof)
+        .expect("the viewer terminates cleanly after the go-to-line flow");
+    match s.get_process().wait().expect("reap the viewer") {
+        WaitStatus::Exited(_, code) => {
+            assert_eq!(
+                code, 0,
+                "AC-21/AC-3/AC-7: no go-to-line key crashed the viewer"
+            )
+        }
+        other => panic!("expected a clean exit, got {other:?}"),
+    }
+}

--- a/tests/e2e_keyboard.rs
+++ b/tests/e2e_keyboard.rs
@@ -363,17 +363,22 @@ fn go_to_line_jumps_to_a_source_line_and_is_unavailable_in_markdown() {
         "AC-3/AC-21: after Enter the content pane scrolls to source line 40 (DEEPMARKER visible)",
     );
 
-    // Step 6: AC-7 live — the prompt is closed and focus is still the tree; `j` now NavDowns onto
-    // notes.md (RenderedMarkdown), where `:` must show the unavailable notice and open no prompt.
+    // Step 6: AC-7 (revised) live — go-to-line now opens in EVERY view. The prompt is closed and
+    // focus is still the tree; `j` NavDowns onto notes.md (RenderedMarkdown), where `:` opens the
+    // prompt (its "Go to line:" label appears) rather than the old "unavailable" notice. The notes.md
+    // content pane has blank rows below its two lines, so the freshly-reserved prompt row writes the
+    // label into previously-blank cells — a robust pty anchor. (The switch-then-jump on confirm is
+    // proven rigorously by the controller unit test; here we prove the prompt opens in markdown.)
     s.send("j").expect("send NavDown to move to notes.md");
     s.expect("MDHEADERMARK")
         .expect("notes.md is now selected and its content is shown");
     s.send(":").expect("send `:` on the markdown file");
-    s.expect("unavailable")
-        .expect("AC-7: `:` on a RenderedMarkdown file shows the unavailable notice");
+    s.expect("Go to line:")
+        .expect("AC-7: `:` opens the go-to-line prompt even in a rendered-markdown view");
 
-    // Step 7: clean exit (no prompt is open on the markdown file). The Esc-no-jump path is proven
-    // rigorously by the T-3 unit tests; this e2e covers the live routing/jump/notice flow.
+    // Step 7: Esc closes the prompt (otherwise the prompt would swallow the quit key), then exit.
+    s.send("\u{1b}").expect("send Esc to close the prompt");
+    std::thread::sleep(Duration::from_millis(150));
     s.send("q").expect("send close");
     s.expect(Eof)
         .expect("the viewer terminates cleanly after the go-to-line flow");

--- a/tests/e2e_keyboard.rs
+++ b/tests/e2e_keyboard.rs
@@ -285,8 +285,8 @@ fn worktree_picker_switches_root_by_keyboard_and_exits_cleanly() {
 
 /// T-5 — go-to-line e2e: `:` opens the line-number prompt on a source-mapped (SyntaxContent) file;
 /// typing a line number and Enter scrolls the content to that line (AC-3 jump + AC-21 routing);
-/// pressing `:` on a RenderedMarkdown file shows the "unavailable" notice without opening a prompt
-/// (AC-7).
+/// pressing `:` on a RenderedMarkdown file ALSO opens the prompt (AC-7 revised — it opens in every
+/// view; the switch-then-jump on confirm is proven by the controller unit test).
 ///
 /// Routing proof (AC-21): after opening the prompt with `:`, we send `j` (NavDown in the normal
 /// viewer key-map) and then `40`. If routing were broken, `j` would move the tree cursor onto
@@ -301,7 +301,7 @@ fn worktree_picker_switches_root_by_keyboard_and_exits_cleanly() {
 /// scroll → ratatui writes the row in one contiguous run and `expect("DEEPMARKER")` is reliable.
 /// `DEEPMARKER` is on line 40, below the initial viewport, so it only appears after the jump.
 #[test]
-fn go_to_line_jumps_to_a_source_line_and_is_unavailable_in_markdown() {
+fn go_to_line_jumps_to_a_source_line_and_opens_in_markdown_too() {
     let dir = TempDir::new();
     let p = dir.path();
     init_repo_with_commit(p);
@@ -321,12 +321,12 @@ fn go_to_line_jumps_to_a_source_line_and_is_unavailable_in_markdown() {
     }
     std::fs::write(p.join("long.txt"), lines.join("\n") + "\n").unwrap();
 
-    // notes.md: RenderedMarkdown view-mode → `:` is unavailable.
+    // notes.md: RenderedMarkdown view-mode → `:` opens the prompt too (AC-7 revised).
     std::fs::write(p.join("notes.md"), "# MDHEADERMARK\nSome note text.\n").unwrap();
 
-    // Commit both so view-policy picks the right modes: long.txt → SyntaxContent (`:` works);
-    // notes.md → RenderedMarkdown (`:` unavailable). `long.txt` sorts before `notes.md`, so the
-    // cursor starts on long.txt at launch.
+    // Commit both so view-policy picks the right modes: long.txt → SyntaxContent (`:` jumps in-place);
+    // notes.md → RenderedMarkdown (`:` opens, confirm auto-switches). `long.txt` sorts before
+    // `notes.md`, so the cursor starts on long.txt at launch.
     git(p, &["add", "long.txt", "notes.md"]);
     git(p, &["commit", "-q", "-m", "go-to-line test files"]);
 

--- a/tests/presenter.rs
+++ b/tests/presenter.rs
@@ -2349,7 +2349,7 @@ fn finder_geometry_exposes_the_scrollbar_track_only_when_rows_overflow() {
     );
 }
 
-// ── T-4: bottom prompt line (AC-1) + unavailable-notice path (AC-7) ──────────
+// ── T-4: bottom prompt line (AC-1) + no-file-notice path (AC-7) ──────────────
 
 #[test]
 fn an_open_go_to_line_prompt_renders_a_bottom_line() {
@@ -2391,15 +2391,16 @@ fn no_prompt_open_leaves_layout_unchanged() {
 }
 
 #[test]
-fn unavailable_notice_renders_for_ac7() {
-    // AC-7: when go-to-line is invoked on a non-text view (e.g. diff or binary), the controller
-    // emits an action notice. This test verifies the Presenter surfaces that notice in the content
-    // area — the existing notices channel renders it without any new code paths.
+fn go_to_line_no_file_notice_renders_for_ac7() {
+    // AC-7 (revised): the ONLY go-to-line notice is the no-file case — `:` with a directory / nothing
+    // selected emits "Go to line: select a file first" and opens no prompt. (A transformed view no
+    // longer shows an "unavailable" notice — confirming there auto-switches and jumps.) This verifies
+    // the Presenter surfaces that notice via the existing notices channel, with no new code path.
     let mut st = sample_state();
-    st.notices = vec!["Go to line is unavailable in this view".into()];
+    st.notices = vec!["Go to line: select a file first".into()];
     let out = render(&st, 100, 24);
     assert!(
-        out.contains("Go to line is unavailable in this view"),
-        "unavailable notice (AC-7) must appear in the rendered frame\n{out}"
+        out.contains("Go to line: select a file first"),
+        "the no-file go-to-line notice (AC-7) must appear in the rendered frame\n{out}"
     );
 }

--- a/tests/presenter.rs
+++ b/tests/presenter.rs
@@ -2353,12 +2353,12 @@ fn finder_geometry_exposes_the_scrollbar_track_only_when_rows_overflow() {
 
 #[test]
 fn an_open_go_to_line_prompt_renders_a_bottom_line() {
-    // AC-1: when a prompt is open (`ViewState.prompt = Some(":42")`), the Presenter draws a
-    // one-row line at the very bottom of the frame showing the prompt string.
+    // AC-1: when a prompt is open (`ViewState.prompt = Some("Go to line: 42")`), the Presenter draws
+    // a one-row line at the very bottom of the frame showing the prompt string.
     let mut st = sample_state();
     st.update_banner = None; // no banner — prompt is the sole bottom row
-    st.prompt = Some(":42".into());
-    // Render at a known size; the bottom row (row h-1) must contain ":42".
+    st.prompt = Some("Go to line: 42".into());
+    // Render at a known size; the bottom row (row h-1) must contain the prompt label + number.
     let (w, h) = (100u16, 24u16);
     let out = render(&st, w, h);
     let last_row = out
@@ -2366,8 +2366,8 @@ fn an_open_go_to_line_prompt_renders_a_bottom_line() {
         .last()
         .expect("at least one row in the rendered output");
     assert!(
-        last_row.contains(":42"),
-        "the last row must contain ':42' when a prompt is open\n{out}"
+        last_row.contains("Go to line: 42"),
+        "the last row must contain 'Go to line: 42' when a prompt is open\n{out}"
     );
     // The two-column layout is still drawn above the prompt row.
     assert!(
@@ -2382,10 +2382,10 @@ fn no_prompt_open_leaves_layout_unchanged() {
     // body_footer_prompt falls through to body_and_footer with no prompt row reserved.
     let st = sample_state(); // prompt: None (set by the sample_state helper)
     let out_no_prompt = render(&st, 100, 24);
-    // The bottom row must NOT contain ":" followed by digits (no phantom prompt).
+    // The bottom row must NOT contain the go-to-line prompt label (no phantom prompt).
     let last_row = out_no_prompt.lines().last().expect("at least one row");
     assert!(
-        !last_row.contains(":42"),
+        !last_row.contains("Go to line:"),
         "no prompt row rendered when prompt is None\n{out_no_prompt}"
     );
 }

--- a/tests/presenter.rs
+++ b/tests/presenter.rs
@@ -78,6 +78,7 @@ fn sample_state() -> ViewState {
         finder: None,
         root_name: "r".to_string(), // the fixture tree is rooted at /r
         branch: None,
+        prompt: None,
     }
 }
 
@@ -2345,5 +2346,60 @@ fn finder_geometry_exposes_the_scrollbar_track_only_when_rows_overflow() {
     assert!(
         geometry(area, &small).finder_vbar.is_none(),
         "geometry().finder_vbar must be None when every match row fits"
+    );
+}
+
+// ── T-4: bottom prompt line (AC-1) + unavailable-notice path (AC-7) ──────────
+
+#[test]
+fn an_open_go_to_line_prompt_renders_a_bottom_line() {
+    // AC-1: when a prompt is open (`ViewState.prompt = Some(":42")`), the Presenter draws a
+    // one-row line at the very bottom of the frame showing the prompt string.
+    let mut st = sample_state();
+    st.update_banner = None; // no banner — prompt is the sole bottom row
+    st.prompt = Some(":42".into());
+    // Render at a known size; the bottom row (row h-1) must contain ":42".
+    let (w, h) = (100u16, 24u16);
+    let out = render(&st, w, h);
+    let last_row = out
+        .lines()
+        .last()
+        .expect("at least one row in the rendered output");
+    assert!(
+        last_row.contains(":42"),
+        "the last row must contain ':42' when a prompt is open\n{out}"
+    );
+    // The two-column layout is still drawn above the prompt row.
+    assert!(
+        out.contains("fn main()"),
+        "content still shows above the prompt line\n{out}"
+    );
+}
+
+#[test]
+fn no_prompt_open_leaves_layout_unchanged() {
+    // AC-1 (negative): with `prompt: None` the layout is byte-identical to the pre-T-4 baseline —
+    // body_footer_prompt falls through to body_and_footer with no prompt row reserved.
+    let st = sample_state(); // prompt: None (set by the sample_state helper)
+    let out_no_prompt = render(&st, 100, 24);
+    // The bottom row must NOT contain ":" followed by digits (no phantom prompt).
+    let last_row = out_no_prompt.lines().last().expect("at least one row");
+    assert!(
+        !last_row.contains(":42"),
+        "no prompt row rendered when prompt is None\n{out_no_prompt}"
+    );
+}
+
+#[test]
+fn unavailable_notice_renders_for_ac7() {
+    // AC-7: when go-to-line is invoked on a non-text view (e.g. diff or binary), the controller
+    // emits an action notice. This test verifies the Presenter surfaces that notice in the content
+    // area — the existing notices channel renders it without any new code paths.
+    let mut st = sample_state();
+    st.notices = vec!["Go to line is unavailable in this view".into()];
+    let out = render(&st, 100, 24);
+    assert!(
+        out.contains("Go to line is unavailable in this view"),
+        "unavailable notice (AC-7) must appear in the rendered frame\n{out}"
     );
 }

--- a/tests/presenter_narrow.rs
+++ b/tests/presenter_narrow.rs
@@ -46,6 +46,7 @@ fn state(width: u16, focus: Focus) -> ViewState {
         finder: None,
         root_name: "r".to_string(), // the fixture tree is rooted at /r
         branch: None,
+        prompt: None,
     }
 }
 


### PR DESCRIPTION
## In-file navigation — Phase 1: **Go to line** (`:`)

First half of the in-file-navigation feature (Linear project *In-file navigation*). **Staged build:** this PR ships **go-to-line only**; in-file search (`/`, `n`/`N`) follows as PR #2.

### What & why
The viewer can move *between* files (tree, and the `f` finder) but had no way to navigate *within* the open file. This adds the universal `:N` primitive: press `:`, type a line number, `Enter` jumps the content pane there.

### Behavior
- `:` opens a one-line **bottom prompt**; digits build the number, non-digits are ignored, `Backspace` edits.
- `Enter` jumps so the target source line is visible (landed near the top); **out-of-range clamps** to the last line; **empty `Enter`** closes with no jump; `Esc` cancels (scroll unchanged).
- **View-gated:** available only in the **source-mapped** (syntax/content) view, where a source line maps 1:1 to a display row. In rendered-markdown / diff / full-diff (or with nothing selected) it shows a one-line *"unavailable"* notice and opens nothing — honest about the absent line→row map (see ADR-0006).
- Fully **read-only** — pure in-memory navigation; no file/git mutation, no persistent state, no event hook (opens only on the explicit `:` key).

### Acceptance criteria covered
- **AC-1** open prompt (source-mapped) · **AC-2** digit entry · **AC-3** jump visible · **AC-4** 1-based, clamp out-of-range · **AC-5** empty-Enter no-op · **AC-6** Esc no-op · **AC-7** unavailable+notice in transformed views (incl. `FullDiff`)
- **AC-21** (go-to-line portion) prompt keys don't fire viewer intents · **AC-N6** no event/auto trigger

### Tasks → commits
| Task | Commit | Advances |
|---|---|---|
| T-1 content `scroll_to_line` | `f3e43dc` | AC-3, AC-4 |
| T-2 `OpenGoToLine` intent + `:` key + view-gated open | `f1ffce3` | AC-1, AC-7, AC-N6 |
| T-3 keystroke + confirm + cancel | `1a3aa6f` | AC-2, AC-3, AC-4, AC-5, AC-6 |
| T-4 event-loop routing + Presenter bottom prompt | `0e0a6e2` | AC-1, AC-7 |
| T-5 pty e2e | `f9f36d1` | AC-21 |
| docs (README/CHANGELOG/ARCHITECTURE) | `1a229a1` | — |

New modules: `src/infile.rs` (prompt-modal state). Reuses go-to-file's `src/prompt.rs` `PromptInput` and the `app.rs` modal raw-key routing.

### Tests
Unit (`intent`, `input`), integration (`controller` — open/gate/clamp/empty/Esc/directory-edge), Presenter (bottom-prompt render + AC-7 notice, **zero snapshot churn**), and a pty **e2e** (`:`+`j`-swallowed+`40`→jump; `:` on markdown→unavailable). **469 tests pass**; clippy `-D` / fmt / release all clean.

### Notes for the reviewer
- **No deferred shortcuts / `SHORTCUT(T-N)` ceilings** recorded by the build.
- This branch's base includes the docs-backfill #53 (go-to-file + tree-title), merged to `main` first so docs stay consistent.
- The full spec chain (Brief / AC / Design / Tech Stack / Plan / gate-report) lives in the Linear project *In-file navigation* and in `specs/in-file-navigation/` (local-only/gitignored); ADR-0006 records the search-over-displayed-content + view-gated-go-to-line decision.
- **Merge is owner-gated** — please don't auto-merge.
