### PR TITLE
refactor(M6): controller.rs consolidation + Modal enum (PR 1 of 2)

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -1367,6 +1367,9 @@ impl Controller {
         if span == 0 || total == 0 {
             return Effects::noop();
         }
+        // Its own mapping, not the shared `track_to_offset`: with a single match the finder maps a
+        // drag to index 0 and selects it, whereas `track_to_offset` no-ops at a zero range — a
+        // deliberate difference for the modal list, so the rounding stays inline here.
         let max = (total - 1) as u32;
         let idx = ((rel * max + span / 2) / span) as usize;
         finder.set_cursor(idx);
@@ -1595,6 +1598,21 @@ impl Controller {
         (rel, len.saturating_sub(1) as u32)
     }
 
+    /// Map a press/drag at `pos` on a scrollbar track `[start, start + len)` onto an offset in
+    /// `[0, max]`, rounded to the nearest integer. `None` (the caller no-ops) when the mapping is
+    /// degenerate — a 1-cell track (`span == 0`) or a zero range (`max == 0`). The single
+    /// track→offset rounding rule every linear scrollbar drag shares: a vertical bar passes the
+    /// row + track `y`/`height`, a horizontal bar the col + track `x`/`width`. (The finder maps a
+    /// drag to a *match index* and intentionally differs at the degenerate boundary, so it keeps
+    /// its own mapping — see `finder_scroll_to_row`.)
+    fn track_to_offset(pos: u16, start: u16, len: u16, max: u32) -> Option<u32> {
+        let (rel, span) = Self::track_fraction(pos, start, len);
+        if span == 0 || max == 0 {
+            return None;
+        }
+        Some((rel * max + span / 2) / span)
+    }
+
     /// Map a vertical press/drag on the content scrollbar track to a content scroll offset. The
     /// track is the fed-back `content_vbar` rect; the fraction maps linearly onto
     /// `[0, max_content_scroll]`, rounded to the nearest line. No-op without overflow.
@@ -1602,12 +1620,12 @@ impl Controller {
         let Some(track) = self.geom.content_vbar else {
             return Effects::noop();
         };
-        let max = self.max_content_scroll();
-        let (rel, span) = Self::track_fraction(row, track.y, track.height);
-        if span == 0 || max == 0 {
+        let Some(off) =
+            Self::track_to_offset(row, track.y, track.height, self.max_content_scroll() as u32)
+        else {
             return Effects::noop();
-        }
-        self.content_scroll = ((rel * max as u32 + span / 2) / span) as u16;
+        };
+        self.content_scroll = off as u16;
         Effects::redraw()
     }
 
@@ -1616,12 +1634,12 @@ impl Controller {
         let Some(track) = self.geom.content_hbar else {
             return Effects::noop();
         };
-        let max = self.max_content_hscroll();
-        let (rel, span) = Self::track_fraction(col, track.x, track.width);
-        if span == 0 || max == 0 {
+        let Some(off) =
+            Self::track_to_offset(col, track.x, track.width, self.max_content_hscroll() as u32)
+        else {
             return Effects::noop();
-        }
-        self.content_hscroll = ((rel * max as u32 + span / 2) / span) as u16;
+        };
+        self.content_hscroll = off as u16;
         Effects::redraw()
     }
 
@@ -1631,11 +1649,10 @@ impl Controller {
             return Effects::noop();
         };
         let max = self.geom.tree_content_width.saturating_sub(track.width);
-        let (rel, span) = Self::track_fraction(col, track.x, track.width);
-        if span == 0 || max == 0 {
+        let Some(off) = Self::track_to_offset(col, track.x, track.width, max as u32) else {
             return Effects::noop();
-        }
-        self.tree_hscroll = ((rel * max as u32 + span / 2) / span) as u16;
+        };
+        self.tree_hscroll = off as u16;
         Effects::redraw()
     }
 
@@ -1647,11 +1664,14 @@ impl Controller {
             return Effects::noop();
         };
         let len = self.tree.visible_nodes().len();
-        let (rel, span) = Self::track_fraction(row, track.y, track.height);
-        if span == 0 || len <= 1 {
+        // `max = len - 1` (the last index): a 1-cell track or a list of ≤ 1 node yields `None` here,
+        // exactly the old `span == 0 || len <= 1` no-op.
+        let Some(idx) =
+            Self::track_to_offset(row, track.y, track.height, len.saturating_sub(1) as u32)
+        else {
             return Effects::noop();
-        }
-        let idx = ((rel * (len as u32 - 1) + span / 2) / span) as usize;
+        };
+        let idx = idx as usize;
         self.focus = Focus::Tree;
         // A drag fires many events on the same row; only re-select (and re-render the content, an
         // expensive job) when the target actually changes, so a held scrub doesn't re-render the

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -1801,15 +1801,12 @@ impl Controller {
     /// the display-row offset of a source line), so the scroll clamp and the go-to-line target are
     /// computed by the SAME wrapping logic and therefore always agree (AC-3/AC-4).
     fn wrapped_rows_before(&self, n: usize) -> usize {
-        let w = self.content_width.max(1) as usize;
+        let w = self.content_width as usize;
         self.content
             .lines
             .iter()
             .take(n)
-            .map(|l| {
-                let text: String = l.spans.iter().map(|s| s.content.as_ref()).collect();
-                crate::text_layout::wrapped_rows(&text, w).max(l.width().max(1).div_ceil(w))
-            })
+            .map(|l| crate::text_layout::line_wrapped_rows(l, w))
             .sum::<usize>()
     }
 

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -2347,10 +2347,14 @@ impl Controller {
         self.modal.help()
     }
 
-    /// Dismiss the help overlay. Called by handle_help_key on Esc/`q`.
-    /// A no-op when the overlay is already closed.
+    /// Dismiss the help overlay. A no-op when help is not the open modal — so this clears ONLY the
+    /// help overlay, never some other modal that happens to be open (matching the old per-field
+    /// `self.help = None`, which was inert unless help was actually open). The match guard keeps
+    /// that contract now that the four modal slots share one `modal` field.
     pub fn close_help(&mut self) {
-        self.modal = Modal::None;
+        if matches!(self.modal, Modal::Help(_)) {
+            self.modal = Modal::None;
+        }
     }
 
     /// Route a key event while the help overlay is open (AC-2, AC-3, AC-7, AC-8, AC-9, AC-20).
@@ -2372,8 +2376,8 @@ impl Controller {
         if key.modifiers.difference(KeyModifiers::SHIFT) != KeyModifiers::NONE {
             return Effects::noop();
         }
-        // Read the last-known help-body geometry up front (the borrow of `self.help` below is
-        // exclusive), so the scroll-down arm can clamp eagerly against it.
+        // Read the last-known help-body geometry up front (the `self.modal.help_mut()` borrow below
+        // is exclusive), so the scroll-down arm can clamp eagerly against it.
         let (help_body_rows, help_body_height) =
             (self.geom.help_body_rows, self.geom.help_body_height);
         let Some(help) = self.modal.help_mut() else {

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -227,6 +227,79 @@ struct RenderJob {
 /// the `poll` that applies them.
 type StatusResult = (BTreeMap<PathBuf, Status>, BTreeMap<PathBuf, Status>);
 
+/// The single open modal overlay, or [`Modal::None`] when the columns have focus. Collapses what
+/// were four parallel `Option<…State>` fields (picker / finder / prompt / help) into one value, so
+/// "at most one modal is open at a time" is enforced by the type rather than by hand: opening any
+/// modal (`self.modal = Modal::Picker(…)`) implicitly closes whatever else was open, and a single
+/// `Modal::None` closes the lot (the old per-field teardown in [`re_root`](Controller::re_root)).
+/// The variants:
+/// - `Picker` — the worktree picker (AC-1); a re-root closes it (its candidate list is old-root).
+/// - `Finder` — the go-to-file finder (AC-1), opened by `f`; closed by confirm/cancel/re-root.
+/// - `Prompt` — the in-file-nav bottom prompt (go-to-line / search). While open the run loop routes
+///   raw keys to `handle_prompt_key` and the mouse is inert, so the selection can't change beneath it.
+/// - `Help` — the help overlay (AC-1, AC-6), opened by `?`; dismissed by Esc/`q`. While open,
+///   `handle()`/`handle_mouse()` return early (AC-N4).
+enum Modal {
+    None,
+    Picker(PickerState),
+    Finder(FinderState),
+    Prompt(PromptState),
+    Help(HelpState),
+}
+
+impl Modal {
+    /// The picker state when the picker is the open modal, else `None` — the enum's `Option<&_>`
+    /// view, so call sites read like the old `self.modal.picker()`.
+    fn picker(&self) -> Option<&PickerState> {
+        match self {
+            Modal::Picker(s) => Some(s),
+            _ => None,
+        }
+    }
+    fn picker_mut(&mut self) -> Option<&mut PickerState> {
+        match self {
+            Modal::Picker(s) => Some(s),
+            _ => None,
+        }
+    }
+    fn finder(&self) -> Option<&FinderState> {
+        match self {
+            Modal::Finder(s) => Some(s),
+            _ => None,
+        }
+    }
+    fn finder_mut(&mut self) -> Option<&mut FinderState> {
+        match self {
+            Modal::Finder(s) => Some(s),
+            _ => None,
+        }
+    }
+    fn prompt(&self) -> Option<&PromptState> {
+        match self {
+            Modal::Prompt(s) => Some(s),
+            _ => None,
+        }
+    }
+    fn prompt_mut(&mut self) -> Option<&mut PromptState> {
+        match self {
+            Modal::Prompt(s) => Some(s),
+            _ => None,
+        }
+    }
+    fn help(&self) -> Option<&HelpState> {
+        match self {
+            Modal::Help(s) => Some(s),
+            _ => None,
+        }
+    }
+    fn help_mut(&mut self) -> Option<&mut HelpState> {
+        match self {
+            Modal::Help(s) => Some(s),
+            _ => None,
+        }
+    }
+}
+
 /// The interaction orchestrator and the ephemeral session state.
 pub struct Controller {
     root: PathBuf,
@@ -319,19 +392,12 @@ pub struct Controller {
     /// One-shot receiver for a re-root's off-thread status/changed-set computation (AC-17).
     /// `Some` between a re-root and the tick that applies the result; `None` otherwise.
     status_rx: Option<mpsc::Receiver<StatusResult>>,
-    /// The open worktree picker's state, or `None` when closed (AC-1). A re-root closes it
-    /// (AC-13); the switch itself is wired in later tasks.
-    picker: Option<PickerState>,
-    /// The open go-to-file finder's state, or `None` when closed (AC-1). Opened by the `f` key
-    /// (OpenFinder intent); closed by confirm/cancel and by [`re_root`](Self::re_root) (a
-    /// re-root invalidates the old-root candidate list).
-    finder: Option<FinderState>,
-    /// The open in-file-nav bottom prompt (go-to-line), or `None` when closed. While `Some`, the run
-    /// loop routes raw keys to `handle_prompt_key` and the mouse is inert ([`handle_mouse`]
-    /// returns early), so the selection can't change under an open prompt. Closed by confirm/cancel
-    /// and by [`re_root`](Self::re_root) (symmetric with the picker/finder teardown).
-    /// Mutually exclusive with the picker/finder modals.
-    prompt: Option<PromptState>,
+    /// The single open modal overlay (picker / finder / prompt / help), or [`Modal::None`] when the
+    /// columns have focus. One field instead of four parallel `Option`s, so mutual exclusion is
+    /// type-enforced — see [`Modal`]. A re-root resets it to `Modal::None` (the old symmetric
+    /// per-modal teardown), since a re-root invalidates the picker/finder old-root candidate lists
+    /// and must not strand a prompt/help over the freshly re-rooted tree.
+    modal: Modal,
     /// The herdr query channel for the agent-active overlay (AC-3), injected post-construction
     /// via [`set_host`](Self::set_host). `None` until then ⇒ a git-only picker (AC-15).
     /// Session-level — survives a re-root unchanged.
@@ -370,10 +436,6 @@ pub struct Controller {
     /// search + its highlighting (AC-20). The incremental-typing path (`refresh_search`) does NOT
     /// call `dispatch_render`, so live typing is never wiped by that clear.
     search: Option<SearchState>,
-    /// The open help overlay's state, or `None` when closed (AC-1, AC-6). Opened by the `?`
-    /// key (ShowHelp intent); dismissed by Esc/`q`. Modal — while `Some`, handle() and
-    /// handle_mouse() return early (AC-N4).
-    help: Option<HelpState>,
 }
 
 impl Controller {
@@ -457,13 +519,10 @@ impl Controller {
             update_dismissed: false,
             update_rx: None,
             status_rx: None,
-            picker: None,
-            finder: None,
-            prompt: None,
+            modal: Modal::None,
             pending_goto: None,
             applied_seq: 0,
             search: None,
-            help: None,
             herdr: None,
             our_workspace_id: None,
             base_branch,
@@ -605,21 +664,12 @@ impl Controller {
         self.content_path = None;
         self.action_notice = None;
         self.changed = BTreeMap::new();
-        self.picker = None;
-        // Close the finder too (symmetric teardown). A re-root invalidates its candidate list,
-        // which is rooted at the OLD root — a stale `confirm_finder` would then `root.join(old_rel)`
-        // against the NEW root and reveal nothing. Unreachable today (finder/picker are mutually
-        // exclusive and re_root only fires via picker-confirm), but kept structural so a future
-        // re-root trigger can't strand a finder.
-        self.finder = None;
-        // Close the go-to-line prompt too (symmetric teardown). Unreachable today — the prompt is
-        // modal and re_root only fires via picker-confirm — but kept structural so a future re-root
-        // trigger can't strand an open prompt over a freshly re-rooted tree.
-        self.prompt = None;
-        // Close the help overlay too (symmetric teardown). Inert today — help is modal and can't be
-        // open during a re-root — but matches the other modal teardowns so a future re-root trigger
-        // can't strand an open overlay over a freshly re-rooted tree.
-        self.help = None;
+        // Close whatever modal is open (one assignment, since `modal` is now a single value). A
+        // re-root only fires via picker-confirm, so in practice it's the picker being torn down —
+        // but a re-root also invalidates the finder's old-root candidate list and must not strand a
+        // prompt/help over the freshly re-rooted tree, so closing the lot here stays correct for any
+        // future re-root trigger.
+        self.modal = Modal::None;
         self.last_click = None;
 
         // PREFERENCES ARE CARRIED (AC-12) — deliberately NOT reset: show_ignored, hide_hidden,
@@ -719,7 +769,7 @@ impl Controller {
     /// The open worktree picker's state, or `None` when it is closed. Exposed so the Presenter
     /// can draw it and tests can assert the rows / pre-selected cursor.
     pub fn picker(&self) -> Option<&PickerState> {
-        self.picker.as_ref()
+        self.modal.picker()
     }
 
     /// Whether a re-root's off-thread status/changed-set fetch is still pending (not yet applied
@@ -817,13 +867,13 @@ impl Controller {
         let help_body_height = geom.help_body_height;
         let help_body_rows = geom.help_body_rows;
         self.geom = geom;
-        if let Some(finder) = self.finder.as_mut() {
+        if let Some(finder) = self.modal.finder_mut() {
             finder.clamp_hscroll(finder_max_hscroll);
         }
-        if let Some(picker) = self.picker.as_mut() {
+        if let Some(picker) = self.modal.picker_mut() {
             picker.clamp_hscroll(picker_max_hscroll);
         }
-        if let Some(help) = self.help.as_mut() {
+        if let Some(help) = self.modal.help_mut() {
             help.clamp_scroll(help_body_rows, help_body_height);
         }
     }
@@ -912,7 +962,7 @@ impl Controller {
     ///   2. Committed search (no open prompt) → query + count + n/N/Esc hint.
     ///   3. Neither → `None` (Presenter draws nothing on the bottom row).
     fn bottom_line(&self) -> Option<String> {
-        if let Some(p) = &self.prompt {
+        if let Some(p) = self.modal.prompt() {
             match p.mode {
                 crate::infile::PromptMode::GoToLine => {
                     Some(format!("Go to line: {}", p.input.query()))
@@ -971,7 +1021,7 @@ impl Controller {
     /// display string is the worktree's full path — informative for choosing among worktrees. The
     /// Presenter sanitizes the strings (AC-27) and renders the detached/current/agent markers.
     fn picker_view(&self) -> Option<PickerView> {
-        let picker = self.picker.as_ref()?;
+        let picker = self.modal.picker()?;
         Some(PickerView {
             rows: picker
                 .rows
@@ -996,7 +1046,7 @@ impl Controller {
     /// Presenter is borrow-free; carries the current query and cursor. The Presenter sanitizes the
     /// path strings (AC-27) and renders the query-input line + placeholder + match rows.
     fn finder_view(&self) -> Option<FinderView> {
-        let f = self.finder.as_ref()?;
+        let f = self.modal.finder()?;
         Some(FinderView {
             query: f.query().to_string(),
             matches: f
@@ -1015,7 +1065,7 @@ impl Controller {
     /// self-operating key-hints footer string (AC-11). The footer is built here so the Presenter
     /// stays mode-agnostic — it shows, at minimum, how to switch sections and how to close.
     fn help_view(&self) -> Option<HelpView> {
-        let help = self.help.as_ref()?;
+        let help = self.modal.help()?;
         let active = help.active_index();
         let labels: Vec<String> = help
             .section_labels()
@@ -1062,24 +1112,24 @@ impl Controller {
         self.action_notice = None;
         // Modal: while the picker is open, Nav/Activate/Close drive the picker, not the tree;
         // every other intent is inert (a modal selection). (AC-5)
-        if self.picker.is_some() {
+        if self.modal.picker().is_some() {
             return self.handle_picker_intent(intent);
         }
         // The finder is modal too: while it is open the run loop (app.rs) routes raw keys to
         // `handle_finder_key`, so `handle` should not be reached. Guard structurally anyway —
         // symmetric with the picker guard above — so a future or test caller can't leak an intent
         // to the tree or open a second modal beneath the finder overlay.
-        if self.finder.is_some() {
+        if self.modal.finder().is_some() {
             return Effects::noop();
         }
         // A prompt is modal too: the run loop routes raw keys to handle_prompt_key while it is open, so
         // handle() should not be reached. Guard structurally — symmetric with the finder guard.
-        if self.prompt.is_some() {
+        if self.modal.prompt().is_some() {
             return Effects::noop();
         }
         // The help overlay is modal: while it is open, all other intents are inert. The run loop
         // routes keys to handle_help_key instead; this guard mirrors finder/prompt.
-        if self.help.is_some() {
+        if self.modal.help().is_some() {
             return Effects::noop();
         }
         match intent {
@@ -1124,7 +1174,7 @@ impl Controller {
     fn handle_picker_intent(&mut self, intent: Intent) -> Effects {
         match intent {
             Intent::NavUp => {
-                if let Some(p) = self.picker.as_mut()
+                if let Some(p) = self.modal.picker_mut()
                     && p.cursor > 0
                 {
                     p.cursor -= 1;
@@ -1133,7 +1183,7 @@ impl Controller {
                 Effects::noop()
             }
             Intent::NavDown => {
-                if let Some(p) = self.picker.as_mut()
+                if let Some(p) = self.modal.picker_mut()
                     && p.cursor + 1 < p.rows.len()
                 {
                     p.cursor += 1;
@@ -1145,7 +1195,7 @@ impl Controller {
                 // Right (→/l): scroll the overlay rows right so a long path can be read sideways.
                 // Monotonic here — the Presenter clamps to the live inner width at draw, so an
                 // over-scroll past the widest row is harmless and not surfaced to the controller.
-                if let Some(p) = self.picker.as_mut() {
+                if let Some(p) = self.modal.picker_mut() {
                     let next = p.hscroll.saturating_add(HSCROLL_STEP);
                     if next != p.hscroll {
                         p.hscroll = next;
@@ -1156,7 +1206,7 @@ impl Controller {
             }
             Intent::Collapse => {
                 // Left (←/h): scroll the overlay rows left, clamped at the left edge (0).
-                if let Some(p) = self.picker.as_mut()
+                if let Some(p) = self.modal.picker_mut()
                     && p.hscroll > 0
                 {
                     p.hscroll = p.hscroll.saturating_sub(HSCROLL_STEP);
@@ -1172,11 +1222,11 @@ impl Controller {
                 // empty rows and the cursor is bounds-clamped, but the invariant is distant —
                 // use a local guard so a future change cannot introduce a panic.
                 let target = self
-                    .picker
-                    .as_ref()
+                    .modal
+                    .picker()
                     .and_then(|p| p.rows.get(p.cursor))
                     .map(|w| w.path.clone());
-                self.picker = None;
+                self.modal = Modal::None;
                 if let Some(target) = target {
                     self.re_root(&target);
                 }
@@ -1184,7 +1234,7 @@ impl Controller {
             }
             Intent::Close => {
                 // Cancel: close the picker; nothing else changes (AC-6).
-                self.picker = None;
+                self.modal = Modal::None;
                 Effects::redraw()
             }
             // Modal: any other intent is inert while picking.
@@ -1199,26 +1249,26 @@ impl Controller {
     pub fn handle_mouse(&mut self, ev: MouseEvent) -> Effects {
         // Modal: while the picker is open the mouse is fully inert — the picker is
         // keyboard-only. This mirrors the keyboard modal gate in `handle`.
-        if self.picker.is_some() {
+        if self.modal.picker().is_some() {
             return Effects::noop();
         }
         // The go-to-line prompt is keyboard-only too: the run loop routes only KEY events to
         // `handle_prompt_key`, so without this guard a click/wheel would still reach the tree/content
         // beneath and change the selection mid-prompt — then a confirm would jump (or auto-switch) the
         // WRONG file, or strand a bogus override on a directory. Make the mouse inert, like the picker.
-        if self.prompt.is_some() {
+        if self.modal.prompt().is_some() {
             return Effects::noop();
         }
         // The help overlay is modal but IS mouse-interactive (like the finder): the wheel scrolls
         // the active section's body and a click on a section tab switches sections. Route to its own
         // handler, which consumes every event and never leaks to the tree/content beneath (AC-21).
-        if self.help.is_some() {
+        if self.modal.help().is_some() {
             return self.handle_help_mouse(ev);
         }
         // The finder is also a modal overlay, but it IS mouse-interactive: wheel scrolls the
         // selection, click selects a result row, double-click confirms. Route to the finder's
         // own handler; it never leaks to the tree/content beneath.
-        if self.finder.is_some() {
+        if self.modal.finder().is_some() {
             return self.handle_finder_mouse(ev);
         }
         if ev.modifiers.contains(KeyModifiers::SHIFT) {
@@ -1297,7 +1347,7 @@ impl Controller {
             // Horizontal wheel: scroll the result rows sideways, mirroring the vertical-wheel
             // handling above. Additive to the keyboard ←/→ scroll (AC-18 keyboard-first).
             MouseEventKind::ScrollRight => {
-                if let Some(f) = self.finder.as_mut() {
+                if let Some(f) = self.modal.finder_mut() {
                     f.scroll_right();
                     Effects::redraw()
                 } else {
@@ -1305,7 +1355,7 @@ impl Controller {
                 }
             }
             MouseEventKind::ScrollLeft => {
-                if let Some(f) = self.finder.as_mut() {
+                if let Some(f) = self.modal.finder_mut() {
                     f.scroll_left();
                     Effects::redraw()
                 } else {
@@ -1360,7 +1410,7 @@ impl Controller {
             return Effects::noop();
         };
         let (rel, span) = Self::track_fraction(row, track.y, track.height);
-        let Some(finder) = self.finder.as_mut() else {
+        let Some(finder) = self.modal.finder_mut() else {
             return Effects::noop();
         };
         let total = finder.matches().len();
@@ -1379,7 +1429,7 @@ impl Controller {
     /// Move the finder selection by `delta` rows (positive = down, negative = up), clamped. A
     /// no-op when the finder is closed or the match list is empty.
     fn finder_move_selection(&mut self, delta: isize) -> Effects {
-        if let Some(f) = self.finder.as_mut() {
+        if let Some(f) = self.modal.finder_mut() {
             f.move_selection(delta);
             Effects::redraw()
         } else {
@@ -1405,7 +1455,7 @@ impl Controller {
         }
         // Map screen row → absolute match-list index.
         let idx = self.geom.finder_scroll as usize + (row - rows_rect.y) as usize;
-        let Some(finder) = self.finder.as_ref() else {
+        let Some(finder) = self.modal.finder() else {
             return Effects::noop();
         };
         if idx >= finder.matches().len() {
@@ -1417,7 +1467,7 @@ impl Controller {
         let double = is_double_click(self.last_click, (col, row), now);
         self.last_click = Some((col, row, now));
         // Set the finder cursor to the clicked row.
-        if let Some(f) = self.finder.as_mut() {
+        if let Some(f) = self.modal.finder_mut() {
             f.set_cursor(idx);
         }
         if double {
@@ -1460,7 +1510,7 @@ impl Controller {
                     .find(|(_, r)| r.contains(pos))
                     .map(|(idx, _)| *idx);
                 if let Some(idx) = hit
-                    && let Some(help) = self.help.as_mut()
+                    && let Some(help) = self.modal.help_mut()
                 {
                     help.select(idx);
                     return Effects::redraw();
@@ -1479,7 +1529,7 @@ impl Controller {
     /// post-draw clamp in [`set_pane_geometry`](Self::set_pane_geometry) stays the resize backstop.
     fn help_scroll(&mut self, delta: isize) -> Effects {
         let (rows, height) = (self.geom.help_body_rows, self.geom.help_body_height);
-        if let Some(help) = self.help.as_mut() {
+        if let Some(help) = self.modal.help_mut() {
             help.scroll_by(delta as i32);
             // Eager clamp only once a frame has measured the body (rows > 0) — see handle_help_key.
             if rows > 0 {
@@ -2205,7 +2255,7 @@ impl Controller {
             })
             .and_then(|active| rows.iter().position(|w| w.path == active))
             .unwrap_or(current_idx);
-        self.picker = Some(PickerState {
+        self.modal = Modal::Picker(PickerState {
             rows,
             agent_statuses,
             cursor,
@@ -2219,11 +2269,11 @@ impl Controller {
     /// Returns [`Effects::redraw`] so the run loop paints the overlay on the next tick.
     ///
     /// Modal mutual-exclusion (finder inert while the picker is open) holds BY CONSTRUCTION:
-    /// `handle()` routes to `handle_picker_intent()` while `self.picker.is_some()`, and its
+    /// `handle()` routes to `handle_picker_intent()` while `self.modal.picker().is_some()`, and its
     /// catch-all `_ => Effects::noop()` swallows `OpenFinder`. No extra guard is needed here.
     fn open_finder(&mut self) -> Effects {
         let candidates = crate::index::build(&self.root);
-        self.finder = Some(FinderState::new(candidates));
+        self.modal = Modal::Finder(FinderState::new(candidates));
         self.last_click = None; // opening the finder resets double-click state so a prior tree
         // click cannot pair with the first finder click as a double-click
         Effects::redraw()
@@ -2231,7 +2281,7 @@ impl Controller {
 
     /// Whether the go-to-file finder overlay is currently open.
     pub fn finder_open(&self) -> bool {
-        self.finder.is_some()
+        self.modal.finder().is_some()
     }
 
     /// Open the in-app help overlay (AC-1, AC-6, AC-19). Builds two sections:
@@ -2281,7 +2331,7 @@ impl Controller {
             body: crate::render::to_text(&about_body),
             scroll: 0,
         };
-        self.help = Some(HelpState::new(vec![whats_new, about]));
+        self.modal = Modal::Help(HelpState::new(vec![whats_new, about]));
         // Reset double-click state (mirrors open_finder): a tree click made just before the overlay
         // opened must not pair with a same-row click made just after it closes as a double-click.
         self.last_click = None;
@@ -2290,19 +2340,19 @@ impl Controller {
 
     /// Whether the help overlay is currently open.
     pub fn help_open(&self) -> bool {
-        self.help.is_some()
+        self.modal.help().is_some()
     }
 
     /// The current help overlay state, or `None` when closed.
     /// Exposed for tests and the `ViewState` projection.
     pub fn help_state(&self) -> Option<&HelpState> {
-        self.help.as_ref()
+        self.modal.help()
     }
 
     /// Dismiss the help overlay. Called by handle_help_key on Esc/`q`.
     /// A no-op when the overlay is already closed.
     pub fn close_help(&mut self) {
-        self.help = None;
+        self.modal = Modal::None;
     }
 
     /// Route a key event while the help overlay is open (AC-2, AC-3, AC-7, AC-8, AC-9, AC-20).
@@ -2328,13 +2378,13 @@ impl Controller {
         // exclusive), so the scroll-down arm can clamp eagerly against it.
         let (help_body_rows, help_body_height) =
             (self.geom.help_body_rows, self.geom.help_body_height);
-        let Some(help) = self.help.as_mut() else {
+        let Some(help) = self.modal.help_mut() else {
             return Effects::noop();
         };
         match key.code {
             // Close keys: '?' / Esc / 'q' dismiss the overlay (AC-2, AC-3).
             KeyCode::Char('?') | KeyCode::Esc | KeyCode::Char('q') => {
-                self.help = None;
+                self.modal = Modal::None;
                 Effects::redraw()
             }
             // Section navigation: Tab / Right → next (AC-7).
@@ -2386,7 +2436,7 @@ impl Controller {
     /// nothing. Snapshots the current content scroll into the prompt state.
     fn open_go_to_line(&mut self) -> Effects {
         if self.selected_view_mode().is_some() {
-            self.prompt = Some(PromptState {
+            self.modal = Modal::Prompt(PromptState {
                 mode: PromptMode::GoToLine,
                 input: crate::prompt::PromptInput::new(),
                 saved_scroll: self.content_scroll,
@@ -2406,7 +2456,7 @@ impl Controller {
         // Modal mutual-exclusion: the picker and finder guards in handle() already prevent this
         // from being reached while those modals are open, but be explicit for clarity and for
         // future direct callers.
-        if self.picker.is_some() || self.finder.is_some() {
+        if self.modal.picker().is_some() || self.modal.finder().is_some() {
             return Effects::noop();
         }
         // File-gate: search requires a file to be selected (not a directory / nothing).
@@ -2424,7 +2474,7 @@ impl Controller {
         // AC-20: opening a new search clears any prior committed SearchState so highlights from
         // the old query are gone before the new prompt opens. Clear first, then snapshot scroll.
         self.search = None;
-        self.prompt = Some(PromptState {
+        self.modal = Modal::Prompt(PromptState {
             mode: PromptMode::Search,
             input: crate::prompt::PromptInput::new(),
             saved_scroll: self.content_scroll,
@@ -2434,13 +2484,13 @@ impl Controller {
 
     /// Whether an in-file-nav bottom prompt is currently open.
     pub fn prompt_open(&self) -> bool {
-        self.prompt.is_some()
+        self.modal.prompt().is_some()
     }
 
     /// The mode of the currently-open bottom-prompt, or `None` when no prompt is open.
     /// Exposed for tests that need to assert which prompt variant was opened.
     pub fn prompt_mode(&self) -> Option<PromptMode> {
-        self.prompt.as_ref().map(|p| p.mode)
+        self.modal.prompt().map(|p| p.mode)
     }
 
     /// The pending auto-switch go-to-line target (1-based source line), or `None`. Set when `:`
@@ -2453,7 +2503,7 @@ impl Controller {
     /// The current go-to-line prompt buffer, or `""` when no prompt is open. Exposed for tests
     /// (AC-2) and the Presenter's bottom prompt line. Mirrors `finder_query()`.
     pub fn prompt_query(&self) -> &str {
-        self.prompt.as_ref().map(|p| p.input.query()).unwrap_or("")
+        self.modal.prompt().map(|p| p.input.query()).unwrap_or("")
     }
 
     /// Route a key event while a bottom-prompt modal is open. The run loop calls this
@@ -2461,7 +2511,7 @@ impl Controller {
     /// mode. (AC-2…AC-6)
     pub fn handle_prompt_key(&mut self, key: KeyEvent) -> Effects {
         // `PromptMode` is `Copy`; read it and drop the borrow before the per-mode handler runs.
-        let Some(mode) = self.prompt.as_ref().map(|p| p.mode) else {
+        let Some(mode) = self.modal.prompt().map(|p| p.mode) else {
             return Effects::noop();
         };
         match mode {
@@ -2485,7 +2535,7 @@ impl Controller {
                 if c.is_ascii_digit()
                     && key.modifiers.difference(KeyModifiers::SHIFT).is_empty() =>
             {
-                if let Some(p) = self.prompt.as_mut() {
+                if let Some(p) = self.modal.prompt_mut() {
                     p.input.push(c);
                 }
                 Effects::redraw()
@@ -2493,18 +2543,18 @@ impl Controller {
             // A non-digit printable is ignored — the buffer is unchanged, no repaint. (AC-2)
             KeyCode::Char(_) => Effects::noop(),
             KeyCode::Backspace => {
-                if let Some(p) = self.prompt.as_mut() {
+                if let Some(p) = self.modal.prompt_mut() {
                     p.input.backspace();
                 }
                 Effects::redraw()
             }
             KeyCode::Enter => {
                 let q = self
-                    .prompt
-                    .as_ref()
+                    .modal
+                    .prompt()
                     .map(|p| p.input.query().to_string())
                     .unwrap_or_default();
-                self.prompt = None; // confirm always closes (AC-5 empty also closes)
+                self.modal = Modal::None; // confirm always closes (AC-5 empty also closes)
                 // A new confirm supersedes any auto-switch jump still queued from an earlier confirm,
                 // so the older line can't overwrite this one when its render lands.
                 self.pending_goto = None;
@@ -2540,7 +2590,7 @@ impl Controller {
                 Effects::redraw()
             }
             KeyCode::Esc => {
-                self.prompt = None; // cancel: close, scroll unchanged (AC-6)
+                self.modal = Modal::None; // cancel: close, scroll unchanged (AC-6)
                 Effects::redraw()
             }
             _ => Effects::noop(),
@@ -2557,14 +2607,14 @@ impl Controller {
             // Accept any printable char (no modifier beyond SHIFT — consistent with the finder's
             // printable-char gate). Unlike go-to-line, search does NOT restrict to digits.
             KeyCode::Char(c) if key.modifiers.difference(KeyModifiers::SHIFT).is_empty() => {
-                if let Some(p) = self.prompt.as_mut() {
+                if let Some(p) = self.modal.prompt_mut() {
                     p.input.push(c);
                 }
                 self.refresh_search();
                 Effects::redraw()
             }
             KeyCode::Backspace => {
-                if let Some(p) = self.prompt.as_mut() {
+                if let Some(p) = self.modal.prompt_mut() {
                     p.input.backspace();
                 }
                 self.refresh_search();
@@ -2577,23 +2627,23 @@ impl Controller {
             // "Search: (no matches)" state persists after the prompt closes.
             KeyCode::Enter => {
                 let empty = self
-                    .prompt
-                    .as_ref()
+                    .modal
+                    .prompt()
                     .map(|p| p.input.query().is_empty())
                     .unwrap_or(true);
                 if empty {
                     self.search = None;
                 }
-                self.prompt = None;
+                self.modal = Modal::None;
                 Effects::redraw()
             }
             // AC-17: Esc cancels the search — restore the pre-open scroll snapshot and clear
             // the in-progress SearchState (no highlights remain after cancel).
             KeyCode::Esc => {
-                let saved_scroll = self.prompt.as_ref().map(|p| p.saved_scroll).unwrap_or(0);
+                let saved_scroll = self.modal.prompt().map(|p| p.saved_scroll).unwrap_or(0);
                 self.content_scroll = saved_scroll;
                 self.search = None;
-                self.prompt = None;
+                self.modal = Modal::None;
                 Effects::redraw()
             }
             _ => Effects::noop(),
@@ -2654,8 +2704,8 @@ impl Controller {
     /// the first match into view (AC-9, AC-10, AC-18).
     fn refresh_search(&mut self) {
         let q = self
-            .prompt
-            .as_ref()
+            .modal
+            .prompt()
             .map(|p| p.input.query().to_string())
             .unwrap_or_default();
         let plain = self.content_plain_lines();
@@ -2689,31 +2739,31 @@ impl Controller {
     /// The full candidate list loaded when the finder was opened, or an empty slice when
     /// the finder is closed. Exposed for tests; the Presenter reads via `finder()`.
     pub fn finder_candidates(&self) -> &[String] {
-        self.finder.as_ref().map(|f| f.candidates()).unwrap_or(&[])
+        self.modal.finder().map(|f| f.candidates()).unwrap_or(&[])
     }
 
     /// The current finder query string, or `""` when the finder is closed or the query is
     /// empty. Exposed for tests; the Presenter reads via `finder()`.
     pub fn finder_query(&self) -> &str {
-        self.finder.as_ref().map(|f| f.query()).unwrap_or("")
+        self.modal.finder().map(|f| f.query()).unwrap_or("")
     }
 
     /// The current ranked match indices (into `finder_candidates()`), or `&[]` when the finder
     /// is closed or the query is empty. Exposed for tests and the Presenter.
     pub fn finder_matches(&self) -> &[usize] {
-        self.finder.as_ref().map(|f| f.matches()).unwrap_or(&[])
+        self.modal.finder().map(|f| f.matches()).unwrap_or(&[])
     }
 
     /// The cursor position within the match list, or `0` when the finder is closed or the
     /// list is empty. Exposed for tests and the confirm path.
     pub fn finder_cursor(&self) -> usize {
-        self.finder.as_ref().map(|f| f.cursor()).unwrap_or(0)
+        self.modal.finder().map(|f| f.cursor()).unwrap_or(0)
     }
 
     /// The horizontal scroll offset for the result rows, or `0` when the finder is closed.
     /// Exposed for tests that verify Left/Right keys and horizontal wheel move hscroll.
     pub fn finder_hscroll(&self) -> u16 {
-        self.finder.as_ref().map(|f| f.hscroll()).unwrap_or(0)
+        self.modal.finder().map(|f| f.hscroll()).unwrap_or(0)
     }
 
     /// Route a key event while the finder overlay is open.
@@ -2730,7 +2780,7 @@ impl Controller {
     ///
     /// When the finder is not open, all keys are a no-op (defensive guard).
     pub fn handle_finder_key(&mut self, key: KeyEvent) -> Effects {
-        let Some(finder) = self.finder.as_mut() else {
+        let Some(finder) = self.modal.finder_mut() else {
             return Effects::noop();
         };
         let effects = match key.code {
@@ -2765,7 +2815,7 @@ impl Controller {
             // the Esc arm) and return early, so they never reach the reset below.
             KeyCode::Enter => return self.confirm_finder(),
             KeyCode::Esc => {
-                self.finder = None;
+                self.modal = Modal::None;
                 self.last_click = None; // closing the finder resets double-click state so a
                 // finder click cannot pair with the next tree click
                 return Effects::redraw();
@@ -2790,7 +2840,7 @@ impl Controller {
     /// - Reveal returns `false` (target missing/removed since open) → close the finder, set a
     ///   non-fatal `action_notice`, leave the tree selection unchanged (AC-20).
     fn confirm_finder(&mut self) -> Effects {
-        let Some(finder) = self.finder.as_ref() else {
+        let Some(finder) = self.modal.finder() else {
             return Effects::noop();
         };
         let Some(cand_idx) = finder.selected_candidate_index() else {
@@ -2798,7 +2848,7 @@ impl Controller {
         };
         let rel = finder.candidates()[cand_idx].clone();
         let abs = self.root.join(&rel);
-        self.finder = None; // confirm dismisses the modal regardless of reveal outcome
+        self.modal = Modal::None; // confirm dismisses the modal regardless of reveal outcome
         self.last_click = None; // closing the finder resets double-click state
         if self.tree.reveal(&abs) {
             // reveal() may have relaxed the tree's changed_only/hide_hidden fields — re-sync
@@ -3026,7 +3076,7 @@ impl Controller {
                 // swaps self.content; matches computed against the OLD content are now stale.
                 // Mirror dispatch_render's AC-20 clear: recompute an open Search prompt against
                 // the new content, else drop a committed search.
-                if self.prompt.as_ref().map(|p| p.mode) == Some(crate::infile::PromptMode::Search) {
+                if self.modal.prompt().map(|p| p.mode) == Some(crate::infile::PromptMode::Search) {
                     self.refresh_search();
                 } else {
                     self.search = None;

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -2041,11 +2041,11 @@ impl Controller {
         // A filename is untrusted — an attacker can craft one in a browsed repo, and a path may
         // legally contain control bytes: ESC/BEL (a terminal escape, e.g. a forged OSC 52) or a
         // newline that would paste-inject into a shell. Strip them before the path reaches the
-        // clipboard *or* the notice — the same defense `sanitize_label` applies to every other
-        // filesystem-derived string we display. (The OSC 52 payload is base64-encoded only for
+        // clipboard *or* the notice — the same AC-27 neutralizer the Presenter applies to every
+        // filesystem-derived string it displays. (The OSC 52 payload is base64-encoded only for
         // transport; the terminal decodes it back to this exact string onto the clipboard, so the
         // encoding alone does not make a control-bearing path safe to paste.)
-        let text: String = raw.chars().filter(|c| !c.is_control()).collect();
+        let text = crate::text_layout::sanitize_control(&raw);
         self.action_notice = Some(match self.clipboard.copy(&text) {
             Ok(()) => format!("Copied {text}"),
             Err(e) => format!("Could not copy path: {e}"),

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -1247,30 +1247,28 @@ impl Controller {
     /// still works (herdr reserves Shift+mouse for exactly that). Selection/activation happen
     /// on button *release*, so a divider drag is never mistaken for a click.
     pub fn handle_mouse(&mut self, ev: MouseEvent) -> Effects {
-        // Modal: while the picker is open the mouse is fully inert — the picker is
-        // keyboard-only. This mirrors the keyboard modal gate in `handle`.
-        if self.modal.picker().is_some() {
-            return Effects::noop();
+        // Modal gate, exhaustive over `Modal` (so a new overlay variant forces a mouse-routing
+        // decision here, mirroring the keyboard gate in `handle`):
+        // - Picker / Prompt are keyboard-only — swallow the mouse entirely. Without this a
+        //   click/wheel would reach the tree/content beneath and change the selection under the
+        //   modal, so a later confirm would act on the WRONG file (or strand an override on a dir).
+        // - Help / Finder ARE mouse-interactive (wheel scrolls, click selects/switches): route to
+        //   their own handler, which consumes every event and never leaks to the columns (AC-21).
+        // - None: no modal → the two-column mouse handler below.
+        match self.modal {
+            Modal::Picker(_) | Modal::Prompt(_) => Effects::noop(),
+            Modal::Help(_) => self.handle_help_mouse(ev),
+            Modal::Finder(_) => self.handle_finder_mouse(ev),
+            Modal::None => self.handle_column_mouse(ev),
         }
-        // The go-to-line prompt is keyboard-only too: the run loop routes only KEY events to
-        // `handle_prompt_key`, so without this guard a click/wheel would still reach the tree/content
-        // beneath and change the selection mid-prompt — then a confirm would jump (or auto-switch) the
-        // WRONG file, or strand a bogus override on a directory. Make the mouse inert, like the picker.
-        if self.modal.prompt().is_some() {
-            return Effects::noop();
-        }
-        // The help overlay is modal but IS mouse-interactive (like the finder): the wheel scrolls
-        // the active section's body and a click on a section tab switches sections. Route to its own
-        // handler, which consumes every event and never leaks to the tree/content beneath (AC-21).
-        if self.modal.help().is_some() {
-            return self.handle_help_mouse(ev);
-        }
-        // The finder is also a modal overlay, but it IS mouse-interactive: wheel scrolls the
-        // selection, click selects a result row, double-click confirms. Route to the finder's
-        // own handler; it never leaks to the tree/content beneath.
-        if self.modal.finder().is_some() {
-            return self.handle_finder_mouse(ev);
-        }
+    }
+
+    /// Handle a mouse event over the two columns, with no modal open (the [`handle_mouse`] gate
+    /// routes here only for [`Modal::None`]). Shift+mouse is inert so the terminal can do its own
+    /// text selection; otherwise the wheel scrolls the column under the pointer, a left press
+    /// starts a divider or scrollbar drag (scrollbars also jump to the pressed position), and a
+    /// left release is a click — unless it ended a drag, in which case it's consumed.
+    fn handle_column_mouse(&mut self, ev: MouseEvent) -> Effects {
         if ev.modifiers.contains(KeyModifiers::SHIFT) {
             return Effects::noop();
         }

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -1961,8 +1961,7 @@ impl Controller {
         };
         // Recompute the changed-set against the new baseline (AC-16) and keep the changed-only
         // filter consistent with it.
-        self.changed = self.git.changed_set(self.baseline);
-        self.tree.set_changed_only(self.changed_only, &self.changed);
+        self.set_changed(self.git.changed_set(self.baseline));
         // Drop any pending re-root async status fetch: this synchronous
         // recompute is now authoritative, so a stale in-flight async result must not clobber
         // it in `poll`. Invariant: every synchronous git-state recompute invalidates a pending
@@ -2860,6 +2859,29 @@ impl Controller {
         Effects::redraw()
     }
 
+    /// Store a new changed-set and re-apply the changed-only filter against it (AC-16). The two
+    /// move together — the filter reads `self.changed` — so the pair lives in one place and the
+    /// stored set and the displayed filter can never disagree.
+    fn set_changed(&mut self, changed: BTreeMap<PathBuf, Status>) {
+        self.changed = changed;
+        self.tree.set_changed_only(self.changed_only, &self.changed);
+    }
+
+    /// Push a freshly-queried git status + changed-set onto the tree together: per-node status
+    /// markers (AC-7) plus the changed-set behind the changed-only filter (AC-16). The single
+    /// place a status and its matching changed-set are applied in lockstep, so the markers can
+    /// never drift from the set the filter reads. `changed` is passed in because callers source
+    /// it differently — synchronously (`refresh_git_state`) or from the off-thread re-root fetch
+    /// (`poll`).
+    fn apply_git_state(
+        &mut self,
+        status: &BTreeMap<PathBuf, Status>,
+        changed: BTreeMap<PathBuf, Status>,
+    ) {
+        self.tree.set_status(status);
+        self.set_changed(changed);
+    }
+
     /// Re-query git for the working-tree status (tree markers, AC-7) and the changed-set
     /// against the active baseline (AC-16), updating the tree caches. No-op without a repo
     /// (AC-26). Runs on the calling thread, but only on deliberate, infrequent actions —
@@ -2870,9 +2892,8 @@ impl Controller {
             return;
         }
         let status = self.git.status();
-        self.tree.set_status(&status);
-        self.changed = self.git.changed_set(self.baseline);
-        self.tree.set_changed_only(self.changed_only, &self.changed);
+        let changed = self.git.changed_set(self.baseline);
+        self.apply_git_state(&status, changed);
         // Refresh the cached branch too: `refresh_git_state` runs on `r`,
         // editor-return, and focus-gain to pick up EXTERNAL git changes — so an external
         // `git checkout` must update the tree's bottom-border branch, not just status/changed-set.
@@ -3020,9 +3041,7 @@ impl Controller {
         if let Some(rx) = &self.status_rx {
             match rx.try_recv() {
                 Ok((status, changed)) => {
-                    self.tree.set_status(&status);
-                    self.changed = changed;
-                    self.tree.set_changed_only(self.changed_only, &self.changed);
+                    self.apply_git_state(&status, changed);
                     self.status_rx = None;
                     // The synchronous `re_root` dispatched the first render against the *empty*
                     // changed-set, so a changed file rendered in content/markdown mode, not Diff.

--- a/src/index.rs
+++ b/src/index.rs
@@ -8,6 +8,21 @@
 use ignore::WalkBuilder;
 use std::path::Path;
 
+/// The shared base for the crate's two gitignore-aware walks — this File Index and the Tree
+/// Model (`tree.rs`). Sets the hermetic policy both share so it lives in one place: honor an
+/// ancestor `.gitignore`, ignore the user's global gitignore and generic `.ignore` files, and
+/// apply `.gitignore` even outside a git repo. The caller sets what differs between the two
+/// walks — depth, dotfile hiding, and whether `.gitignore`/`.git/info/exclude` are honored.
+pub(crate) fn walk_builder(root: &Path) -> WalkBuilder {
+    let mut builder = WalkBuilder::new(root);
+    builder
+        .parents(true) // honor ancestor .gitignore for correct nested semantics
+        .git_global(false) // hermetic: ignore the user's global gitignore
+        .ignore(false) // only git ignore sources, not generic .ignore files
+        .require_git(false); // honor .gitignore even outside a git repo (AC-13, AC-19, AC-4, AC-26)
+    builder
+}
+
 /// Return every file under `root` as a root-relative `String`, respecting `.gitignore`.
 ///
 /// - Recursive (no depth limit) — AC-12.
@@ -19,13 +34,9 @@ use std::path::Path;
 /// - Works in non-git directories without error (`require_git(false)`) — AC-19.
 /// - Read-only: no filesystem or git mutations — AC-N1, AC-N2.
 pub fn build(root: &Path) -> Vec<String> {
-    let mut builder = WalkBuilder::new(root);
+    let mut builder = walk_builder(root);
     builder
         .hidden(false) // include dotfiles (AC-17 depends on the index NOT hiding dotfiles)
-        .parents(true) // honor ancestor .gitignore for correct nested semantics
-        .git_global(false) // hermetic: ignore the user's global gitignore
-        .ignore(false) // only git ignore sources, not generic .ignore files
-        .require_git(false) // honor .gitignore even outside a git repo (AC-13, AC-19)
         .git_ignore(true)
         .git_exclude(true)
         .filter_entry(|e| e.file_name() != ".git"); // prune entire .git subtree — AC-14

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -1605,8 +1605,9 @@ fn help_overlay_layout(area: Rect, help: &HelpView) -> HelpLayout {
     }
     // The body wraps (prose), so its height in rendered rows — not raw lines — is what the scroll
     // offset and scrollbar must be measured against. Sum the per-line WRAPPED rows with the EXACT
-    // counter the content pane uses (`text_layout::wrapped_rows`), so the help clamp and the content
-    // clamp can never drift. A long changelog otherwise can't scroll to its last entry (AC-8/AC-9).
+    // helper the content pane uses (`text_layout::line_wrapped_rows`), so the help clamp and the
+    // content clamp can never drift. A long changelog otherwise can't scroll to its last entry
+    // (AC-8/AC-9).
     //
     // Two-pass, mirroring the content pane (which measures at its live text width): the wrapped count
     // depends on the width the body is ACTUALLY drawn into, and reserving the 1-col vbar gutter
@@ -1614,15 +1615,12 @@ fn help_overlay_layout(area: Rect, help: &HelpView) -> HelpLayout {
     // leaving the changelog's tail unreachable (FIX-A). Pass 1 estimates at `inner.width` to decide
     // whether the bar is needed; pass 2 recomputes against the post-gutter `text.width` actually drawn.
     let body_rows_at = |w: u16| -> u16 {
-        let w = (w as usize).max(1);
+        let w = w as usize;
         let rows: usize = help
             .body
             .lines
             .iter()
-            .map(|line| {
-                let line_text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
-                crate::text_layout::wrapped_rows(&line_text, w).max(line.width().max(1).div_ceil(w))
-            })
+            .map(|line| crate::text_layout::line_wrapped_rows(line, w))
             .sum();
         rows.min(u16::MAX as usize) as u16
     };

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -8,6 +8,7 @@
 //! Pure view: takes a [`ViewState`] and draws it; holds no state and performs no I/O.
 
 use crate::git::Status;
+use crate::text_layout::sanitize_control;
 use crate::tree::{Node, NodeKind};
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Layout, Rect};
@@ -221,15 +222,6 @@ fn status_marker(node: &Node) -> char {
     }
 }
 
-/// Neutralize a string for display as a label/title: drop control characters (C0, DEL, and
-/// C1 — `char::is_control`), so a repo-controlled file name carrying ESC/CSI bytes cannot
-/// move the cursor, clear the screen, or spoof the UI (AC-27, defense-in-depth). ratatui's
-/// own renderer also drops control graphemes, but the viewer's security guarantee must not
-/// rest on that internal — this makes it explicit.
-fn sanitize_label(s: &str) -> String {
-    s.chars().filter(|c| !c.is_control()).collect()
-}
-
 /// The display name of a node — its final path component, or the whole path for a root.
 fn node_name(node: &Node) -> String {
     node.path
@@ -325,7 +317,7 @@ fn tree_row(node: &Node, selected: bool) -> Line<'static> {
         status_marker(node),
         "  ".repeat(node.depth),
         glyph,
-        sanitize_label(&node_name(node)),
+        sanitize_control(&node_name(node)),
     );
     let mut style = Style::new();
     if let Some(color) = row_color(node) {
@@ -487,7 +479,7 @@ fn draw_tree(frame: &mut Frame, area: Rect, state: &ViewState) {
     // Top title = the root directory basename (mirroring how the content pane titles itself from
     // the selected node), sanitized (a repo dir name is untrusted, AC-27) and truncated to the
     // column so a long name can't break the border. Fall back to "Files" only when it is empty.
-    let name = sanitize_label(&state.root_name);
+    let name = sanitize_control(&state.root_name);
     let title = if name.is_empty() {
         "Files".to_string()
     } else {
@@ -502,7 +494,7 @@ fn draw_tree(frame: &mut Frame, area: Rect, state: &ViewState) {
     if let Some(branch) = &state.branch {
         // Middle-ellipsis (not tail) so a long branch keeps both its `prefix/` and trailing feature
         // name visible when the tree column is narrow.
-        block = block.title_bottom(truncate_middle(&sanitize_label(branch), area.width));
+        block = block.title_bottom(truncate_middle(&sanitize_control(branch), area.width));
     }
     let inner = block.inner(area);
     frame.render_widget(block, area);
@@ -564,12 +556,12 @@ fn draw_content(frame: &mut Frame, area: Rect, state: &ViewState) -> (u16, u16) 
     // or "Content" — but only when NO render is in flight, otherwise the fallback would pick up
     // the still-loading selection's name and re-introduce the title-ahead-of-body bug.
     let title = if let Some(name) = &state.content_title {
-        sanitize_label(name)
+        sanitize_control(name)
     } else if !state.content_rendering {
         state
             .nodes
             .get(state.selected)
-            .map(|n| sanitize_label(&node_name(n)))
+            .map(|n| sanitize_control(&node_name(n)))
             .unwrap_or_else(|| "Content".to_string())
     } else {
         "Content".to_string()
@@ -579,7 +571,7 @@ fn draw_content(frame: &mut Frame, area: Rect, state: &ViewState) -> (u16, u16) 
     // discovers the help overlay without opening it first. It shares the border
     // row (not the layout), so it never crowds the content or steals a row.
     let hint =
-        Line::styled(sanitize_label(HELP_HINT), Style::new().fg(Color::Reset)).right_aligned();
+        Line::styled(sanitize_control(HELP_HINT), Style::new().fg(Color::Reset)).right_aligned();
     let block = Block::bordered()
         .title(title)
         .title_bottom(hint)
@@ -594,7 +586,7 @@ fn draw_content(frame: &mut Frame, area: Rect, state: &ViewState) -> (u16, u16) 
         let notice_lines: Vec<Line> = state
             .notices
             .iter()
-            .map(|n| Line::styled(sanitize_label(n), Style::new().fg(Color::Yellow)))
+            .map(|n| Line::styled(sanitize_control(n), Style::new().fg(Color::Yellow)))
             .collect();
         frame.render_widget(Paragraph::new(notice_lines), notices_rect);
     }
@@ -667,7 +659,7 @@ fn body_and_footer(area: Rect, state: &ViewState) -> (Rect, Option<Rect>) {
 /// to its row by ratatui.
 fn draw_update_footer(frame: &mut Frame, area: Rect, banner: &str) {
     let line = Line::styled(
-        sanitize_label(banner),
+        sanitize_control(banner),
         Style::new()
             .add_modifier(Modifier::REVERSED)
             .add_modifier(Modifier::BOLD),
@@ -695,7 +687,7 @@ fn body_footer_prompt(area: Rect, state: &ViewState) -> (Rect, Option<Rect>, Opt
 /// ignored the terminal theme. Sanitized (AC-27), clipped to its row.
 fn draw_prompt_line(frame: &mut Frame, area: Rect, prompt: &str) {
     let line = Line::styled(
-        sanitize_label(prompt),
+        sanitize_control(prompt),
         Style::new().add_modifier(Modifier::REVERSED),
     );
     frame.render_widget(Paragraph::new(line), area);
@@ -799,7 +791,7 @@ pub struct PaneGeometry {
     pub help_vbar: Option<Rect>,
     /// The screen rect of each section tab in the help overlay's top-border tab row, paired with its
     /// section index — `(index, cell_rect)`. Computed inside [`help_overlay_layout`] from the SAME
-    /// widths [`draw_help_overlay`] uses (the `"Help: "` prefix + cumulative `sanitize_label(label)`
+    /// widths [`draw_help_overlay`] uses (the `"Help: "` prefix + cumulative `sanitize_control(label)`
     /// widths + `HELP_TAB_SEP`), so a click maps to the tab actually drawn. Empty when the overlay is
     /// closed. The controller hit-tests a left-click against these to switch sections (AC-10).
     pub help_tabs: Vec<(usize, Rect)>,
@@ -1070,7 +1062,7 @@ fn picker_overlay_layout(area: Rect, picker: &PickerView) -> PickerLayout {
 /// AC-5). Each row is `<path> [branch]`, or `<path> (detached)` when HEAD is detached — never
 /// an empty branch (AC-2). The `cursor` row is highlighted (`REVERSED`, the same
 /// idiom `tree_row` uses for the tree selection). The path and branch are both run through
-/// `sanitize_label` first, so a worktree path or branch name carrying control bytes cannot
+/// `sanitize_control` first, so a worktree path or branch name carrying control bytes cannot
 /// move the cursor or spoof the UI (AC-27, defense-in-depth — exactly as the tree does).
 ///
 /// The box is **sized to its content** (the widest rendered row × the row count, plus the
@@ -1207,9 +1199,9 @@ fn agent_badge_color(status: &str) -> Color {
 ///
 /// The whole row is `REVERSED` when it is the cursor row (the same idiom `tree_row` uses).
 fn picker_row(row: &PickerRowView, selected: bool) -> Line<'static> {
-    let path = sanitize_label(&row.path);
+    let path = sanitize_control(&row.path);
     let suffix = match &row.branch {
-        Some(branch) => format!(" [{}]", sanitize_label(branch)),
+        Some(branch) => format!(" [{}]", sanitize_control(branch)),
         None if row.detached => " (detached)".to_string(),
         // No branch and not detached: show nothing rather than an empty `[]` (defensive).
         None => String::new(),
@@ -1240,7 +1232,7 @@ fn picker_row(row: &PickerRowView, selected: bool) -> Line<'static> {
     }
     // Trailing agent badge (AC-19): colored by status, sanitized (AC-27).
     if let Some(status) = &row.agent {
-        let status = sanitize_label(status);
+        let status = sanitize_control(status);
         spans.push(Span::styled(
             format!("  ● {status}"),
             base.fg(agent_badge_color(&status)),
@@ -1264,7 +1256,7 @@ const HELP_TITLE: &str = "Help";
 /// The persistent discoverability hint shown on the content pane's bottom border — a
 /// right-aligned one-segment affordance that `?` opens help, visible on the default screen
 /// without opening any modal. Static (first-party), so no sanitization is needed
-/// beyond the defense-in-depth `sanitize_label` applied at the call site (AC-27).
+/// beyond the defense-in-depth `sanitize_control` applied at the call site (AC-27).
 const HELP_HINT: &str = "? help";
 /// The help overlay's desired interior WIDTH (columns) before clamping to the frame. A generous
 /// fixed size (the changelog/about bodies are unbounded — the box does NOT size to content like the
@@ -1335,7 +1327,7 @@ fn finder_overlay_layout(area: Rect, finder: &FinderView) -> FinderLayout {
             Style::new().add_modifier(Modifier::DIM),
         )
     } else {
-        let display_query = sanitize_label(&finder.query);
+        let display_query = sanitize_control(&finder.query);
         Line::from(format!("{FINDER_PROMPT}{display_query}"))
     };
 
@@ -1345,7 +1337,7 @@ fn finder_overlay_layout(area: Rect, finder: &FinderView) -> FinderLayout {
         .iter()
         .enumerate()
         .map(|(i, path)| {
-            let text = sanitize_label(path);
+            let text = sanitize_control(path);
             let style = if i == finder.cursor {
                 Style::new().add_modifier(Modifier::REVERSED)
             } else {
@@ -1444,9 +1436,9 @@ fn finder_overlay_layout(area: Rect, finder: &FinderView) -> FinderLayout {
 /// Draw the go-to-file finder as a centered, bordered overlay on top of the columns (AC-1).
 ///
 /// The interior (top to bottom) is:
-///   1. A **query-input line**: `"> "` + the current query text (both through `sanitize_label`
+///   1. A **query-input line**: `"> "` + the current query text (both through `sanitize_control`
 ///      for AC-27 parity). When the query is empty a dim placeholder replaces the prompt.
-///   2. **Match rows**: each matched root-relative path run through `sanitize_label` (AC-5, AC-27);
+///   2. **Match rows**: each matched root-relative path run through `sanitize_control` (AC-5, AC-27);
 ///      the `cursor` row is highlighted with REVERSED — the same idiom the picker uses. When
 ///      `matches` is empty (empty query or no hit) no rows are drawn (AC-2).
 ///
@@ -1467,7 +1459,7 @@ fn draw_finder_overlay(frame: &mut Frame, area: Rect, finder: &FinderView) {
             Style::new().add_modifier(Modifier::DIM),
         )
     } else {
-        let display_query = sanitize_label(&finder.query);
+        let display_query = sanitize_control(&finder.query);
         Line::from(format!("{FINDER_PROMPT}{display_query}"))
     };
 
@@ -1477,7 +1469,7 @@ fn draw_finder_overlay(frame: &mut Frame, area: Rect, finder: &FinderView) {
         .iter()
         .enumerate()
         .map(|(i, path)| {
-            let text = sanitize_label(path);
+            let text = sanitize_control(path);
             let style = if i == finder.cursor {
                 Style::new().add_modifier(Modifier::REVERSED)
             } else {
@@ -1562,7 +1554,7 @@ struct HelpLayout {
     body_rows: u16,
     /// Each section tab's screen rect in the top-border tab row, paired with its section index —
     /// `(index, cell_rect)`. Derived from the SAME widths `draw_help_overlay` renders the tab Line
-    /// with (the `"Help: "` prefix + cumulative `sanitize_label(label)` widths + `HELP_TAB_SEP`), so
+    /// with (the `"Help: "` prefix + cumulative `sanitize_control(label)` widths + `HELP_TAB_SEP`), so
     /// the drawn tabs and the hit-test rects can never drift. Each rect is the tab label's own cells
     /// (1 row tall, at `popup.y`); a tab clipped past the popup's right edge is dropped.
     tabs: Vec<(usize, Rect)>,
@@ -1593,7 +1585,7 @@ fn help_overlay_layout(area: Rect, help: &HelpView) -> HelpLayout {
 
     // Section-tab rects in the top-border tab row, derived from the SAME span widths the draw path
     // lays out: a left-aligned `title_top` Line begins at the first interior border column
-    // (`popup.x + 1`), starting with the `"Help: "` prefix; each tab is `sanitize_label(label)`
+    // (`popup.x + 1`), starting with the `"Help: "` prefix; each tab is `sanitize_control(label)`
     // wide, separated by `HELP_TAB_SEP`. We walk those widths to place each tab's cell rect, so a
     // click maps to the tab actually drawn (the whole point of the shared helper). Rects fully past
     // the popup's right border are dropped (clipped off-screen, not clickable).
@@ -1666,7 +1658,7 @@ fn help_overlay_layout(area: Rect, help: &HelpView) -> HelpLayout {
 ///
 /// Layout mirrors [`draw_help_overlay`]'s `title_top`: a left-aligned title begins at the first
 /// interior border column (`popup.x + 1`) with the `"{HELP_TITLE}: "` prefix, then each label —
-/// `sanitize_label(label)` wide — separated by [`HELP_TAB_SEP`]. A tab whose cells fall entirely
+/// `sanitize_control(label)` wide — separated by [`HELP_TAB_SEP`]. A tab whose cells fall entirely
 /// past the popup's right border is dropped (ratatui clips it off-screen, so it isn't clickable).
 fn help_tab_rects(popup: Rect, labels: &[String], active: usize) -> Vec<(usize, Rect)> {
     // The title row is the popup's top border; left-aligned titles start one cell in from the corner.
@@ -1684,7 +1676,7 @@ fn help_tab_rects(popup: Rect, labels: &[String], active: usize) -> Vec<(usize, 
         // hit-test rect (a click on the glyph still switches the right section) and advance past
         // it before placing the label rect.
         let marker_w = if i == active { active_marker_w } else { 0 };
-        let label_w = sanitize_label(label).chars().count() as u16;
+        let label_w = sanitize_control(label).chars().count() as u16;
         let total_w = marker_w.saturating_add(label_w);
         // Keep only a tab that begins before the right border — its visible cells are clickable.
         if total_w > 0 && x < right_edge {
@@ -1745,12 +1737,13 @@ fn draw_help_overlay(frame: &mut Frame, area: Rect, help: &HelpView) {
                 .add_modifier(Modifier::BOLD);
             tab_spans.push(Span::styled(HELP_ACTIVE_MARKER, style));
         }
-        tab_spans.push(Span::styled(sanitize_label(label), style));
+        tab_spans.push(Span::styled(sanitize_control(label), style));
     }
     let tabs = Line::from(tab_spans);
 
     // Bottom border: the self-operating key-hints footer (AC-11), centered, in the body's color.
-    let footer = Line::styled(sanitize_label(&help.hint), Style::new().fg(Color::Reset)).centered();
+    let footer =
+        Line::styled(sanitize_control(&help.hint), Style::new().fg(Color::Reset)).centered();
 
     // Clear whatever is beneath the popup so it reads as a true modal (on top of the picker/finder).
     frame.render_widget(Clear, layout.popup);
@@ -1797,26 +1790,6 @@ fn draw_help_overlay(frame: &mut Frame, area: Rect, help: &HelpView) {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn sanitize_label_strips_control_bytes_keeps_printable() {
-        // ESC + CSI + C0 controls removed; the printable remainder (incl. unicode) survives.
-        assert_eq!(
-            sanitize_label("evil\u{1b}[2J\u{1b}[10;10Hpwned"),
-            "evil[2J[10;10Hpwned"
-        );
-        assert_eq!(sanitize_label("a\u{07}\u{08}\rb\tc"), "abc");
-        assert_eq!(sanitize_label("plain_name.rs"), "plain_name.rs");
-        assert_eq!(sanitize_label("café—ok"), "café—ok");
-        // C1 controls (U+0080..U+009F) are also dropped.
-        assert_eq!(sanitize_label("x\u{0090}y"), "xy");
-        // No control codepoint survives, ever.
-        assert!(
-            !sanitize_label("\u{1b}\u{07}\u{7f}\u{9b}z")
-                .chars()
-                .any(|c| c.is_control())
-        );
-    }
 
     #[test]
     fn help_body_text_width_is_the_interior_minus_the_scrollbar_gutter() {

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -967,6 +967,21 @@ fn centered_rect_sized(w: u16, h: u16, area: Rect) -> Rect {
     }
 }
 
+/// The base frame every modal overlay (picker, finder, help) is drawn in: a bordered block with
+/// uniform [`PICKER_PADDING`]. The `*_overlay_layout` fns measure `inner` from it; the draw fns
+/// start from it and add the titles + [`modal_border_style`] on top. Titles render on the
+/// already-reserved border rows and the accent is style-only, so neither changes the interior
+/// geometry — the measured interior and the drawn interior therefore always agree.
+fn modal_frame() -> Block<'static> {
+    Block::bordered().padding(Padding::uniform(PICKER_PADDING))
+}
+
+/// The shared modal border accent — blue + bold — so the picker, finder, and help overlays read
+/// as the same kind of surface and the accent is defined once.
+fn modal_border_style() -> Style {
+    Style::new().fg(Color::Blue).add_modifier(Modifier::BOLD)
+}
+
 /// Uniform inner padding (cells on every side) between the picker rows and the box border, so the
 /// content reads with a little breathing room — matching herdr's indented popup content. Applied
 /// both horizontally (a column gutter each side) and vertically (a blank row above the first row
@@ -1038,7 +1053,7 @@ fn picker_overlay_layout(area: Rect, picker: &PickerView) -> PickerLayout {
     let cap_h = area.height.saturating_sub(2);
     let popup = centered_rect_sized(want_w.min(cap_w), want_h.min(cap_h), area);
 
-    let block = Block::bordered().padding(Padding::uniform(PICKER_PADDING));
+    let block = modal_frame();
     let inner = block.inner(popup);
 
     let visible = inner.height as usize;
@@ -1110,16 +1125,15 @@ fn draw_picker_overlay(frame: &mut Frame, area: Rect, picker: &PickerView) {
     // Clear whatever the columns drew beneath the popup so it reads as a true modal.
     frame.render_widget(Clear, layout.popup);
 
-    let block = Block::bordered()
+    // The shared modal frame already carries the 1-cell uniform gutter (so the rows aren't flush
+    // against the border or the title/footer chrome on the border rows); `inner()` subtracts it
+    // all round, so the rows, cursor highlight, current marker, agent badge, and scrollbars all
+    // flow from the padded interior below.
+    let block = modal_frame()
         .title_top(top_left)
         .title_top(top_right)
         .title_bottom(footer)
-        .border_style(Style::new().fg(Color::Blue).add_modifier(Modifier::BOLD))
-        // A 1-cell gutter on every side so the rows aren't flush against the border (or the
-        // title/footer chrome that shares the border rows). `inner()` subtracts this all round
-        // automatically, so the rows, cursor highlight, current marker, agent badge, vertical
-        // scroll, and hscroll all flow from the padded interior below.
-        .padding(Padding::uniform(PICKER_PADDING));
+        .border_style(modal_border_style());
     frame.render_widget(block, layout.popup);
 
     let visible = layout.inner.height as usize;
@@ -1373,7 +1387,7 @@ fn finder_overlay_layout(area: Rect, finder: &FinderView) -> FinderLayout {
     let cap_h = area.height.saturating_sub(2);
     let popup = centered_rect_sized(want_w.min(cap_w), want_h.min(cap_h), area);
 
-    let block = Block::bordered().padding(Padding::uniform(PICKER_PADDING));
+    let block = modal_frame();
     let inner = block.inner(popup);
 
     // The query line always occupies the first row of the interior (when it fits).
@@ -1488,11 +1502,10 @@ fn draw_finder_overlay(frame: &mut Frame, area: Rect, finder: &FinderView) {
     // Clear whatever the columns drew beneath the popup so it reads as a true modal.
     frame.render_widget(Clear, layout.popup);
 
-    let block = Block::bordered()
+    let block = modal_frame()
         .title_top(top_left)
         .title_bottom(footer)
-        .border_style(Style::new().fg(Color::Blue).add_modifier(Modifier::BOLD))
-        .padding(Padding::uniform(PICKER_PADDING));
+        .border_style(modal_border_style());
     frame.render_widget(block, layout.popup);
 
     // Render the query line if the interior is tall enough.
@@ -1580,7 +1593,7 @@ fn help_overlay_layout(area: Rect, help: &HelpView) -> HelpLayout {
     let cap_h = area.height.saturating_sub(2);
     let popup = centered_rect_sized(want_w.min(cap_w), want_h.min(cap_h), area);
 
-    let block = Block::bordered().padding(Padding::uniform(PICKER_PADDING));
+    let block = modal_frame();
     let inner = block.inner(popup);
 
     // Section-tab rects in the top-border tab row, derived from the SAME span widths the draw path
@@ -1746,11 +1759,10 @@ fn draw_help_overlay(frame: &mut Frame, area: Rect, help: &HelpView) {
     // Clear whatever is beneath the popup so it reads as a true modal (on top of the picker/finder).
     frame.render_widget(Clear, layout.popup);
 
-    let block = Block::bordered()
+    let block = modal_frame()
         .title_top(tabs)
         .title_bottom(footer)
-        .border_style(Style::new().fg(Color::Blue).add_modifier(Modifier::BOLD))
-        .padding(Padding::uniform(PICKER_PADDING));
+        .border_style(modal_border_style());
     frame.render_widget(block, layout.popup);
 
     if let Some(body_area) = layout.body {

--- a/src/text_layout.rs
+++ b/src/text_layout.rs
@@ -7,6 +7,8 @@
 //! `sanitize_control` lives here for the same reason: the Presenter (every displayed string) and
 //! the controller (the clipboard path) share one AC-27 neutralizer rather than two copies.
 
+use ratatui::text::Line;
+
 /// How many rows one rendered line occupies under ratatui's word wrapper (`Wrap{trim:false}`)
 /// at `width` columns: greedy word packing — fill the row with space-separated words until the
 /// next one doesn't fit, then wrap; a word wider than the row is broken across rows. A plain
@@ -37,6 +39,17 @@ pub(crate) fn wrapped_rows(text: &str, width: usize) -> usize {
         }
     }
     rows
+}
+
+/// Wrapped rows a single rendered [`Line`] occupies at `width` columns: flatten its spans to text,
+/// run the word-wrap simulation, and floor by the all-columns char-wrap so the simulation can never
+/// undershoot (a leading/interior over-long word still costs its char-wrapped rows). `width` is
+/// clamped to ≥ 1 so a zero width can't divide-by-zero. The content-pane scroll clamp and the
+/// help-overlay body measurement both call this, so their per-line row counts can never drift.
+pub(crate) fn line_wrapped_rows(line: &Line, width: usize) -> usize {
+    let width = width.max(1);
+    let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+    wrapped_rows(&text, width).max(line.width().max(1).div_ceil(width))
 }
 
 /// Neutralize a string for display (a label/title) or for the clipboard: drop control characters

--- a/src/text_layout.rs
+++ b/src/text_layout.rs
@@ -1,9 +1,11 @@
-//! Shared text-layout helpers, neutral to the view/controller split.
+//! Shared text helpers, neutral to the view/controller split.
 //!
 //! `wrapped_rows` lives here (not on the Session Controller) so the Presenter can measure wrapped
 //! body heights without importing from the controller — the view layer must not depend on the
 //! orchestration layer. Both the content-pane scroll clamp (controller) and the help-overlay body
 //! measurement (presenter) call this single helper, so their wrapped-row counts can never drift.
+//! `sanitize_control` lives here for the same reason: the Presenter (every displayed string) and
+//! the controller (the clipboard path) share one AC-27 neutralizer rather than two copies.
 
 /// How many rows one rendered line occupies under ratatui's word wrapper (`Wrap{trim:false}`)
 /// at `width` columns: greedy word packing — fill the row with space-separated words until the
@@ -37,9 +39,39 @@ pub(crate) fn wrapped_rows(text: &str, width: usize) -> usize {
     rows
 }
 
+/// Neutralize a string for display (a label/title) or for the clipboard: drop control characters
+/// (C0, DEL, and C1 — `char::is_control`), so a repo-controlled file name carrying ESC/CSI bytes
+/// cannot move the cursor, clear the screen, spoof the UI, or paste-inject once copied (AC-27,
+/// defense-in-depth). ratatui's renderer also drops control graphemes, but the viewer's security
+/// guarantee must not rest on that internal — and the clipboard path never touches a renderer at
+/// all. Neutral to the view/controller split, so both layers share one definition.
+pub(crate) fn sanitize_control(s: &str) -> String {
+    s.chars().filter(|c| !c.is_control()).collect()
+}
+
 #[cfg(test)]
 mod tests {
-    use super::wrapped_rows;
+    use super::{sanitize_control, wrapped_rows};
+
+    #[test]
+    fn sanitize_control_strips_control_bytes_keeps_printable() {
+        // ESC + CSI + C0 controls removed; the printable remainder (incl. unicode) survives.
+        assert_eq!(
+            sanitize_control("evil\u{1b}[2J\u{1b}[10;10Hpwned"),
+            "evil[2J[10;10Hpwned"
+        );
+        assert_eq!(sanitize_control("a\u{07}\u{08}\rb\tc"), "abc");
+        assert_eq!(sanitize_control("plain_name.rs"), "plain_name.rs");
+        assert_eq!(sanitize_control("café—ok"), "café—ok");
+        // C1 controls (U+0080..U+009F) are also dropped.
+        assert_eq!(sanitize_control("x\u{0090}y"), "xy");
+        // No control codepoint survives, ever.
+        assert!(
+            !sanitize_control("\u{1b}\u{07}\u{7f}\u{9b}z")
+                .chars()
+                .any(|c| c.is_control())
+        );
+    }
 
     #[test]
     fn wrapped_rows_counts_word_wrapping_not_just_char_wrapping() {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -5,7 +5,7 @@
 //! its root — no node ever escapes it (AC-N5) — and reads only, never writes (AC-N1).
 
 use crate::git::Status;
-use ignore::WalkBuilder;
+use crate::index::walk_builder;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::path::{Path, PathBuf};
 
@@ -229,16 +229,12 @@ impl TreeModel {
     /// entries dropped when `hide_hidden` (#46), `.git` always hidden, directories before files,
     /// each group alphabetical. Read-only.
     fn entries(&self, dir: &Path) -> Vec<(PathBuf, NodeKind)> {
-        let mut builder = WalkBuilder::new(dir);
+        let mut builder = walk_builder(dir);
         builder
             .max_depth(Some(1))
             // Dotfiles (e.g. .gitignore, .github) show by default; the hide-hidden toggle (#46)
             // turns on `ignore`'s hidden filter to drop every `.`-prefixed entry.
             .hidden(self.hide_hidden)
-            .parents(true) // honor ancestor .gitignore for correct nested semantics
-            .git_global(false) // hermetic: ignore the user's global gitignore
-            .ignore(false) // only git ignore sources, not generic .ignore files
-            .require_git(false) // honor .gitignore even outside a git repo (AC-4, AC-26)
             .git_ignore(!self.show_ignored)
             .git_exclude(!self.show_ignored);
 

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -2076,7 +2076,7 @@ fn copy_path_strips_control_bytes_from_a_hostile_filename() {
     // A filename is attacker-controllable in a browsed repo and may legally contain control bytes —
     // ESC/BEL (a terminal escape, e.g. a forged OSC 52) or a newline (a shell paste-injection when
     // the copied path is later pasted). Both the clipboard payload and the confirmation notice must
-    // be stripped of control characters, matching the `sanitize_label` defense the tree and update
+    // be stripped of control characters, matching the `sanitize_control` defense the tree and update
     // banner already apply to filesystem-derived strings.
     let dir = TempDir::new();
     let hostile = "a\u{1b}]52;c;evil\u{07}\nrm -rf b";
@@ -3559,6 +3559,24 @@ fn finder_dir() -> (TempDir, Controller) {
     let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
     ctrl.handle(Intent::OpenFinder);
     (dir, ctrl)
+}
+
+// close_help() must clear ONLY the help overlay — never some other modal that happens to be open.
+// Regression guard for the Modal-enum refactor: the old per-field `self.help = None` was inert
+// unless help was open, so `close_help()` while the finder is open must leave the finder open.
+#[test]
+fn close_help_does_not_close_a_non_help_modal() {
+    let (_dir, mut ctrl) = finder_dir();
+    assert!(
+        ctrl.finder_open(),
+        "precondition: the finder is the open modal"
+    );
+    assert!(!ctrl.help_open(), "precondition: help is not open");
+    ctrl.close_help(); // contract: a no-op unless help is the open modal
+    assert!(
+        ctrl.finder_open(),
+        "close_help() must not close the unrelated finder modal"
+    );
 }
 
 /// Map `finder_matches()` indices through `finder_candidates()` to get paths.


### PR DESCRIPTION
## M6 (PR 1 of 2) — controller.rs consolidation + Modal enum

First of two PRs that clear **M6** of the Optimisations backlog (the `controller.rs` god-module the
latest audit flagged). This PR is the **logic** half: deduplicate the satellite formulas and
collapse the four parallel modal fields into one type-enforced enum. **PR 2** (a follow-up) is the
**pure relocation** half — splitting `controller.rs` into a `controller/` module directory — kept
separate so its large move-diff doesn't bury the logic changes reviewed here.

Pure behavior-preserving refactor: no features, no user-facing change, read-only invariant intact.
Each commit leaves the suite green.

### What's in it

**Dedups — one definition for each duplicated rule (so they can't drift):**
- `walk_builder` factory shared by the File Index and the Tree Model walks (`index.rs` ↔ `tree.rs`).
- `sanitize_control` — the AC-27 control-char neutralizer, shared by the Presenter (every displayed
  string) and the controller (the clipboard-copy path), moved to `text_layout`.
- `line_wrapped_rows` — the per-line wrapped-row count, shared by the content-pane scroll clamp and
  the help-overlay body measurement.
- `track_to_offset` — the scrollbar track→offset rounding, shared by the four linear drag handlers
  (the finder keeps its own mapping — it deliberately differs at the single-match boundary; noted in
  code).
- `set_changed` / `apply_git_state` — the git status + changed-set are now applied to the tree
  through one path, so the markers and the changed-only filter can't fall out of sync.
- `modal_frame` / `modal_border_style` — the picker/finder/help overlays share one base frame and
  one border accent (the `insta` snapshots are unchanged → byte-identical render).

**Modal enum — mutual exclusion by type, not by hand:**
- The four `Option<PickerState|FinderState|PromptState|HelpState>` fields become one
  `modal: Modal` (`enum Modal { None, Picker, Finder, Prompt, Help }`). Opening any modal now
  implicitly closes whatever was open, and a single `Modal::None` closes the lot — the `re_root`
  teardown that explicitly nulled all four (with "unreachable but structural" comments) is now one
  line. `Modal` carries `Option<&_>` / `Option<&mut _>` accessors so the ~80 read sites keep reading
  like the old `.as_ref()`/`.as_mut()`.
- `handle_mouse`'s four-`if` modal gate becomes one **exhaustive** `match self.modal`, so a future
  modal variant forces a mouse-routing decision. Its non-modal body moves into `handle_column_mouse`,
  mirroring the existing `handle_finder_mouse` / `handle_help_mouse`.

### Notes

- **`controller.rs` does not shrink in this PR** (the enum + its accessors roughly offset the
  four-field collapse). The file-size win is **PR 2**'s module move; this PR's win is single-source
  correctness + the type-enforced single-modal invariant.
- **No docs change**: this is an internal refactor with no user-facing behavior, so no `CHANGELOG` /
  README entry. `ARCHITECTURE.md`'s module table is updated in PR 2, when the `controller/`
  submodules are introduced.

### Verification

Green on Linux: `cargo build --release` · `cargo test` (37 groups) · `cargo clippy --all-targets -- -D
warnings` · `cargo fmt --check`. The behavior oracle for the modal change — the modal × intent guard
matrix and the read-only-invariant test — stays green. The full CI matrix (incl. macOS) runs on this
PR.
