### PR TITLE
feat: native Windows support (preview)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,5 +68,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.96.0
       - uses: Swatinem/rust-cache@v2
+      # A release build exercises AC-1 (the crate links for the MSVC target) on every PR, not only
+      # at tag time — so a release-only/target-specific break shows here, not first on a release.
+      - name: build (release)
+        run: cargo build --release
       - name: test
         run: cargo test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,18 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo install cargo-audit --locked
       - run: cargo audit
+
+  # Windows support is preview (AC-19, AC-N2): this job is advisory/non-blocking
+  # (continue-on-error) and deliberately separate from the required `test` matrix above, so a
+  # Windows-only flake can never block an unrelated Linux/macOS PR. Re-evaluate (fold into the
+  # required matrix) once Windows graduates out of preview.
+  windows:
+    name: test (windows-latest, advisory)
+    runs-on: windows-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.96.0
+      - uses: Swatinem/rust-cache@v2
+      - name: test
+        run: cargo test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,10 @@ jobs:
             triple: x86_64-apple-darwin
           - os: ubuntu-latest
             triple: x86_64-unknown-linux-musl
+          # Windows support is preview; v1 targets x86_64-pc-windows-msvc only (no aarch64 —
+          # AC-N4).
+          - os: windows-latest
+            triple: x86_64-pc-windows-msvc
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -57,8 +61,19 @@ jobs:
         shell: bash
         run: |
           mkdir -p dist
-          asset="herdr-file-viewer-${{ matrix.triple }}"
-          cp "target/${{ matrix.triple }}/release/herdr-file-viewer" "dist/$asset"
+          triple="${{ matrix.triple }}"
+          # Windows binaries (and their published asset) carry the .exe suffix; every other
+          # target is extension-less. This is the only per-OS tweak in the whole release flow —
+          # everything below (SHA256SUMS, artifact upload, the publish job's glob) is reused
+          # as-is (AC-18).
+          if [[ "$triple" == *windows* ]]; then
+            src="target/$triple/release/herdr-file-viewer.exe"
+            asset="herdr-file-viewer-$triple.exe"
+          else
+            src="target/$triple/release/herdr-file-viewer"
+            asset="herdr-file-viewer-$triple"
+          fi
+          cp "$src" "dist/$asset"
           cd dist
           if command -v sha256sum >/dev/null 2>&1; then
             sha256sum "$asset" > "$asset.sha256"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Native Windows support (preview).** The viewer now builds and runs on
+  `x86_64-pc-windows-msvc`, declared as a supported herdr platform alongside Linux and macOS.
+  Windows-specific platform seams: correct git path decoding for non-ASCII filenames, a
+  `NUL`-device git hardening target, an `%LOCALAPPDATA%`-based update-check cache, quote-aware
+  `$EDITOR` parsing (so a `"C:\Program Files\...\Code.exe"`-style path works), a `notepad.exe`
+  default editor, and `.exe`-suffix resolution for the configured herdr binary. Install parity
+  via a new `scripts/fetch-or-build.ps1` (PowerShell 5.1) mirroring the existing prebuilt-binary
+  + SHA-256-verified install with a `cargo build` fallback — no Rust toolchain required for a
+  normal install — plus PowerShell launcher scripts
+  (`scripts/open-file-viewer.ps1`/`-tab.ps1`) reproducing the bash launch-or-focus-or-close
+  toggle. `release.yml` publishes an `x86_64-pc-windows-msvc` binary; `ci.yml` runs the test
+  suite on `windows-latest` as an advisory (non-blocking) job while the platform is preview.
+  Windows support requires herdr's **preview channel**; see the README's Windows section. (No
+  Windows-on-ARM, no code-signing, no Windows renderer-install in this release.)
+
 ## [1.7.0] - 2026-06-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,16 +23,17 @@ All notable changes to this project are documented here. The format is based on
   Windows-on-ARM, no code-signing, no Windows renderer-install in this release.)
 
 ### Fixed
-- **Windows launch path under herdr's `\\?\` server cwd (real-hardware findings, GH #58).** On
-  Windows, herdr runs plugin commands against an extended-length (`\\?\`) verbatim working
-  directory, which the OS does not normalize — so a relative pane/action command (or one with
-  `/` or `.`) failed to resolve (`ERROR_PATH_NOT_FOUND`). The Windows launchers now open the pane
-  with an explicit clean `--cwd <plugin-root>` (herdr resolves the relative command against that
-  normalizable base), the manifest gains a distinct Windows pane entry (`file-viewer-windows`)
-  that names the `.exe` explicitly (herdr does not append it), and the Windows actions re-derive
-  the launcher script's absolute path from the cwd (stripping any `\\?\` prefix) instead of
-  passing a relative `-File`. A `windows-latest` test now parses the manifest's inline PowerShell
-  so a syntax error can't reach a real install.
+- **Windows launch, verified end-to-end on real hardware (GH #58).** herdr on Windows can't spawn
+  the manifest's *relative* pane command: it passes the relative program to `CreateProcessW`, which
+  resolves it against herdr's own directory (not any `--cwd`), failing with `ERROR_PATH_NOT_FOUND`
+  (os error 3); herdr also reports the plugin root as a `\\?\` verbatim path and does not append
+  `.exe`. So on Windows the launcher scripts now spawn the viewer **by absolute path** — `pane split`
+  (or `tab create`) + `pane run "<abs .exe>"`, rooted at the user's focused-pane directory and
+  labelled `Files` so the open/focus/close toggle still works — and the Windows actions locate the
+  launcher script by asking herdr for its own plugin root (`plugin list`, stripping `\\?\`) instead
+  of relying on the process cwd. A `windows-latest` test parses the manifest's inline PowerShell and
+  the launcher scripts so a syntax error can't reach a real install. (Renderers `glow`/`bat`/`delta`
+  remain optional runtime installs; without them the viewer shows plain text, unchanged.)
 
 ## [1.7.0] - 2026-06-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,18 @@ All notable changes to this project are documented here. The format is based on
   Windows support requires herdr's **preview channel**; see the README's Windows section. (No
   Windows-on-ARM, no code-signing, no Windows renderer-install in this release.)
 
+### Fixed
+- **Windows launch path under herdr's `\\?\` server cwd (real-hardware findings, GH #58).** On
+  Windows, herdr runs plugin commands against an extended-length (`\\?\`) verbatim working
+  directory, which the OS does not normalize — so a relative pane/action command (or one with
+  `/` or `.`) failed to resolve (`ERROR_PATH_NOT_FOUND`). The Windows launchers now open the pane
+  with an explicit clean `--cwd <plugin-root>` (herdr resolves the relative command against that
+  normalizable base), the manifest gains a distinct Windows pane entry (`file-viewer-windows`)
+  that names the `.exe` explicitly (herdr does not append it), and the Windows actions re-derive
+  the launcher script's absolute path from the cwd (stripping any `\\?\` prefix) instead of
+  passing a relative `-File`. A `windows-latest` test now parses the manifest's inline PowerShell
+  so a syntax error can't reach a real install.
+
 ## [1.7.0] - 2026-06-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,14 @@ All notable changes to this project are documented here. The format is based on
   of relying on the process cwd. A `windows-latest` test parses the manifest's inline PowerShell and
   the launcher scripts so a syntax error can't reach a real install. (Renderers `glow`/`bat`/`delta`
   remain optional runtime installs; without them the viewer shows plain text, unchanged.)
+- **Windows launcher: spawn the viewer via the PowerShell call operator (GH #58).** herdr's
+  `pane run` types the command into the pane's shell (PowerShell on Windows); a bare path split on a
+  space in the install path (e.g. `C:\Users\First Last\...`), so the viewer never launched for any
+  user whose plugin path contains a space. The launchers now run it as `& "<abs .exe>"` — call
+  operator + quoted path — confirmed live on real Windows from a spaced install path, with a
+  cross-platform test guarding the spawn form on the required CI matrix. `fetch-or-build.ps1` also
+  forces TLS 1.2 so the prebuilt fast path isn't needlessly dropped to a source build on older or
+  policy-locked Windows hosts.
 
 ## [1.7.0] - 2026-06-30
 

--- a/README.md
+++ b/README.md
@@ -119,9 +119,14 @@ Native Windows (`x86_64-pc-windows-msvc`) is supported as a **preview**, mirrori
 posture there: the crate builds, the test suite runs (advisory) on `windows-latest` CI, and
 install works the same way as Linux/macOS — `herdr plugin install` downloads a SHA-256-verified
 prebuilt binary (via `scripts/fetch-or-build.ps1`) or falls back to `cargo build --release`, no
-extra tooling required beyond the in-box Windows PowerShell 5.1. The same `open-file-viewer` /
-`open-file-viewer-tab` keybindings work via PowerShell launcher scripts.
+extra tooling required beyond the in-box Windows PowerShell 5.1. The open/toggle actions work via
+PowerShell launcher scripts.
 
+- **On Windows, bind the `-windows` action ids.** herdr requires every action id to be unique, so
+  the Windows launchers register as **`open-file-viewer-windows`** and
+  **`open-file-viewer-tab-windows`** (the unqualified `open-file-viewer` / `open-file-viewer-tab`
+  ids are the Linux/macOS variants). Point your herdr keybinding at the `-windows` id:
+  `command = "herdr plugin action invoke open-file-viewer-windows --plugin herdr-file-viewer"`.
 - **Requires herdr's preview channel.** Windows herdr binaries ship only on herdr's pre-release
   update channel, so you need to be on it before installing this plugin on Windows.
 - **Preview means best-effort, not a parity guarantee.** There's no Windows host in this

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 ![Rust 1.96+](https://img.shields.io/badge/rust-1.96%2B-orange.svg)
 ![herdr 0.7+](https://img.shields.io/badge/herdr-0.7%2B-8a2be2)
-![platforms: linux • macOS](https://img.shields.io/badge/platforms-linux%20%E2%80%A2%20macOS-informational)
+![platforms: linux • macOS • Windows (preview)](https://img.shields.io/badge/platforms-linux%20%E2%80%A2%20macOS%20%E2%80%A2%20Windows%20(preview)-informational)
 
 **Browse your repo without leaving your terminal session — a git-aware, read-only file viewer
 that lives in a herdr pane.** A keyboard-driven TUI with a directory tree
@@ -112,6 +112,27 @@ viewer and its open actions ship **inside** the plugin and register automaticall
 you only add the keybinding. The [keys](#keys) are below; deeper detail lives in the docs:
 [install & updating](docs/install.md), [external renderers](docs/renderers.md), and
 [summoning & keybindings](docs/usage.md).
+
+## Windows (preview)
+
+Native Windows (`x86_64-pc-windows-msvc`) is supported as a **preview**, mirroring herdr's own
+posture there: the crate builds, the test suite runs (advisory) on `windows-latest` CI, and
+install works the same way as Linux/macOS — `herdr plugin install` downloads a SHA-256-verified
+prebuilt binary (via `scripts/fetch-or-build.ps1`) or falls back to `cargo build --release`, no
+extra tooling required beyond the in-box Windows PowerShell 5.1. The same `open-file-viewer` /
+`open-file-viewer-tab` keybindings work via PowerShell launcher scripts.
+
+- **Requires herdr's preview channel.** Windows herdr binaries ship only on herdr's pre-release
+  update channel, so you need to be on it before installing this plugin on Windows.
+- **Preview means best-effort, not a parity guarantee.** There's no Windows host in this
+  project's CI gate (the `windows-latest` job is advisory, not required), so a Windows-specific
+  regression can land between releases. Full feature parity with Linux/macOS is the goal, not a
+  promise — please [open an issue](https://github.com/smarzban/herdr-file-viewer/issues) if you
+  hit a Windows-specific problem.
+- **WSL works today, with zero extra setup.** If you'd rather not wait on native-Windows preview
+  maturity, the existing Linux (`x86_64-unknown-linux-musl`) binary already runs unmodified
+  inside WSL — install herdr and this plugin from within your WSL distro exactly as you would on
+  native Linux.
 
 ## Keys
 

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -11,8 +11,17 @@
 #    duplicate action id at load time regardless of platform (verified against herdr 0.7.1),
 #    so the Windows launchers use the `-windows`-suffixed ids `open-file-viewer-windows` /
 #    `open-file-viewer-tab-windows`. On Windows, bind THOSE action ids.
-#  - [[panes]] is platform-agnostic (no shell; the binary is spawned directly — herdr appends
-#    `.exe` on Windows). No aarch64 Windows target is declared (v1 = x86_64-pc-windows-msvc).
+#  - Windows path handling (verified against real hardware, herdr 0.7.1-preview, GH #58): herdr
+#    does NOT append `.exe`, and it resolves a relative command against the process cwd — which on
+#    Windows is a `\\?\` extended-length (verbatim) path. Verbatim paths reach the OS with NO
+#    normalization, so a relative command (or one containing `/` or `.`) fails to resolve
+#    (ERROR_PATH_NOT_FOUND / os error 3). Two consequences:
+#     * [[panes]] has a distinct Windows entry (`file-viewer-windows`) naming the `.exe` explicitly;
+#       the Windows launcher opens it with `--cwd <plugin-root>` (a normal absolute path) so herdr
+#       resolves the relative command against a normalizable base instead of the `\\?\` server cwd.
+#     * the Windows [[actions]] re-derive the launcher script's absolute path from the cwd (stripping
+#       any `\\?\` prefix) rather than passing a relative `-File` path herdr would spawn under `\\?\`.
+#    No aarch64 Windows target is declared (v1 = x86_64-pc-windows-msvc).
 
 id = "herdr-file-viewer"
 name = "herdr-file-viewer"
@@ -36,12 +45,22 @@ command = ["powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", "s
 
 # The viewer pane. herdr performs the split placement on launch (AC-17); the [[actions]]
 # below summon it — declaring placement = "split" is what opens it beside the current pane.
-# Platform-agnostic: no shell is involved in opening the pane itself (AC-15).
+# No shell is involved in opening the pane itself (AC-15).
 [[panes]]
 id = "file-viewer"
 title = "Files"
 placement = "split"
 command = ["./target/release/herdr-file-viewer"]
+
+# Windows pane: a distinct id (herdr rejects duplicates) naming the `.exe` explicitly, since herdr
+# does NOT append it. The Windows launcher opens THIS entrypoint with `--cwd <plugin-root>` so the
+# relative command resolves against a normal path, not the `\\?\` server cwd (see header). Unused on
+# unix — panes are spawned on demand, so an extra entry the unix launchers never open costs nothing.
+[[panes]]
+id = "file-viewer-windows"
+title = "Files"
+placement = "split"
+command = ["./target/release/herdr-file-viewer.exe"]
 
 # The action that summons the viewer (bound to a keybinding in herdr config). This is
 # the only way the viewer is opened — there is no [[events]] hook (AC-N4). herdr actions
@@ -58,7 +77,12 @@ id = "open-file-viewer-windows"
 platforms = ["windows"]
 title = "Open file viewer"
 description = "Open the git-aware file viewer in a split pane beside the current work."
-command = ["powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", "scripts/open-file-viewer.ps1"]
+# Re-derive the launcher's ABSOLUTE path from the (possibly `\\?\`-prefixed) process cwd, rather than
+# a relative `-File` herdr would fail to resolve under a verbatim cwd. `.Substring(4)` drops `\\?\`.
+command = [
+  "powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command",
+  '''$d=[IO.Directory]::GetCurrentDirectory(); if ($d.StartsWith('\\?\')) { $d = $d.Substring(4) }; & (Join-Path (Join-Path $d 'scripts') 'open-file-viewer.ps1')''',
+]
 
 # The same viewer, opened in its own tab instead of a split. Idempotent across tabs: switches
 # to an existing viewer tab rather than duplicating it, and toggles off when already on it.
@@ -75,4 +99,8 @@ id = "open-file-viewer-tab-windows"
 platforms = ["windows"]
 title = "Open file viewer (tab)"
 description = "Open the git-aware file viewer in its own tab (switch to it if already open)."
-command = ["powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", "scripts/open-file-viewer-tab.ps1"]
+# See open-file-viewer-windows: re-derive the launcher's absolute path from the `\\?\` cwd.
+command = [
+  "powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command",
+  '''$d=[IO.Directory]::GetCurrentDirectory(); if ($d.StartsWith('\\?\')) { $d = $d.Substring(4) }; & (Join-Path (Join-Path $d 'scripts') 'open-file-viewer-tab.ps1')''',
+]

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -3,24 +3,36 @@
 # A git-aware, read-only file viewer that herdr opens in a split pane beside the
 # user's current work. The viewer appears ONLY in response to an explicit action
 # (its keybinding) — there are no event hooks and no automatic invocation (AC-N4).
+#
+# Windows support is preview (see README's Windows section): the unix and Windows [[build]]/
+# [[actions]] entries below are duplicated and platform-gated via the item-level `platforms`
+# key — herdr's platform filter runs exactly the host-matching entry per id and returns
+# `platform_unsupported` for the others. No aarch64 Windows target is declared (v1 targets
+# x86_64-pc-windows-msvc only).
 
 id = "herdr-file-viewer"
 name = "herdr-file-viewer"
 version = "1.7.0"
 description = "A git-aware, read-only file viewer: a keyboard-driven TUI in a herdr split pane."
 min_herdr_version = "0.7.0"
-platforms = ["linux", "macos"]
+platforms = ["linux", "macos", "windows"]
 
-# Build step herdr runs at install time. Fast path: scripts/fetch-or-build.sh downloads the
-# prebuilt binary matching this source's version + platform and verifies its SHA-256. On ANY miss
-# (no matching release, download/checksum failure, unsupported platform) it falls back to building
-# from source with cargo — so installing never gets harder than before, and no Rust toolchain is
-# needed when a matching prebuilt release exists.
+# Build step herdr runs at install time. Fast path: the platform's fetch-or-build script
+# downloads the prebuilt binary matching this source's version + platform and verifies its
+# SHA-256. On ANY miss (no matching release, download/checksum failure, unsupported platform) it
+# falls back to building from source with cargo — so installing never gets harder than before,
+# and no Rust toolchain is needed when a matching prebuilt release exists.
 [[build]]
+platforms = ["linux", "macos"]
 command = ["/bin/sh", "scripts/fetch-or-build.sh"]
+
+[[build]]
+platforms = ["windows"]
+command = ["powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", "scripts/fetch-or-build.ps1"]
 
 # The viewer pane. herdr performs the split placement on launch (AC-17); the [[actions]]
 # below summon it — declaring placement = "split" is what opens it beside the current pane.
+# Platform-agnostic: no shell is involved in opening the pane itself (AC-15).
 [[panes]]
 id = "file-viewer"
 title = "Files"
@@ -32,15 +44,31 @@ command = ["./target/release/herdr-file-viewer"]
 # run a `command`; the launcher script opens the [[panes]] entry below as a split.
 [[actions]]
 id = "open-file-viewer"
+platforms = ["linux", "macos"]
 title = "Open file viewer"
 description = "Open the git-aware file viewer in a split pane beside the current work."
 command = ["bash", "scripts/open-file-viewer.sh"]
+
+[[actions]]
+id = "open-file-viewer"
+platforms = ["windows"]
+title = "Open file viewer"
+description = "Open the git-aware file viewer in a split pane beside the current work."
+command = ["powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", "scripts/open-file-viewer.ps1"]
 
 # The same viewer, opened in its own tab instead of a split. Idempotent across tabs: switches
 # to an existing viewer tab rather than duplicating it, and toggles off when already on it.
 # Bind a key to it (e.g. `prefix+shift+f`) in ~/.config/herdr/config.toml.
 [[actions]]
 id = "open-file-viewer-tab"
+platforms = ["linux", "macos"]
 title = "Open file viewer (tab)"
 description = "Open the git-aware file viewer in its own tab (switch to it if already open)."
 command = ["bash", "scripts/open-file-viewer-tab.sh"]
+
+[[actions]]
+id = "open-file-viewer-tab"
+platforms = ["windows"]
+title = "Open file viewer (tab)"
+description = "Open the git-aware file viewer in its own tab (switch to it if already open)."
+command = ["powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", "scripts/open-file-viewer-tab.ps1"]

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -4,11 +4,15 @@
 # user's current work. The viewer appears ONLY in response to an explicit action
 # (its keybinding) — there are no event hooks and no automatic invocation (AC-N4).
 #
-# Windows support is preview (see README's Windows section): the unix and Windows [[build]]/
-# [[actions]] entries below are duplicated and platform-gated via the item-level `platforms`
-# key — herdr's platform filter runs exactly the host-matching entry per id and returns
-# `platform_unsupported` for the others. No aarch64 Windows target is declared (v1 targets
-# x86_64-pc-windows-msvc only).
+# Windows support is preview (see README's Windows section). Cross-platform packaging:
+#  - [[build]] has a unix (/bin/sh) and a Windows (PowerShell) entry, each gated by the
+#    item-level `platforms` key; herdr runs exactly the host-matching one at install time.
+#  - [[actions]] are gated the same way, but each carries a UNIQUE id — herdr rejects a
+#    duplicate action id at load time regardless of platform (verified against herdr 0.7.1),
+#    so the Windows launchers use the `-windows`-suffixed ids `open-file-viewer-windows` /
+#    `open-file-viewer-tab-windows`. On Windows, bind THOSE action ids.
+#  - [[panes]] is platform-agnostic (no shell; the binary is spawned directly — herdr appends
+#    `.exe` on Windows). No aarch64 Windows target is declared (v1 = x86_64-pc-windows-msvc).
 
 id = "herdr-file-viewer"
 name = "herdr-file-viewer"
@@ -50,7 +54,7 @@ description = "Open the git-aware file viewer in a split pane beside the current
 command = ["bash", "scripts/open-file-viewer.sh"]
 
 [[actions]]
-id = "open-file-viewer"
+id = "open-file-viewer-windows"
 platforms = ["windows"]
 title = "Open file viewer"
 description = "Open the git-aware file viewer in a split pane beside the current work."
@@ -67,7 +71,7 @@ description = "Open the git-aware file viewer in its own tab (switch to it if al
 command = ["bash", "scripts/open-file-viewer-tab.sh"]
 
 [[actions]]
-id = "open-file-viewer-tab"
+id = "open-file-viewer-tab-windows"
 platforms = ["windows"]
 title = "Open file viewer (tab)"
 description = "Open the git-aware file viewer in its own tab (switch to it if already open)."

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -11,16 +11,15 @@
 #    duplicate action id at load time regardless of platform (verified against herdr 0.7.1),
 #    so the Windows launchers use the `-windows`-suffixed ids `open-file-viewer-windows` /
 #    `open-file-viewer-tab-windows`. On Windows, bind THOSE action ids.
-#  - Windows path handling (verified against real hardware, herdr 0.7.1-preview, GH #58): herdr
-#    does NOT append `.exe`, and it resolves a relative command against the process cwd — which on
-#    Windows is a `\\?\` extended-length (verbatim) path. Verbatim paths reach the OS with NO
-#    normalization, so a relative command (or one containing `/` or `.`) fails to resolve
-#    (ERROR_PATH_NOT_FOUND / os error 3). Two consequences:
-#     * [[panes]] has a distinct Windows entry (`file-viewer-windows`) naming the `.exe` explicitly;
-#       the Windows launcher opens it with `--cwd <plugin-root>` (a normal absolute path) so herdr
-#       resolves the relative command against a normalizable base instead of the `\\?\` server cwd.
-#     * the Windows [[actions]] re-derive the launcher script's absolute path from the cwd (stripping
-#       any `\\?\` prefix) rather than passing a relative `-File` path herdr would spawn under `\\?\`.
+#  - Windows launch (verified on real hardware, herdr 0.7.1-preview, GH #58): herdr can NOT spawn the
+#    manifest's RELATIVE pane command on Windows — it passes the relative program to CreateProcessW,
+#    which resolves it against herdr's OWN directory (not any `--cwd` we set), failing with
+#    ERROR_PATH_NOT_FOUND (os error 3). herdr also reports the plugin root as a `\\?\` verbatim path
+#    and does NOT append `.exe`. So on Windows the launcher scripts spawn the viewer BY ABSOLUTE PATH
+#    (`pane split` / `tab create` + `pane run`), and the Windows [[actions]] locate the launcher
+#    script by asking herdr for its own plugin root (`plugin list`, stripping the `\\?\` prefix)
+#    rather than relying on the process cwd. There is deliberately NO Windows [[panes]] entry — the
+#    manifest pane's relative command is unspawnable there.
 #    No aarch64 Windows target is declared (v1 = x86_64-pc-windows-msvc).
 
 id = "herdr-file-viewer"
@@ -52,15 +51,8 @@ title = "Files"
 placement = "split"
 command = ["./target/release/herdr-file-viewer"]
 
-# Windows pane: a distinct id (herdr rejects duplicates) naming the `.exe` explicitly, since herdr
-# does NOT append it. The Windows launcher opens THIS entrypoint with `--cwd <plugin-root>` so the
-# relative command resolves against a normal path, not the `\\?\` server cwd (see header). Unused on
-# unix — panes are spawned on demand, so an extra entry the unix launchers never open costs nothing.
-[[panes]]
-id = "file-viewer-windows"
-title = "Files"
-placement = "split"
-command = ["./target/release/herdr-file-viewer.exe"]
+# (No Windows [[panes]] entry: herdr can't spawn the relative command on Windows, so the Windows
+# launchers spawn the viewer by absolute path via `pane split`/`tab create` + `pane run` — see header.)
 
 # The action that summons the viewer (bound to a keybinding in herdr config). This is
 # the only way the viewer is opened — there is no [[events]] hook (AC-N4). herdr actions
@@ -77,11 +69,11 @@ id = "open-file-viewer-windows"
 platforms = ["windows"]
 title = "Open file viewer"
 description = "Open the git-aware file viewer in a split pane beside the current work."
-# Re-derive the launcher's ABSOLUTE path from the (possibly `\\?\`-prefixed) process cwd, rather than
-# a relative `-File` herdr would fail to resolve under a verbatim cwd. `.Substring(4)` drops `\\?\`.
+# Locate the launcher by asking herdr for its own plugin root (the action's cwd is unreliable on
+# Windows), stripping the `\\?\` verbatim prefix herdr reports, then run the .ps1 by absolute path.
 command = [
   "powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command",
-  '''$d=[IO.Directory]::GetCurrentDirectory(); if ($d.StartsWith('\\?\')) { $d = $d.Substring(4) }; & (Join-Path (Join-Path $d 'scripts') 'open-file-viewer.ps1')''',
+  '''$b=$env:HERDR_BIN_PATH; if(-not $b){$b='herdr'}; $p=((& $b plugin list --json|ConvertFrom-Json).result.plugins|?{$_.plugin_id -eq 'herdr-file-viewer'}).plugin_root; if($p -and $p.StartsWith('\\?\')){$p=$p.Substring(4)}; & (Join-Path (Join-Path $p 'scripts') 'open-file-viewer.ps1')''',
 ]
 
 # The same viewer, opened in its own tab instead of a split. Idempotent across tabs: switches
@@ -99,8 +91,8 @@ id = "open-file-viewer-tab-windows"
 platforms = ["windows"]
 title = "Open file viewer (tab)"
 description = "Open the git-aware file viewer in its own tab (switch to it if already open)."
-# See open-file-viewer-windows: re-derive the launcher's absolute path from the `\\?\` cwd.
+# See open-file-viewer-windows: locate the launcher via herdr's own plugin root, not the cwd.
 command = [
   "powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command",
-  '''$d=[IO.Directory]::GetCurrentDirectory(); if ($d.StartsWith('\\?\')) { $d = $d.Substring(4) }; & (Join-Path (Join-Path $d 'scripts') 'open-file-viewer-tab.ps1')''',
+  '''$b=$env:HERDR_BIN_PATH; if(-not $b){$b='herdr'}; $p=((& $b plugin list --json|ConvertFrom-Json).result.plugins|?{$_.plugin_id -eq 'herdr-file-viewer'}).plugin_root; if($p -and $p.StartsWith('\\?\')){$p=$p.Substring(4)}; & (Join-Path (Join-Path $p 'scripts') 'open-file-viewer-tab.ps1')''',
 ]

--- a/scripts/fetch-or-build.ps1
+++ b/scripts/fetch-or-build.ps1
@@ -141,8 +141,12 @@ if (-not (Invoke-FvDownload $SumsUrl $TmpSums)) { Invoke-FvFallback "checksums n
 # Expected hash = the SHA256SUMS line for our asset filename.
 $Expected = $null
 $assetPattern = [regex]::Escape($Asset)
+# The separator before the filename is `  ` (two spaces, coreutils TEXT mode) on Linux/macOS, but
+# ` *` (one space + `*`, BINARY mode) when the line is produced by Git-for-Windows `sha256sum` on
+# the release runner — accept either marker (`[ *]`), or every Windows install would miss the
+# prebuilt and fall back to a source build (defeats AC-11/12/13).
 Get-Content $TmpSums | ForEach-Object {
-    if (-not $Expected -and $_ -match "^([0-9a-fA-F]{64})  ${assetPattern}`$") {
+    if (-not $Expected -and $_ -match "^([0-9a-fA-F]{64}) [ *]${assetPattern}`$") {
         $Expected = $Matches[1].ToLowerInvariant()
     }
 }

--- a/scripts/fetch-or-build.ps1
+++ b/scripts/fetch-or-build.ps1
@@ -77,6 +77,15 @@ function Get-FvSha256Hex {
 function Invoke-FvDownload {
     param([string]$Url, [string]$Dest)
     try {
+        # Force TLS 1.2 -- Windows PowerShell 5.1 inherits the .NET Framework default, which on
+        # older / policy-locked hosts can negotiate TLS 1.0 and be rejected by GitHub's release
+        # CDN, needlessly dropping the prebuilt fast path to a source build (which then needs a
+        # Rust toolchain). curl/wget on the unix side negotiate 1.2 unconditionally, so this only
+        # closes a .ps1-vs-.sh gap.
+        try {
+            [Net.ServicePointManager]::SecurityProtocol =
+                [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+        } catch {}
         Invoke-WebRequest -Uri $Url -OutFile $Dest -UseBasicParsing -ErrorAction Stop
         return $true
     } catch {

--- a/scripts/fetch-or-build.ps1
+++ b/scripts/fetch-or-build.ps1
@@ -1,0 +1,163 @@
+# fetch-or-build.ps1 -- herdr [[build]] step for herdr-file-viewer (Windows).
+#
+# Windows PowerShell 5.1 (Desktop) compatible -- the in-box shell on Windows 10/11/Server, so
+# installing the viewer needs no extra tooling. The Windows sibling of fetch-or-build.sh: same
+# behaviour, different shell.
+#
+# Fast path: download the prebuilt binary that matches THIS source's declared version + platform
+# from the GitHub release, verify its SHA-256, and install it at target\release\herdr-file-viewer.exe.
+# The match is by VERSION, not by exact commit: a checkout that is AHEAD of the matching release
+# (e.g. main has merged work that isn't tagged yet) still uses that released binary, so landing a
+# PR no longer forces new users to compile while a release is pending. Integrity is unchanged -- the
+# binary is still SHA-256 verified -- and a version with no published release still 404s to source.
+# Fallback: on ANY miss (no asset for this version, network/download error, checksum mismatch,
+# unmapped platform, no cargo) print a clear notice and build from source with cargo -- identical to
+# the pre-prebuilt behavior, so installing never gets harder than before.
+#
+# Paths and the release base URL are overridable via env (FV_REPO_ROOT / FV_CARGO_TOML / FV_OUT /
+# FV_BASE_URL) so this logic is exercised by a hermetic test with a mocked Invoke-WebRequest and a
+# stubbed cargo (mirrors fetch-or-build.sh's PATH-stubbed curl/cargo).
+#
+# v1 targets x86_64-pc-windows-msvc only (no aarch64 Windows -- AC-N4); no code-signing (AC-N5);
+# no Windows renderer-install (AC-N6).
+
+$ErrorActionPreference = 'Stop'
+
+$Repo = 'smarzban/herdr-file-viewer'
+
+$RepoRoot = if ($env:FV_REPO_ROOT) { $env:FV_REPO_ROOT } else { Join-Path $PSScriptRoot '..' }
+$CargoToml = if ($env:FV_CARGO_TOML) { $env:FV_CARGO_TOML } else { Join-Path $RepoRoot 'Cargo.toml' }
+$Out = if ($env:FV_OUT) { $env:FV_OUT } else { Join-Path $RepoRoot 'target\release\herdr-file-viewer.exe' }
+$BaseUrl = if ($env:FV_BASE_URL) { $env:FV_BASE_URL } else { "https://github.com/$Repo/releases/download" }
+
+# Build from source -- the original, unconditional behavior. A missing cargo gets a clear message
+# pointing at rustup, exactly like the sh script's fallback.
+function Build-FromSource {
+    $cargo = Get-Command cargo -ErrorAction SilentlyContinue
+    if (-not $cargo) {
+        [Console]::Error.WriteLine("herdr-file-viewer needs Rust 1.96+ to build, but cargo was not found. Install Rust from https://rustup.rs then re-run: herdr plugin install $Repo")
+        exit 1
+    }
+    & cargo build --release
+    exit $LASTEXITCODE
+}
+
+function Invoke-FvFallback {
+    param([string]$Reason)
+    [Console]::Error.WriteLine("herdr-file-viewer: $Reason - building from source instead.")
+    if ($script:TmpDir -and (Test-Path $script:TmpDir)) {
+        Remove-Item -Recurse -Force $script:TmpDir -ErrorAction SilentlyContinue
+    }
+    Build-FromSource
+}
+
+# Hex SHA-256 of a file. Get-FileHash is primary; certutil is the fallback (hedges the
+# constrained-environment Get-FileHash gap herdr's own installer hit), mirroring the sh script's
+# sha256sum/shasum preference order. $null on total failure (no usable tool / unreadable file).
+function Get-FvSha256Hex {
+    param([string]$Path)
+    try {
+        return (Get-FileHash -Algorithm SHA256 -Path $Path -ErrorAction Stop).Hash.ToLowerInvariant()
+    } catch {
+        try {
+            $out = & certutil -hashfile $Path SHA256 2>$null
+        } catch {
+            return $null
+        }
+        if ($LASTEXITCODE -ne 0 -or -not $out) { return $null }
+        $hashLine = $out | Where-Object { $_ -match '^[0-9a-fA-F]{64}$' } | Select-Object -First 1
+        if ($hashLine) { return $hashLine.Trim().ToLowerInvariant() }
+        return $null
+    }
+}
+
+# A thin Invoke-WebRequest wrapper -- the hermetic test shadows Invoke-WebRequest itself (a
+# PowerShell function in the calling scope takes precedence over a cmdlet of the same name, the
+# same mechanism Pester's mocking uses), so this wrapper needs no extra seam beyond that.
+function Invoke-FvDownload {
+    param([string]$Url, [string]$Dest)
+    try {
+        Invoke-WebRequest -Uri $Url -OutFile $Dest -UseBasicParsing -ErrorAction Stop
+        return $true
+    } catch {
+        return $false
+    }
+}
+
+# --- resolve the target triple from the platform --------------------------------------------
+$Arch = $env:PROCESSOR_ARCHITECTURE
+$Triple = $null
+if ($Arch -eq 'AMD64') { $Triple = 'x86_64-pc-windows-msvc' }
+if (-not $Triple) { Invoke-FvFallback "no prebuilt binary for Windows/$Arch" }
+
+# --- read the version this source declares ---------------------------------------------------
+$Version = $null
+if (Test-Path $CargoToml) {
+    $match = Select-String -Path $CargoToml -Pattern '^version\s*=\s*"([^"]+)"' | Select-Object -First 1
+    if ($match) { $Version = $match.Matches[0].Groups[1].Value }
+}
+if (-not $Version) { Invoke-FvFallback "could not read version from $CargoToml" }
+
+$Asset = "herdr-file-viewer-$Triple.exe"
+
+$script:TmpDir = Join-Path ([System.IO.Path]::GetTempPath()) ("fv-fob-" + [System.Guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $script:TmpDir -Force | Out-Null
+
+# --- version-only match + transparency "ahead" note (best-effort, never a failure) -----------
+# For transparency only: if this is a git work tree and we can read both HEAD and the release's
+# published COMMIT marker, note when the checkout is ahead -- the binary is the released
+# v$Version while the working tree may carry newer, unreleased source. Wrapped so any failure
+# here (git absent, no network) never blocks the main install flow.
+$AheadNote = ''
+try {
+    $git = Get-Command git -ErrorAction SilentlyContinue
+    if ($git) {
+        & git -C $RepoRoot rev-parse --is-inside-work-tree *> $null
+        if ($LASTEXITCODE -eq 0) {
+            $headRev = (& git -C $RepoRoot rev-parse HEAD 2>$null)
+            if (-not $headRev) { $headRev = 'nohead' }
+            $commitFile = Join-Path $script:TmpDir 'COMMIT'
+            if (Invoke-FvDownload "$BaseUrl/v$Version/COMMIT" $commitFile) {
+                $releaseCommit = (Get-Content $commitFile -Raw -ErrorAction SilentlyContinue)
+                if ($releaseCommit) { $releaseCommit = $releaseCommit.Trim() }
+                if ($releaseCommit -and ($headRev -ne $releaseCommit)) {
+                    $AheadNote = " Note: this checkout ($headRev) is ahead of the v$Version release commit ($releaseCommit), so newer unreleased source is not in this binary."
+                }
+            }
+        }
+    }
+} catch {
+    # Best-effort only -- never block the install on a transparency note.
+}
+
+$BinUrl = "$BaseUrl/v$Version/$Asset"
+$SumsUrl = "$BaseUrl/v$Version/SHA256SUMS"
+$TmpBin = Join-Path $script:TmpDir $Asset
+$TmpSums = Join-Path $script:TmpDir 'SHA256SUMS'
+
+if (-not (Invoke-FvDownload $BinUrl $TmpBin)) { Invoke-FvFallback "prebuilt binary not available for v$Version ($Asset)" }
+if (-not (Invoke-FvDownload $SumsUrl $TmpSums)) { Invoke-FvFallback "checksums not available for v$Version" }
+
+# Expected hash = the SHA256SUMS line for our asset filename.
+$Expected = $null
+$assetPattern = [regex]::Escape($Asset)
+Get-Content $TmpSums | ForEach-Object {
+    if (-not $Expected -and $_ -match "^([0-9a-fA-F]{64})  ${assetPattern}`$") {
+        $Expected = $Matches[1].ToLowerInvariant()
+    }
+}
+if (-not $Expected) { Invoke-FvFallback "no checksum listed for $Asset" }
+
+$Actual = Get-FvSha256Hex $TmpBin
+if (-not $Actual) { Invoke-FvFallback 'no SHA-256 tool (Get-FileHash/certutil) available' }
+if ($Actual -ne $Expected) { Invoke-FvFallback "checksum mismatch for $Asset (expected $Expected, got $Actual)" }
+
+# Verified -- move it into place.
+$OutDir = Split-Path -Parent $Out
+if ($OutDir -and -not (Test-Path $OutDir)) {
+    New-Item -ItemType Directory -Path $OutDir -Force | Out-Null
+}
+Move-Item -Force $TmpBin $Out
+[Console]::Out.WriteLine("herdr-file-viewer: installed prebuilt v$Version ($Triple), verified SHA-256.$AheadNote")
+Remove-Item -Recurse -Force $script:TmpDir -ErrorAction SilentlyContinue
+exit 0

--- a/scripts/fetch-or-build.sh
+++ b/scripts/fetch-or-build.sh
@@ -122,8 +122,11 @@ tmpsums="$tmpdir/SHA256SUMS"
 download "$bin_url" "$tmpbin"   || fallback "prebuilt binary not available for v$version ($asset)"
 download "$sums_url" "$tmpsums" || fallback "checksums not available for v$version"
 
-# Expected hash = the SHA256SUMS line for our asset filename.
-expected=$(grep -E "^[0-9a-f]{64}  $asset\$" "$tmpsums" 2>/dev/null | awk '{print $1}' | head -n 1)
+# Expected hash = the SHA256SUMS line for our asset filename. The separator before the name is
+# `  ` (two spaces, coreutils text mode) here, but `sha256sum`'s binary mode emits ` *name`; accept
+# either marker (`[ *]`) so a binary-mode line (e.g. from Git-for-Windows on the release runner)
+# still verifies rather than silently forcing a source build.
+expected=$(grep -E "^[0-9a-f]{64} [ *]$asset\$" "$tmpsums" 2>/dev/null | awk '{print $1}' | head -n 1)
 [ -n "$expected" ] || fallback "no checksum listed for $asset"
 
 actual=$(sha256_of "$tmpbin") || fallback "no sha-256 tool (sha256sum/shasum) available"

--- a/scripts/open-file-viewer-tab.ps1
+++ b/scripts/open-file-viewer-tab.ps1
@@ -1,0 +1,60 @@
+# open-file-viewer-tab.ps1 -- Windows sibling of scripts/open-file-viewer-tab.sh.
+#
+# Idempotent launcher for the file viewer in its own TAB -- used by the `open-file-viewer-tab`
+# action and a herdr keybinding (e.g. `prefix+shift+f`). "Open-or-switch, toggle on repeat",
+# scoped across tabs:
+#   - no Files pane anywhere                  -> open the viewer in a new tab (focused)
+#   - a Files pane lives in another tab       -> switch to that tab (no duplicate viewer)
+#   - a Files pane is in the current tab,
+#     but not focused                         -> focus it in place
+#   - the focused pane IS the Files pane      -> close it ("toggle off"; herdr auto-closes the
+#                                               now-empty tab -- verified)
+#
+# Sibling of scripts/open-file-viewer.ps1 (the split-pane variant). The OPEN/SWITCHTAB/FOCUS/
+# CLOSE decision is computed in-process by the viewer binary
+# (`herdr-file-viewer.exe --launch-decision-tab`, fed the `pane list` JSON on stdin), so it is
+# unit-tested (src/launch.rs) and the pane/tab ids it returns are validated flag-safe
+# (option-injection guard). Any failure degrades to OPEN (open a fresh viewer tab). herdr has no
+# focus-by-id, so an in-tab focus is a `zoom <id> --on/--off` cycle; a cross-tab switch is
+# `tab focus <tab_id>`.
+
+$ErrorActionPreference = 'Continue'
+
+$HerdrBin = if ($env:HERDR_BIN_PATH) { $env:HERDR_BIN_PATH } else { 'herdr' }
+$ViewerBin = Join-Path $PSScriptRoot '..\target\release\herdr-file-viewer.exe'
+
+function Open-Tab {
+    & $HerdrBin plugin pane open --plugin herdr-file-viewer --entrypoint file-viewer --placement tab --focus
+    exit $LASTEXITCODE
+}
+
+$Decision = 'OPEN'
+if (Test-Path $ViewerBin) {
+    $panes = & $HerdrBin pane list 2>$null
+    if ($LASTEXITCODE -ne 0) { $panes = $null }
+    if ($panes) {
+        $panesText = ($panes -join "`n")
+        $Decision = ($panesText | & $ViewerBin --launch-decision-tab 2>$null)
+        if ($LASTEXITCODE -ne 0 -or -not $Decision) { $Decision = 'OPEN' }
+    }
+}
+
+if ($Decision -like 'SWITCHTAB *') {
+    $TabId = $Decision.Substring(10)
+    # If the target tab vanished between the pane-list snapshot and now (a race -- the viewer
+    # tab was closed in between), fall back to opening a fresh viewer tab rather than leaving the
+    # keypress a silent no-op.
+    & $HerdrBin tab focus $TabId
+    if ($LASTEXITCODE -ne 0) { Open-Tab } else { exit 0 }
+} elseif ($Decision -like 'FOCUS *') {
+    $PaneId = $Decision.Substring(6)
+    & $HerdrBin pane zoom $PaneId --on *> $null
+    & $HerdrBin pane zoom $PaneId --off
+    exit $LASTEXITCODE
+} elseif ($Decision -like 'CLOSE *') {
+    $PaneId = $Decision.Substring(6)
+    & $HerdrBin pane close $PaneId
+    exit $LASTEXITCODE
+} else {
+    Open-Tab
+}

--- a/scripts/open-file-viewer-tab.ps1
+++ b/scripts/open-file-viewer-tab.ps1
@@ -21,10 +21,15 @@
 $ErrorActionPreference = 'Continue'
 
 $HerdrBin = if ($env:HERDR_BIN_PATH) { $env:HERDR_BIN_PATH } else { 'herdr' }
-$ViewerBin = Join-Path $PSScriptRoot '..\target\release\herdr-file-viewer.exe'
+
+# See open-file-viewer.ps1: a NORMAL absolute plugin root (strip any `\\?\` prefix) so herdr resolves
+# the pane's relative command against a normalizable `--cwd`, not the `\\?\` server cwd.
+$PluginRoot = Split-Path -Parent $PSScriptRoot
+if ($PluginRoot.StartsWith('\\?\')) { $PluginRoot = $PluginRoot.Substring(4) }
+$ViewerBin = Join-Path $PluginRoot 'target\release\herdr-file-viewer.exe'
 
 function Open-Tab {
-    & $HerdrBin plugin pane open --plugin herdr-file-viewer --entrypoint file-viewer --placement tab --focus
+    & $HerdrBin plugin pane open --plugin herdr-file-viewer --entrypoint file-viewer-windows --cwd $PluginRoot --placement tab --focus
     exit $LASTEXITCODE
 }
 

--- a/scripts/open-file-viewer-tab.ps1
+++ b/scripts/open-file-viewer-tab.ps1
@@ -50,7 +50,9 @@ function Open-Tab {
     $out = (& $HerdrBin tab create --cwd $cwd --label Files --focus | Out-String)
     $np = Get-PaneId $out
     if ($np) {
-        & $HerdrBin pane run $np "$ViewerBin"
+        # Call operator + quoted absolute path so a spaced install path still launches — see
+        # open-file-viewer.ps1's Open-Pane for the full why. (GH #58 — confirmed live on Windows.)
+        & $HerdrBin pane run $np "& \`"$ViewerBin\`""
         & $HerdrBin pane rename $np Files *> $null
     }
     exit 0

--- a/scripts/open-file-viewer-tab.ps1
+++ b/scripts/open-file-viewer-tab.ps1
@@ -1,6 +1,6 @@
 # open-file-viewer-tab.ps1 -- Windows sibling of scripts/open-file-viewer-tab.sh.
 #
-# Idempotent launcher for the file viewer in its own TAB -- used by the `open-file-viewer-tab`
+# Idempotent launcher for the file viewer in its own TAB -- used by the `open-file-viewer-tab-windows`
 # action and a herdr keybinding (e.g. `prefix+shift+f`). "Open-or-switch, toggle on repeat",
 # scoped across tabs:
 #   - no Files pane anywhere                  -> open the viewer in a new tab (focused)
@@ -10,27 +10,50 @@
 #   - the focused pane IS the Files pane      -> close it ("toggle off"; herdr auto-closes the
 #                                               now-empty tab -- verified)
 #
-# Sibling of scripts/open-file-viewer.ps1 (the split-pane variant). The OPEN/SWITCHTAB/FOCUS/
-# CLOSE decision is computed in-process by the viewer binary
-# (`herdr-file-viewer.exe --launch-decision-tab`, fed the `pane list` JSON on stdin), so it is
-# unit-tested (src/launch.rs) and the pane/tab ids it returns are validated flag-safe
-# (option-injection guard). Any failure degrades to OPEN (open a fresh viewer tab). herdr has no
-# focus-by-id, so an in-tab focus is a `zoom <id> --on/--off` cycle; a cross-tab switch is
-# `tab focus <tab_id>`.
+# Sibling of scripts/open-file-viewer.ps1 (the split-pane variant) -- see its header for WHY the
+# Windows launchers spawn the viewer by ABSOLUTE path (`tab create` + `pane run`) instead of
+# `plugin pane open --entrypoint`: herdr can't spawn the manifest's relative pane command on Windows
+# (CreateProcessW resolves a relative program against herdr's own dir), and stores the plugin root
+# as a `\\?\` verbatim path. The OPEN/SWITCHTAB/FOCUS/CLOSE decision is computed in-process by the
+# viewer binary (`--launch-decision-tab`, fed `pane list` JSON on stdin) and is unit-tested
+# (src/launch.rs). Any failure degrades to OPEN (a fresh viewer tab).
 
 $ErrorActionPreference = 'Continue'
 
 $HerdrBin = if ($env:HERDR_BIN_PATH) { $env:HERDR_BIN_PATH } else { 'herdr' }
 
-# See open-file-viewer.ps1: a NORMAL absolute plugin root (strip any `\\?\` prefix) so herdr resolves
-# the pane's relative command against a normalizable `--cwd`, not the `\\?\` server cwd.
-$PluginRoot = Split-Path -Parent $PSScriptRoot
-if ($PluginRoot.StartsWith('\\?\')) { $PluginRoot = $PluginRoot.Substring(4) }
+function Strip-Verbatim([string]$p) {
+    if ($p -and $p.StartsWith('\\?\')) { return $p.Substring(4) }
+    return $p
+}
+$PluginRoot = Strip-Verbatim (Split-Path -Parent $PSScriptRoot)
 $ViewerBin = Join-Path $PluginRoot 'target\release\herdr-file-viewer.exe'
 
+# Root the tree at the focused pane's cwd (the user's work pane). `pane list` prints JSON by default.
+function Get-UserCwd {
+    try {
+        $focused = (& $HerdrBin pane list | ConvertFrom-Json).result.panes |
+            Where-Object { $_.focused } | Select-Object -First 1
+        if ($focused -and $focused.cwd) { return Strip-Verbatim $focused.cwd }
+    } catch {}
+    return $PluginRoot
+}
+
+function Get-PaneId([string]$json) {
+    return ([regex]'"pane_id":"([^"]+)"').Match($json).Groups[1].Value
+}
+
 function Open-Tab {
-    & $HerdrBin plugin pane open --plugin herdr-file-viewer --entrypoint file-viewer-windows --cwd $PluginRoot --placement tab --focus
-    exit $LASTEXITCODE
+    $cwd = Get-UserCwd
+    # `tab create` makes a new tab with a shell pane (its `root_pane`); run the viewer into it by
+    # absolute path and label the pane "Files" so a later launch-decision recognises it.
+    $out = (& $HerdrBin tab create --cwd $cwd --label Files --focus | Out-String)
+    $np = Get-PaneId $out
+    if ($np) {
+        & $HerdrBin pane run $np "$ViewerBin"
+        & $HerdrBin pane rename $np Files *> $null
+    }
+    exit 0
 }
 
 $Decision = 'OPEN'

--- a/scripts/open-file-viewer.ps1
+++ b/scripts/open-file-viewer.ps1
@@ -1,0 +1,54 @@
+# open-file-viewer.ps1 -- Windows sibling of scripts/open-file-viewer.sh.
+#
+# Idempotent launcher for the file viewer -- used by both the `open-file-viewer` action and a
+# herdr keybinding (a `[[keys.command]]` with `type = "shell"`, run via PowerShell on Windows).
+# "Launch-or-focus, toggle on repeat", scoped to the current tab:
+#   - no Files pane in the current tab      -> open a split (focused)
+#   - a Files pane exists but isn't focused -> focus it
+#   - the focused pane IS the Files pane    -> close it ("hide"; herdr has no hide-without-close,
+#                                              and reopening just re-walks the tree -- cheap)
+#
+# herdr actions/keybindings run a command (no declarative "open this pane" field), so this shells
+# out to the herdr CLI via $env:HERDR_BIN_PATH (herdr injects it; fall back to `herdr` on PATH).
+#
+# The OPEN/FOCUS/CLOSE decision is computed in-process by the viewer binary itself
+# (`herdr-file-viewer.exe --launch-decision`, fed the `pane list` JSON on stdin) -- so it is
+# unit-tested (src/launch.rs) and the pane id it returns is already validated as flag-safe
+# (option-injection guard). Any failure (binary missing, parse error, no focused pane) degrades
+# to OPEN, preserving the original always-open behavior. herdr has no focus-by-id, so a focus is
+# a `zoom <id> --on/--off` cycle: `--on` focuses (and maximizes) the pane, `--off` un-maximizes
+# while keeping it focused.
+
+$ErrorActionPreference = 'Continue'
+
+$HerdrBin = if ($env:HERDR_BIN_PATH) { $env:HERDR_BIN_PATH } else { 'herdr' }
+$ViewerBin = Join-Path $PSScriptRoot '..\target\release\herdr-file-viewer.exe'
+
+function Open-Pane {
+    & $HerdrBin plugin pane open --plugin herdr-file-viewer --entrypoint file-viewer --placement split --direction right --focus
+    exit $LASTEXITCODE
+}
+
+$Decision = 'OPEN'
+if (Test-Path $ViewerBin) {
+    $panes = & $HerdrBin pane list 2>$null
+    if ($LASTEXITCODE -ne 0) { $panes = $null }
+    if ($panes) {
+        $panesText = ($panes -join "`n")
+        $Decision = ($panesText | & $ViewerBin --launch-decision 2>$null)
+        if ($LASTEXITCODE -ne 0 -or -not $Decision) { $Decision = 'OPEN' }
+    }
+}
+
+if ($Decision -like 'FOCUS *') {
+    $PaneId = $Decision.Substring(6)
+    & $HerdrBin pane zoom $PaneId --on *> $null
+    & $HerdrBin pane zoom $PaneId --off
+    exit $LASTEXITCODE
+} elseif ($Decision -like 'CLOSE *') {
+    $PaneId = $Decision.Substring(6)
+    & $HerdrBin pane close $PaneId
+    exit $LASTEXITCODE
+} else {
+    Open-Pane
+}

--- a/scripts/open-file-viewer.ps1
+++ b/scripts/open-file-viewer.ps1
@@ -22,10 +22,17 @@
 $ErrorActionPreference = 'Continue'
 
 $HerdrBin = if ($env:HERDR_BIN_PATH) { $env:HERDR_BIN_PATH } else { 'herdr' }
-$ViewerBin = Join-Path $PSScriptRoot '..\target\release\herdr-file-viewer.exe'
+
+# Plugin root as a NORMAL absolute path. herdr resolves a pane's relative command against the cwd
+# we pass; the server cwd on Windows is a `\\?\` extended-length path against which relative paths
+# (and `/`, `.`) don't resolve, so we strip any `\\?\` prefix and hand `plugin pane open` a clean
+# `--cwd`. `$PSScriptRoot` is `<root>\scripts`, so the parent is the plugin root.
+$PluginRoot = Split-Path -Parent $PSScriptRoot
+if ($PluginRoot.StartsWith('\\?\')) { $PluginRoot = $PluginRoot.Substring(4) }
+$ViewerBin = Join-Path $PluginRoot 'target\release\herdr-file-viewer.exe'
 
 function Open-Pane {
-    & $HerdrBin plugin pane open --plugin herdr-file-viewer --entrypoint file-viewer --placement split --direction right --focus
+    & $HerdrBin plugin pane open --plugin herdr-file-viewer --entrypoint file-viewer-windows --cwd $PluginRoot --placement split --direction right --focus
     exit $LASTEXITCODE
 }
 

--- a/scripts/open-file-viewer.ps1
+++ b/scripts/open-file-viewer.ps1
@@ -56,7 +56,12 @@ function Open-Pane {
     $out = (& $HerdrBin pane split --direction right --cwd $cwd --focus | Out-String)
     $np = Get-PaneId $out
     if ($np) {
-        & $HerdrBin pane run $np "$ViewerBin"
+        # Run the viewer by ABSOLUTE path via the PowerShell CALL OPERATOR. herdr types <command>
+        # into the pane's shell (PowerShell on Windows); a bare or plain-quoted path splits on a
+        # space in the install path (e.g. C:\Users\First Last\...) and the viewer never starts.
+        # `& "<path>"` executes it; the `\"` escaping survives Windows PowerShell 5.1's native-arg
+        # quote-stripping so herdr receives the quotes intact. (GH #58 — confirmed live on Windows.)
+        & $HerdrBin pane run $np "& \`"$ViewerBin\`""
         # Label it so a later invocation's launch-decision recognises it (best-effort).
         & $HerdrBin pane rename $np Files *> $null
     }

--- a/scripts/open-file-viewer.ps1
+++ b/scripts/open-file-viewer.ps1
@@ -1,39 +1,66 @@
 # open-file-viewer.ps1 -- Windows sibling of scripts/open-file-viewer.sh.
 #
-# Idempotent launcher for the file viewer -- used by both the `open-file-viewer` action and a
-# herdr keybinding (a `[[keys.command]]` with `type = "shell"`, run via PowerShell on Windows).
-# "Launch-or-focus, toggle on repeat", scoped to the current tab:
+# Idempotent launcher for the file viewer -- used by the `open-file-viewer-windows` action and a
+# herdr keybinding. "Launch-or-focus, toggle on repeat", scoped to the current tab:
 #   - no Files pane in the current tab      -> open a split (focused)
 #   - a Files pane exists but isn't focused -> focus it
 #   - the focused pane IS the Files pane    -> close it ("hide"; herdr has no hide-without-close,
 #                                              and reopening just re-walks the tree -- cheap)
 #
-# herdr actions/keybindings run a command (no declarative "open this pane" field), so this shells
-# out to the herdr CLI via $env:HERDR_BIN_PATH (herdr injects it; fall back to `herdr` on PATH).
+# WHY THIS DIVERGES FROM THE UNIX .sh (verified on real Windows, herdr 0.7.1-preview, GH #58):
+# the unix launcher opens the viewer with `plugin pane open --entrypoint file-viewer`, letting herdr
+# spawn the manifest's RELATIVE pane command. That does NOT work on Windows: herdr passes the
+# relative program name to CreateProcessW, which resolves it against herdr's OWN directory (not any
+# cwd we pass), so it fails with ERROR_PATH_NOT_FOUND (os error 3). herdr also stores the plugin
+# root as a `\\?\` verbatim path. So on Windows we instead spawn the viewer BY ABSOLUTE PATH:
+# `pane split` an empty pane, then `pane run` the absolute `.exe` into it, and `pane rename` it to
+# "Files" so the toggle (below) can find it again. We root the tree at the user's focused-pane cwd
+# (the viewer, launched via `pane run`, gets no HERDR_PLUGIN_CONTEXT_JSON, so it roots from its cwd).
 #
 # The OPEN/FOCUS/CLOSE decision is computed in-process by the viewer binary itself
 # (`herdr-file-viewer.exe --launch-decision`, fed the `pane list` JSON on stdin) -- so it is
-# unit-tested (src/launch.rs) and the pane id it returns is already validated as flag-safe
-# (option-injection guard). Any failure (binary missing, parse error, no focused pane) degrades
-# to OPEN, preserving the original always-open behavior. herdr has no focus-by-id, so a focus is
-# a `zoom <id> --on/--off` cycle: `--on` focuses (and maximizes) the pane, `--off` un-maximizes
-# while keeping it focused.
+# unit-tested (src/launch.rs) and the pane id it returns is validated flag-safe. Any failure
+# degrades to OPEN. herdr has no focus-by-id, so a focus is a `zoom <id> --on/--off` cycle.
 
 $ErrorActionPreference = 'Continue'
 
 $HerdrBin = if ($env:HERDR_BIN_PATH) { $env:HERDR_BIN_PATH } else { 'herdr' }
 
-# Plugin root as a NORMAL absolute path. herdr resolves a pane's relative command against the cwd
-# we pass; the server cwd on Windows is a `\\?\` extended-length path against which relative paths
-# (and `/`, `.`) don't resolve, so we strip any `\\?\` prefix and hand `plugin pane open` a clean
-# `--cwd`. `$PSScriptRoot` is `<root>\scripts`, so the parent is the plugin root.
-$PluginRoot = Split-Path -Parent $PSScriptRoot
-if ($PluginRoot.StartsWith('\\?\')) { $PluginRoot = $PluginRoot.Substring(4) }
+# Plugin root as a NORMAL absolute path (strip herdr's `\\?\` verbatim prefix). `$PSScriptRoot` is
+# `<root>\scripts`, so the parent is the plugin root; the viewer binary is an ABSOLUTE path under it.
+function Strip-Verbatim([string]$p) {
+    if ($p -and $p.StartsWith('\\?\')) { return $p.Substring(4) }
+    return $p
+}
+$PluginRoot = Strip-Verbatim (Split-Path -Parent $PSScriptRoot)
 $ViewerBin = Join-Path $PluginRoot 'target\release\herdr-file-viewer.exe'
 
+# The directory to root the tree at: the focused pane's cwd (the user's work pane) at invocation
+# time. `pane list` prints JSON by default (it rejects a `--json` flag).
+function Get-UserCwd {
+    try {
+        $focused = (& $HerdrBin pane list | ConvertFrom-Json).result.panes |
+            Where-Object { $_.focused } | Select-Object -First 1
+        if ($focused -and $focused.cwd) { return Strip-Verbatim $focused.cwd }
+    } catch {}
+    return $PluginRoot
+}
+
+# Extract the first `pane_id` from a herdr CLI JSON reply.
+function Get-PaneId([string]$json) {
+    return ([regex]'"pane_id":"([^"]+)"').Match($json).Groups[1].Value
+}
+
 function Open-Pane {
-    & $HerdrBin plugin pane open --plugin herdr-file-viewer --entrypoint file-viewer-windows --cwd $PluginRoot --placement split --direction right --focus
-    exit $LASTEXITCODE
+    $cwd = Get-UserCwd
+    $out = (& $HerdrBin pane split --direction right --cwd $cwd --focus | Out-String)
+    $np = Get-PaneId $out
+    if ($np) {
+        & $HerdrBin pane run $np "$ViewerBin"
+        # Label it so a later invocation's launch-decision recognises it (best-effort).
+        & $HerdrBin pane rename $np Files *> $null
+    }
+    exit 0
 }
 
 $Decision = 'OPEN'

--- a/src/app.rs
+++ b/src/app.rs
@@ -304,7 +304,20 @@ fn resolve_editor(editor: Option<OsString>) -> Option<OsString> {
 
 #[cfg(windows)]
 fn resolve_editor(editor: Option<OsString>) -> Option<OsString> {
-    editor.or_else(|| Some(OsString::from("notepad.exe")))
+    editor.or_else(|| {
+        // Default to Notepad, resolved to its ABSOLUTE `System32` path. A bare `notepad.exe`
+        // would be subject to Windows' executable search order — which can include the process
+        // working directory, here an *untrusted* browsed repo — so a `notepad.exe` planted in the
+        // repo could be spawned instead of the system editor, breaking the read-only/no-repo-code
+        // boundary (constitution #1). Resolving via `%SystemRoot%` closes that hole. If
+        // `SystemRoot` is somehow unset, fall back to no editor (a "no editor configured" notice)
+        // rather than a hijackable bare name.
+        let root = std::env::var_os("SystemRoot").filter(|r| !r.is_empty())?;
+        let mut p = std::path::PathBuf::from(root);
+        p.push("System32");
+        p.push("notepad.exe");
+        Some(p.into_os_string())
+    })
 }
 
 /// The live Editor Launcher: spawn `$EDITOR <file>` as a blocking hand-off, suspending and
@@ -543,11 +556,24 @@ mod tests {
         assert_eq!(resolve_editor(None), None);
     }
 
-    /// Windows: an unset `$EDITOR` falls back to a known default (`notepad.exe`).
+    /// Windows: an unset `$EDITOR` falls back to an ABSOLUTE `System32\notepad.exe` (never a
+    /// bare, search-path-hijackable `notepad.exe` — see the seam's security note). `windows-latest`
+    /// always has `%SystemRoot%` set, so the default resolves to a real absolute path.
     #[cfg(windows)]
     #[test]
-    fn resolve_editor_windows_unset_falls_back_to_notepad() {
-        assert_eq!(resolve_editor(None), Some(OsString::from("notepad.exe")));
+    fn resolve_editor_windows_unset_falls_back_to_absolute_notepad() {
+        let got = resolve_editor(None).expect("a default editor on Windows");
+        let p = std::path::Path::new(&got);
+        assert!(
+            p.is_absolute(),
+            "the default editor path is absolute: {got:?}"
+        );
+        assert!(
+            got.to_string_lossy()
+                .to_lowercase()
+                .ends_with("system32\\notepad.exe"),
+            "defaults to System32\\notepad.exe: {got:?}"
+        );
     }
 
     /// A fresh empty temp dir for a test (no tempfile dep — matches the project's hermetic

--- a/src/app.rs
+++ b/src/app.rs
@@ -68,7 +68,7 @@ pub fn run() -> io::Result<()> {
             RootProviders { git, content }
         });
     let editor: Box<dyn EditorHandoff> = Box::new(LiveEditor {
-        editor: std::env::var_os("EDITOR"),
+        editor: resolve_editor(std::env::var_os("EDITOR")),
     });
     let clipboard: Box<dyn Clipboard> = Box::new(Osc52Clipboard);
 
@@ -291,6 +291,22 @@ impl ContentProvider for LiveContent {
     }
 }
 
+/// Resolve the editor command to use, given `$EDITOR`'s raw value (AC-8 part).
+///
+/// unix: unchanged (AC-3) — a set `$EDITOR` is used as-is; unset stays `None` (the editor
+/// hand-off then reports "no editor configured", today's behaviour). Windows: a set `$EDITOR`
+/// is likewise used as-is; unset falls back to a known default (`notepad.exe`, always present
+/// on Windows) instead of leaving the hand-off unconfigured.
+#[cfg(not(windows))]
+fn resolve_editor(editor: Option<OsString>) -> Option<OsString> {
+    editor
+}
+
+#[cfg(windows)]
+fn resolve_editor(editor: Option<OsString>) -> Option<OsString> {
+    editor.or_else(|| Some(OsString::from("notepad.exe")))
+}
+
 /// The live Editor Launcher: spawn `$EDITOR <file>` as a blocking hand-off, suspending and
 /// restoring the TUI around it. A missing `$EDITOR` is a non-fatal error the controller
 /// surfaces as a notice.
@@ -508,6 +524,31 @@ fn default_renderers() -> Renderers {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ---- resolve_editor: default-editor platform seam (AC-8, T-5) --------------
+
+    /// A set `$EDITOR` is always used as-is, on every platform.
+    #[test]
+    fn resolve_editor_passes_through_a_set_value() {
+        assert_eq!(
+            resolve_editor(Some(OsString::from("vim"))),
+            Some(OsString::from("vim"))
+        );
+    }
+
+    /// unix: an unset `$EDITOR` stays `None` (today's behaviour, unchanged — AC-3).
+    #[cfg(not(windows))]
+    #[test]
+    fn resolve_editor_unix_unset_stays_none() {
+        assert_eq!(resolve_editor(None), None);
+    }
+
+    /// Windows: an unset `$EDITOR` falls back to a known default (`notepad.exe`).
+    #[cfg(windows)]
+    #[test]
+    fn resolve_editor_windows_unset_falls_back_to_notepad() {
+        assert_eq!(resolve_editor(None), Some(OsString::from("notepad.exe")));
+    }
 
     /// A fresh empty temp dir for a test (no tempfile dep — matches the project's hermetic
     /// test style). Distinct per `tag` so parallel unit tests don't collide.

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -66,15 +66,14 @@ impl EditorLauncher {
 
     /// Build the local-spawn argv: the configured editor split into program + arguments
     /// (so `$EDITOR` values like `"code --wait"` launch correctly), with the selected file
-    /// appended as the final argument. Whitespace-split is the conventional `$EDITOR`
-    /// reading; an editor path containing spaces is not supported. An empty/whitespace-only
-    /// editor falls back to the raw value so the launch fails loudly rather than exec-ing the
-    /// file.
+    /// appended as the final argument. A quote-aware tokenizer (see [`tokenize_command`])
+    /// replaces a naive whitespace-split so a double-quoted program path containing spaces
+    /// (e.g. `"C:\Program Files\…\Code.exe" --wait`) stays a single argv[0]. An
+    /// empty/whitespace-only editor falls back to the raw value so the launch fails loudly
+    /// rather than exec-ing the file.
     fn editor_argv(&self, file: &Path) -> Vec<OsString> {
-        let mut argv: Vec<OsString> = self
-            .editor
-            .to_string_lossy()
-            .split_whitespace()
+        let mut argv: Vec<OsString> = tokenize_command(&self.editor.to_string_lossy())
+            .into_iter()
             .map(OsString::from)
             .collect();
         if argv.is_empty() {
@@ -82,5 +81,64 @@ impl EditorLauncher {
         }
         argv.push(file.as_os_str().to_owned());
         argv
+    }
+}
+
+/// Split a configured command string into tokens, honouring double-quoted segments so a
+/// quoted program path containing spaces (e.g. a Windows `"C:\Program Files\…\Code.exe"`)
+/// stays one token instead of being split apart. Whitespace outside quotes separates tokens;
+/// the quote characters themselves are not included in the token. Cross-platform — not
+/// `cfg`-gated, since a quoted-path `$EDITOR` value is a valid configuration on any platform.
+fn tokenize_command(s: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    let mut in_token = false;
+    let mut in_quotes = false;
+    for c in s.chars() {
+        match c {
+            '"' => {
+                in_quotes = !in_quotes;
+                in_token = true;
+            }
+            c if c.is_whitespace() && !in_quotes => {
+                if in_token {
+                    tokens.push(std::mem::take(&mut current));
+                    in_token = false;
+                }
+            }
+            c => {
+                current.push(c);
+                in_token = true;
+            }
+        }
+    }
+    if in_token {
+        tokens.push(current);
+    }
+    tokens
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tokenize_command_splits_unquoted_whitespace() {
+        assert_eq!(tokenize_command("code --wait"), vec!["code", "--wait"]);
+        assert_eq!(tokenize_command("vi"), vec!["vi"]);
+    }
+
+    #[test]
+    fn tokenize_command_keeps_a_quoted_segment_with_spaces_as_one_token() {
+        assert_eq!(
+            tokenize_command(r#""C:\Program Files\Code\Code.exe" --wait"#),
+            vec![r"C:\Program Files\Code\Code.exe", "--wait"]
+        );
+    }
+
+    #[test]
+    fn tokenize_command_empty_or_whitespace_only_yields_no_tokens() {
+        assert!(tokenize_command("").is_empty());
+        assert!(tokenize_command("   ").is_empty());
     }
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -15,9 +15,7 @@
 
 use crate::root::Resolved;
 use std::collections::BTreeMap;
-use std::ffi::OsStr;
 use std::io::Read;
-use std::os::unix::ffi::OsStrExt;
 use std::path::{Component, Path, PathBuf};
 use std::process::{Command, Stdio};
 
@@ -65,6 +63,27 @@ pub fn status(repo_root: &Path) -> BTreeMap<PathBuf, Status> {
     }
 }
 
+/// Decode one raw path field from git's NUL-delimited (`-z`) output into a [`PathBuf`].
+///
+/// unix: a lossless byte-for-byte mapping (today's `OsStr::from_bytes`) — any filename
+/// (spaces, control chars, non-UTF-8 bytes) maps to the real filesystem path, since unix
+/// `OsStr` is an arbitrary byte sequence.
+///
+/// Windows: git always emits UTF-8 path bytes (Windows paths are UTF-16 internally, so a
+/// non-UTF-8 byte sequence from git is essentially unreachable there). Bytes are decoded as
+/// UTF-8; a path that somehow fails to decode is dropped (`None`) rather than panicking,
+/// consistent with this module's degrade-to-neutral rule (AC-5).
+#[cfg(unix)]
+fn path_from_git_bytes(bytes: &[u8]) -> Option<PathBuf> {
+    use std::os::unix::ffi::OsStrExt;
+    Some(PathBuf::from(std::ffi::OsStr::from_bytes(bytes)))
+}
+
+#[cfg(windows)]
+fn path_from_git_bytes(bytes: &[u8]) -> Option<PathBuf> {
+    std::str::from_utf8(bytes).ok().map(PathBuf::from)
+}
+
 /// Parse `git status --porcelain=v1 -z -uall` output into a per-path status map.
 ///
 /// Extracted from [`status`] so the parser's defensive branches (truncated records,
@@ -84,8 +103,10 @@ fn parse_porcelain_status(out: &[u8]) -> BTreeMap<PathBuf, Status> {
         if code.contains('R') || code.contains('C') {
             fields.next();
         }
-        if let Some(s) = classify(code) {
-            map.insert(PathBuf::from(OsStr::from_bytes(path)), s);
+        if let Some(s) = classify(code)
+            && let Some(p) = path_from_git_bytes(path)
+        {
+            map.insert(p, s);
         }
     }
     map
@@ -109,8 +130,10 @@ fn parse_name_status(out: &[u8]) -> BTreeMap<PathBuf, Status> {
             fields.next()
         };
         let Some(path) = path else { break };
-        if let Some(s) = classify_name_status(code) {
-            map.insert(PathBuf::from(OsStr::from_bytes(path)), s);
+        if let Some(s) = classify_name_status(code)
+            && let Some(p) = path_from_git_bytes(path)
+        {
+            map.insert(p, s);
         }
     }
     map
@@ -426,6 +449,52 @@ fn classify_name_status(code: &str) -> Option<Status> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ---- path_from_git_bytes: platform path-decode seam (AC-5, T-1) ------------
+
+    /// unix: a byte sequence with spaces and non-ASCII (but valid UTF-8) bytes maps
+    /// losslessly to the equivalent `PathBuf`, matching today's `OsStr::from_bytes` behaviour.
+    #[cfg(unix)]
+    #[test]
+    fn path_from_git_bytes_unix_maps_arbitrary_bytes_losslessly() {
+        let bytes = "my résumé file.txt".as_bytes();
+        assert_eq!(
+            path_from_git_bytes(bytes),
+            Some(PathBuf::from("my résumé file.txt"))
+        );
+    }
+
+    /// unix: even non-UTF-8 bytes (which a real OS filename can legally contain) decode
+    /// without loss — `OsStr` is an arbitrary byte sequence on unix.
+    #[cfg(unix)]
+    #[test]
+    fn path_from_git_bytes_unix_preserves_non_utf8_bytes() {
+        use std::os::unix::ffi::OsStrExt;
+        let bytes = [b'a', 0xFF, b'b'];
+        let decoded = path_from_git_bytes(&bytes).expect("non-UTF-8 bytes still decode on unix");
+        assert_eq!(decoded.as_os_str().as_bytes(), &bytes);
+    }
+
+    /// Windows: git emits UTF-8 path bytes; a UTF-8 byte path decodes to the equivalent
+    /// `PathBuf` (the contract this seam exists to satisfy — AC-5).
+    #[cfg(windows)]
+    #[test]
+    fn path_from_git_bytes_windows_decodes_utf8_paths() {
+        let bytes = "my résumé file.txt".as_bytes();
+        assert_eq!(
+            path_from_git_bytes(bytes),
+            Some(PathBuf::from("my résumé file.txt"))
+        );
+    }
+
+    /// Windows: a non-UTF-8 byte sequence (essentially unreachable from real git output)
+    /// is dropped (`None`), never a panic — the module's degrade-to-neutral rule.
+    #[cfg(windows)]
+    #[test]
+    fn path_from_git_bytes_windows_drops_invalid_utf8_without_panic() {
+        let bytes = [0xFFu8, 0xFE, 0xFD];
+        assert_eq!(path_from_git_bytes(&bytes), None);
+    }
 
     /// The shared hardened builder must apply *every* untrusted-repo guard. This is the
     /// regression guard that keeps the Git Service and the Root Resolver — which now build

--- a/src/git.rs
+++ b/src/git.rs
@@ -22,6 +22,14 @@ use std::process::{Command, Stdio};
 /// git's well-known empty-tree object — the baseline for an unborn repo's first files.
 const EMPTY_TREE: &str = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
 
+/// The host's null-device token: the untracked-file diff base and the `core.hooksPath`
+/// neutralization target both need a path that always resolves to "discard" — `/dev/null`
+/// on unix, `NUL` on Windows (AC-6).
+#[cfg(unix)]
+const NULL_DEVICE: &str = "/dev/null";
+#[cfg(windows)]
+const NULL_DEVICE: &str = "NUL";
+
 /// Unified-context window for a full-context (whole-file) diff: a value far larger than any
 /// real file, so every unchanged line is emitted as context around the changes. The output is
 /// bounded by [`MAX_DIFF_BYTES`] (and the render layer's AC-13 cap), so an enormous file's
@@ -232,7 +240,7 @@ pub fn diff(
         ];
         args.extend(unified);
         args.push("--");
-        args.push("/dev/null");
+        args.push(NULL_DEVICE);
         let mut cmd = git_command(repo_root, &args);
         cmd.arg(path);
         return capture_stdout(cmd);
@@ -276,12 +284,9 @@ pub(crate) fn git_command(repo_root: &Path, args: &[&str]) -> Command {
         // repo-planted `filter=<driver>` (clean/smudge) or `diff=<driver>` (textconv)
         // cannot run a configured program during a read-only query.
         .arg(format!("--attr-source={EMPTY_TREE}"))
-        .args([
-            "-c",
-            "core.fsmonitor=false",
-            "-c",
-            "core.hooksPath=/dev/null",
-        ])
+        .args(["-c", "core.fsmonitor=false"])
+        .arg("-c")
+        .arg(format!("core.hooksPath={NULL_DEVICE}"))
         .args(args);
     cmd
 }
@@ -496,6 +501,37 @@ mod tests {
         assert_eq!(path_from_git_bytes(&bytes), None);
     }
 
+    // ---- NULL_DEVICE: platform null-device seam (AC-6, T-2) --------------------
+
+    /// unix: the null-device token is `/dev/null`.
+    #[cfg(unix)]
+    #[test]
+    fn null_device_is_dev_null_on_unix() {
+        assert_eq!(NULL_DEVICE, "/dev/null");
+    }
+
+    /// Windows: the null-device token is `NUL`.
+    #[cfg(windows)]
+    #[test]
+    fn null_device_is_nul_on_windows() {
+        assert_eq!(NULL_DEVICE, "NUL");
+    }
+
+    /// `git_command`'s `core.hooksPath` hardening uses the same host null-device token as the
+    /// untracked-diff base (both derive from [`NULL_DEVICE`]), so the two callers cannot drift.
+    #[test]
+    fn hooks_path_hardening_uses_the_null_device_constant() {
+        let cmd = git_command(Path::new("/some/repo"), &["status"]);
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        assert!(
+            args.contains(&format!("core.hooksPath={NULL_DEVICE}")),
+            "hooksPath uses the platform null-device constant: {args:?}"
+        );
+    }
+
     /// The shared hardened builder must apply *every* untrusted-repo guard. This is the
     /// regression guard that keeps the Git Service and the Root Resolver — which now build
     /// their queries through this one function — from silently dropping a protection (AC-N2).
@@ -517,7 +553,7 @@ mod tests {
             "fsmonitor neutralized: {args:?}"
         );
         assert!(
-            args.contains(&"core.hooksPath=/dev/null".to_string()),
+            args.contains(&format!("core.hooksPath={NULL_DEVICE}")),
             "hooks neutralized: {args:?}"
         );
         assert!(

--- a/src/herdr.rs
+++ b/src/herdr.rs
@@ -9,6 +9,7 @@
 
 use std::ffi::{OsStr, OsString};
 use std::io;
+use std::path::Path;
 use std::process::{Command, Output};
 
 // ---------------------------------------------------------------------------
@@ -95,11 +96,103 @@ impl<R: CommandRunner> HerdrCli for LiveHerdr<R> {
 
 /// Resolve the herdr binary path from the optional env-var value.
 ///
-/// - `Some(non-empty)` → use that path.
+/// - `Some(non-empty)` → use that path (with the Windows `.exe`-suffix seam below applied).
 /// - `None` or `Some("")` → fall back to `"herdr"`.
 pub fn resolve_program(var: Option<String>) -> OsString {
+    resolve_program_with(var, Path::exists)
+}
+
+/// [`resolve_program`]'s logic, factored out so the Windows `.exe`-suffix seam is testable
+/// from an injected exists-predicate (no real filesystem probing needed in tests).
+fn resolve_program_with(var: Option<String>, exists: impl Fn(&Path) -> bool) -> OsString {
     match var {
-        Some(v) if !v.is_empty() => OsString::from(v),
+        Some(v) if !v.is_empty() => with_exe_suffix(v, exists),
         _ => OsString::from("herdr"),
+    }
+}
+
+/// unix: an explicit path/name is used exactly as configured (unchanged — AC-3).
+#[cfg(not(windows))]
+fn with_exe_suffix(v: String, _exists: impl Fn(&Path) -> bool) -> OsString {
+    OsString::from(v)
+}
+
+/// Windows: a *bare* name (no path separator) defers to the OS's own `PATH`/`PATHEXT` search —
+/// untouched, since the OS already tries `.exe`/`.cmd`/… there. An *explicit* path that lacks
+/// an extension and is not found as given resolves to its `.exe` form, so a configured value
+/// like `C:\tools\herdr` (commonly typed without the suffix) still locates the real binary
+/// (AC-9).
+#[cfg(windows)]
+fn with_exe_suffix(v: String, exists: impl Fn(&Path) -> bool) -> OsString {
+    let path = Path::new(&v);
+    let is_explicit_path = v.contains('/') || v.contains('\\');
+    if is_explicit_path && path.extension().is_none() && !exists(path) {
+        return OsString::from(format!("{v}.exe"));
+    }
+    OsString::from(v)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- with_exe_suffix: Windows executable-suffix resolution (AC-9, T-6) -----
+
+    /// unix: any explicit path/name is returned exactly as configured, regardless of what the
+    /// (injected, never consulted) exists-predicate would say — AC-3.
+    #[cfg(not(windows))]
+    #[test]
+    fn with_exe_suffix_unix_returns_the_value_unchanged() {
+        let got = resolve_program_with(Some("/custom/herdr".to_string()), |_| false);
+        assert_eq!(got, OsString::from("/custom/herdr"));
+    }
+
+    /// Windows: an explicit path lacking an extension and not found as given resolves to its
+    /// `.exe` form.
+    #[cfg(windows)]
+    #[test]
+    fn with_exe_suffix_windows_explicit_path_without_extension_gets_exe_suffix() {
+        let got = resolve_program_with(Some(r"C:\tools\herdr".to_string()), |_| false);
+        assert_eq!(got, OsString::from(r"C:\tools\herdr.exe"));
+    }
+
+    /// Windows: a bare name (no path separator) defers to the OS's own `PATH`/`PATHEXT`
+    /// search — left untouched even though it "doesn't exist" by the injected predicate.
+    #[cfg(windows)]
+    #[test]
+    fn with_exe_suffix_windows_bare_name_defers_to_path_search() {
+        let got = resolve_program_with(Some("herdr".to_string()), |_| false);
+        assert_eq!(got, OsString::from("herdr"));
+    }
+
+    /// Windows: an explicit path that already exists as given (e.g. a `.bat` shim, or any
+    /// extension-less file that really is the binary) is left untouched.
+    #[cfg(windows)]
+    #[test]
+    fn with_exe_suffix_windows_explicit_path_that_exists_is_untouched() {
+        let got = resolve_program_with(Some(r"C:\tools\herdr".to_string()), |_| true);
+        assert_eq!(got, OsString::from(r"C:\tools\herdr"));
+    }
+
+    /// Windows: an explicit path that already carries an extension (e.g. `.exe`, `.cmd`) is
+    /// left untouched, even when it does not exist as given.
+    #[cfg(windows)]
+    #[test]
+    fn with_exe_suffix_windows_explicit_path_with_extension_is_untouched() {
+        let got = resolve_program_with(Some(r"C:\tools\herdr.cmd".to_string()), |_| false);
+        assert_eq!(got, OsString::from(r"C:\tools\herdr.cmd"));
+    }
+
+    /// `None`/empty still fall back to `"herdr"` on every platform (unchanged).
+    #[test]
+    fn resolve_program_with_none_or_empty_falls_back_to_herdr() {
+        assert_eq!(
+            resolve_program_with(None, |_| false),
+            OsString::from("herdr")
+        );
+        assert_eq!(
+            resolve_program_with(Some(String::new()), |_| false),
+            OsString::from("herdr")
+        );
     }
 }

--- a/src/index.rs
+++ b/src/index.rs
@@ -45,11 +45,23 @@ pub fn build(root: &Path) -> Vec<String> {
         .build()
         .filter_map(Result::ok) // skip unreadable entries; traversal continues
         .filter(|e| e.file_type().is_some_and(|t| t.is_file())) // files only — AC-15
-        .filter_map(|e| {
-            e.path()
-                .strip_prefix(root)
-                .ok()
-                .map(|rel| rel.to_string_lossy().into_owned())
-        })
+        .filter_map(|e| e.path().strip_prefix(root).ok().map(rel_to_slash))
         .collect()
+}
+
+/// Render a root-relative path as a forward-slash string on every platform. The rest of the app
+/// (git status/diff/worktree paths, the tree, the content title) speaks git's forward-slash
+/// convention; on Windows the native separator is `\`, so a raw stringification would make the
+/// finder's listing inconsistent with the rest of the UI. Joining the path's `Normal` components
+/// with `/` is identical to today's output on unix (the separator already is `/`) and converts
+/// `a\b` → `a/b` on Windows. It also enforces AC-N5 (root-relative, no `..`/absolute leak) by
+/// construction.
+fn rel_to_slash(rel: &Path) -> String {
+    rel.components()
+        .filter_map(|c| match c {
+            std::path::Component::Normal(s) => Some(s.to_string_lossy()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("/")
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -619,6 +619,10 @@ mod tests {
         d
     }
 
+    // Creating a symlink reliably without elevated privilege is a unix assumption (Windows
+    // symlink creation needs Developer Mode or admin rights, not guaranteed on a CI runner);
+    // the escape-via-symlink guard these exercise is platform-agnostic path canonicalization.
+    #[cfg(unix)]
     #[test]
     fn refuses_a_symlink_whose_target_escapes_the_root() {
         use std::os::unix::fs::symlink;
@@ -635,6 +639,7 @@ mod tests {
         fs::remove_file(&outside).ok();
     }
 
+    #[cfg(unix)]
     #[test]
     fn follows_a_symlink_that_stays_within_the_root() {
         use std::os::unix::fs::symlink;

--- a/src/update/cache.rs
+++ b/src/update/cache.rs
@@ -39,14 +39,37 @@ pub fn next_cache(now_unix: u64, latest: Option<Version>) -> Cache {
 }
 
 /// The plugin's cache directory: `$XDG_CACHE_HOME/herdr-file-viewer`, else
-/// `$HOME/.cache/herdr-file-viewer`. `None` when neither is set (then we check without
-/// persisting — a rare headless case).
+/// `$HOME/.cache/herdr-file-viewer` (unix) / `%LOCALAPPDATA%\herdr-file-viewer` (Windows).
+/// `None` when no base directory is available (then we check without persisting — a rare
+/// headless case).
 pub fn cache_dir() -> Option<PathBuf> {
-    let base = std::env::var_os("XDG_CACHE_HOME")
+    cache_dir_from(|var| std::env::var_os(var))
+}
+
+/// [`cache_dir`]'s logic, factored out so it is testable from a stubbed environment (no real
+/// `XDG_CACHE_HOME`/`HOME`/`LOCALAPPDATA` mutation needed). `get_env` mirrors
+/// `std::env::var_os`'s signature.
+fn cache_dir_from(get_env: impl Fn(&str) -> Option<std::ffi::OsString>) -> Option<PathBuf> {
+    let base = cache_base_dir(get_env)?;
+    Some(base.join("herdr-file-viewer"))
+}
+
+/// The per-user cache base directory, before the `herdr-file-viewer` subdirectory is joined.
+/// unix: `$XDG_CACHE_HOME`, else `$HOME/.cache` (today's behaviour, unchanged — AC-3). Windows:
+/// `%LOCALAPPDATA%`. `None` when nothing resolves (AC-7).
+#[cfg(not(windows))]
+fn cache_base_dir(get_env: impl Fn(&str) -> Option<std::ffi::OsString>) -> Option<PathBuf> {
+    get_env("XDG_CACHE_HOME")
         .map(PathBuf::from)
         .filter(|p| !p.as_os_str().is_empty())
-        .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".cache")))?;
-    Some(base.join("herdr-file-viewer"))
+        .or_else(|| get_env("HOME").map(|h| PathBuf::from(h).join(".cache")))
+}
+
+#[cfg(windows)]
+fn cache_base_dir(get_env: impl Fn(&str) -> Option<std::ffi::OsString>) -> Option<PathBuf> {
+    get_env("LOCALAPPDATA")
+        .map(PathBuf::from)
+        .filter(|p| !p.as_os_str().is_empty())
 }
 
 /// Read and parse the cache; `None` (→ "check now") on any absence/error.
@@ -76,7 +99,80 @@ pub fn store(dir: &Path, cache: &Cache) {
 mod tests {
     use super::*;
     use crate::update::version::Version;
+    use std::ffi::OsString;
     use std::sync::atomic::{AtomicU64, Ordering};
+
+    // ---- cache_base_dir: platform cache-dir seam (AC-7, T-3) --------------------
+
+    /// A stub environment as a simple lookup, so the resolver is exercised without touching
+    /// the real process environment.
+    fn env(pairs: &'static [(&'static str, &'static str)]) -> impl Fn(&str) -> Option<OsString> {
+        move |var| {
+            pairs
+                .iter()
+                .find(|(k, _)| *k == var)
+                .map(|(_, v)| OsString::from(*v))
+        }
+    }
+
+    /// unix: `XDG_CACHE_HOME` wins when set and non-empty (today's behaviour, unchanged).
+    #[cfg(not(windows))]
+    #[test]
+    fn cache_base_dir_unix_prefers_xdg_cache_home() {
+        let got = cache_base_dir(env(&[
+            ("XDG_CACHE_HOME", "/xdg/cache"),
+            ("HOME", "/home/user"),
+        ]));
+        assert_eq!(got, Some(PathBuf::from("/xdg/cache")));
+    }
+
+    /// unix: falls back to `$HOME/.cache` when `XDG_CACHE_HOME` is unset or empty.
+    #[cfg(not(windows))]
+    #[test]
+    fn cache_base_dir_unix_falls_back_to_home_dot_cache() {
+        let got = cache_base_dir(env(&[("HOME", "/home/user")]));
+        assert_eq!(got, Some(PathBuf::from("/home/user/.cache")));
+
+        let got_empty_xdg = cache_base_dir(env(&[("XDG_CACHE_HOME", ""), ("HOME", "/home/user")]));
+        assert_eq!(got_empty_xdg, Some(PathBuf::from("/home/user/.cache")));
+    }
+
+    /// unix: `None` when neither `XDG_CACHE_HOME` nor `HOME` is set (headless case).
+    #[cfg(not(windows))]
+    #[test]
+    fn cache_base_dir_unix_none_when_nothing_set() {
+        assert_eq!(cache_base_dir(env(&[])), None);
+    }
+
+    /// Windows: resolves to `%LOCALAPPDATA%` when `HOME`/`XDG_CACHE_HOME` are unset (AC-7).
+    #[cfg(windows)]
+    #[test]
+    fn cache_base_dir_windows_uses_local_app_data() {
+        let got = cache_base_dir(env(&[("LOCALAPPDATA", r"C:\Users\user\AppData\Local")]));
+        assert_eq!(got, Some(PathBuf::from(r"C:\Users\user\AppData\Local")));
+    }
+
+    /// Windows: `None` when `%LOCALAPPDATA%` is absent or empty — no base available.
+    #[cfg(windows)]
+    #[test]
+    fn cache_base_dir_windows_none_when_local_app_data_unset() {
+        assert_eq!(cache_base_dir(env(&[])), None);
+        assert_eq!(cache_base_dir(env(&[("LOCALAPPDATA", "")])), None);
+    }
+
+    /// `cache_dir_from` joins the `herdr-file-viewer` subdirectory onto the resolved base, on
+    /// every platform.
+    #[test]
+    fn cache_dir_from_joins_the_plugin_subdir() {
+        #[cfg(not(windows))]
+        let got = cache_dir_from(env(&[("HOME", "/home/user")]));
+        #[cfg(windows)]
+        let got = cache_dir_from(env(&[("LOCALAPPDATA", r"C:\Users\user\AppData\Local")]));
+        assert!(
+            got.unwrap().ends_with("herdr-file-viewer"),
+            "joins the plugin subdir onto the resolved base"
+        );
+    }
 
     #[test]
     fn should_check_respects_the_24h_window() {

--- a/tests/ci_workflow.rs
+++ b/tests/ci_workflow.rs
@@ -50,12 +50,18 @@ fn the_required_test_matrix_does_not_include_windows() {
 }
 
 #[test]
-fn the_windows_job_runs_cargo_test() {
+fn the_windows_job_builds_release_and_runs_cargo_test() {
     let w = workflow();
     let idx = w
         .find("windows-latest")
         .expect("windows-latest job must exist");
-    let window = &w[idx..(idx + 400).min(w.len())];
+    let window = &w[idx..(idx + 700).min(w.len())];
+    // A release build exercises AC-1 (the crate links for the MSVC target) on every PR; the test
+    // run exercises AC-2/3/4 on real Windows.
+    assert!(
+        window.contains("cargo build --release"),
+        "the windows-latest job must run a release build (AC-1): {window}"
+    );
     assert!(
         window.contains("cargo test"),
         "the windows-latest job must run cargo test: {window}"

--- a/tests/ci_workflow.rs
+++ b/tests/ci_workflow.rs
@@ -1,0 +1,63 @@
+//! The CI workflow's Windows-job contract, asserted as text (mirrors tests/release_workflow.rs):
+//! a `windows-latest` test job exists and is advisory/non-blocking (`continue-on-error: true`),
+//! so a Windows-only flake can never block merge of an unrelated PR (AC-19, AC-N2). GitHub
+//! Actions itself is exercised by the job actually running on `windows-latest` (a manual /
+//! live-CI verification step — see the spec's honest-oracle note).
+
+use std::fs;
+use std::path::PathBuf;
+
+fn workflow() -> String {
+    let p = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(".github/workflows/ci.yml");
+    fs::read_to_string(&p).unwrap_or_else(|e| panic!("read {}: {e}", p.display()))
+}
+
+#[test]
+fn declares_a_windows_latest_job() {
+    assert!(
+        workflow().contains("windows-latest"),
+        "ci.yml must declare a windows-latest job"
+    );
+}
+
+#[test]
+fn the_windows_job_is_advisory_non_blocking() {
+    // AC-19, AC-N2: continue-on-error: true on the Windows job specifically — not on the
+    // required ubuntu/macOS `test` matrix.
+    let w = workflow();
+    let idx = w
+        .find("windows-latest")
+        .expect("windows-latest job must exist");
+    // The continue-on-error directive must appear in the same job block as windows-latest —
+    // checked by a tight window after the runs-on line rather than scanning the whole file
+    // (the existing `test` matrix must NOT be advisory).
+    let window = &w[idx..(idx + 400).min(w.len())];
+    assert!(
+        window.contains("continue-on-error: true"),
+        "the windows-latest job must be continue-on-error: true (advisory): {window}"
+    );
+}
+
+#[test]
+fn the_required_test_matrix_does_not_include_windows() {
+    // The required `test` job's OS matrix stays ubuntu/macOS only — Windows is a separate,
+    // advisory job (AC-N2: it must not be able to block an unrelated PR via the required matrix).
+    let w = workflow();
+    let matrix_idx = w.find("os: [ubuntu-latest, macos-latest]").expect(
+        "the required test job's OS matrix must list exactly ubuntu-latest and macos-latest",
+    );
+    let _ = matrix_idx; // presence is the assertion
+}
+
+#[test]
+fn the_windows_job_runs_cargo_test() {
+    let w = workflow();
+    let idx = w
+        .find("windows-latest")
+        .expect("windows-latest job must exist");
+    let window = &w[idx..(idx + 400).min(w.len())];
+    assert!(
+        window.contains("cargo test"),
+        "the windows-latest job must run cargo test: {window}"
+    );
+}

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -3,6 +3,14 @@
 //! the close key and asserts a clean exit(0). External renderers (glow/delta/bat) need not
 //! be installed — the Content Renderer falls back to plain text, and the tree draws either
 //! way.
+//!
+//! Unix-only: drives the viewer over a real pty via `expectrl`'s unix process backend
+//! (`WaitStatus`). `expectrl`'s Windows backend (`conpty`) exposes a materially different API
+//! (a raw `u32` exit code, no signal/stop semantics) — porting this pty-driven e2e suite is
+//! out of this feature's scope (not named in the windows-support plan); Windows coverage for
+//! what these tests exercise is the unit/integration suite plus AC-15..AC-17's reviewer-checked
+//! criteria.
+#![cfg(unix)]
 
 mod common;
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -105,7 +105,17 @@ pub fn init_repo_with_commit(dir: &Path) {
 
 /// Canonicalize a path for symlink-stable comparisons (e.g. /tmp on macOS).
 pub fn canon(p: &Path) -> PathBuf {
-    std::fs::canonicalize(p).unwrap_or_else(|_| p.to_path_buf())
+    let c = std::fs::canonicalize(p).unwrap_or_else(|_| p.to_path_buf());
+    // On Windows, `fs::canonicalize` returns an extended-length `\\?\` *verbatim* path, whose
+    // `Prefix` (VerbatimDisk) does NOT compare equal to the ordinary `Disk` prefix on the
+    // non-canonicalized paths the tree builds from a raw root — so `node.path.starts_with(canon)`
+    // (and `== canon`) would spuriously fail. Strip the `\\?\` prefix so canon'd paths line up with
+    // the tree's. No-op on unix and on already-non-verbatim paths.
+    #[cfg(windows)]
+    if let Some(rest) = c.to_str().and_then(|s| s.strip_prefix(r"\\?\")) {
+        return PathBuf::from(rest);
+    }
+    c
 }
 
 /// A `Command` that runs the built viewer binary with its cwd set to `dir`. The e2e tests

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -3960,7 +3960,10 @@ fn enter_with_match_closes_finder_and_reveals_file_and_redraws() {
         .strip_prefix(ctrl.root())
         .unwrap()
         .to_string_lossy()
-        .into_owned();
+        // Tree node paths are OS-native (`\` on Windows); the finder's index candidates are
+        // forward-slash (git-style, from `index::build`). Compare on the shared forward-slash
+        // form. No-op on unix.
+        .replace('\\', "/");
     assert_eq!(
         selected_rel, selected_path,
         "tree cursor points to the confirmed file (AC-11)"
@@ -4932,7 +4935,10 @@ fn finder_works_fully_in_a_non_git_directory() {
         .strip_prefix(ctrl.root())
         .unwrap()
         .to_string_lossy()
-        .into_owned();
+        // Tree node paths are OS-native (`\` on Windows); the finder's index candidates are
+        // forward-slash (git-style, from `index::build`). Compare on the shared forward-slash
+        // form. No-op on unix.
+        .replace('\\', "/");
     assert_eq!(
         selected_rel, *matched_path,
         "the tree cursor points to the jumped-to file in a non-git root (AC-19)"

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -2071,6 +2071,10 @@ fn copy_abs_path_copies_the_absolute_path() {
     );
 }
 
+// Unix-only: Windows forbids control bytes (ESC/BEL/newline) in filenames, so the hostile file
+// this test needs cannot be created there (`fs::write` fails). The `sanitize_control` defense the
+// copy path applies is platform-agnostic and unit-tested directly; this end-to-end check is unix.
+#[cfg(unix)]
 #[test]
 fn copy_path_strips_control_bytes_from_a_hostile_filename() {
     // A filename is attacker-controllable in a browsed repo and may legally contain control bytes —
@@ -2210,7 +2214,10 @@ fn switch_worktree_preselects_agent_active() {
     // The agent runs in workspace "ws-agent", which the overlay maps to the LINKED worktree —
     // so the pre-select must be the linked row, not the current (main) one. Tier-2 (a unique
     // agent worktree) fires with no own-workspace hint.
-    let linked_path = linked.path().to_str().unwrap();
+    // Forward-slash the path: a raw Windows `\` is an invalid JSON string escape (so the overlay
+    // JSON would fail to parse and the agent match silently vanish), and git emits forward-slash
+    // worktree paths anyway. No-op on unix.
+    let linked_path = linked.path().to_str().unwrap().replace('\\', "/");
     let worktree_json = format!(
         r#"{{"id": 1, "result": {{"worktrees": [{{"path": "{}", "open_workspace_id": "ws-agent"}}]}}}}"#,
         linked_path
@@ -2270,7 +2277,8 @@ fn picker_populates_per_row_agent_statuses_from_the_overlay() {
     let (mut ctrl, _, _) = controller(repo.path(), true, StubGit::default(), false);
 
     // The linked worktree's workspace hosts a REAL agent (`agent` present) reporting `working`.
-    let linked_path = linked.path().to_str().unwrap();
+    // Forward-slash the path (valid JSON on Windows; matches git's forward-slash paths). No-op on unix.
+    let linked_path = linked.path().to_str().unwrap().replace('\\', "/");
     let worktree_json = format!(
         r#"{{"id": 1, "result": {{"worktrees": [{{"path": "{linked_path}", "open_workspace_id": "ws-agent"}}]}}}}"#
     );
@@ -2816,7 +2824,8 @@ impl RecordingHerdr {
     /// Canned valid JSON for the overlay: a worktree list pointing at `linked_path` in
     /// workspace "ws-spy", and an agent in that workspace (Tier-2 pre-select fires).
     fn new(calls: Arc<Mutex<Vec<Vec<String>>>>, linked_path: &std::path::Path) -> Self {
-        let path_str = linked_path.to_str().unwrap_or("");
+        // Forward-slash for valid JSON on Windows (a raw `\` is an invalid JSON escape). No-op on unix.
+        let path_str = linked_path.to_str().unwrap_or("").replace('\\', "/");
         Self {
             calls,
             worktree_json: format!(

--- a/tests/e2e_editor.rs
+++ b/tests/e2e_editor.rs
@@ -8,6 +8,11 @@
 //! run loop then calls `terminal.clear()`, which issues a cursor-position (DSR) query. A pty
 //! does not answer that query, so a non-best-effort clear would make `run()` return an error
 //! and the process exit non-zero — the `exit == 0` assertion guards against that regression.
+//!
+//! Unix-only: see `tests/cli_smoke.rs` for why this `expectrl`-pty e2e suite is not ported to
+//! Windows's `conpty` backend in this feature (the recording "editor" here is also a `#!/bin/sh`
+//! script made executable via unix permission bits).
+#![cfg(unix)]
 
 mod common;
 

--- a/tests/e2e_help.rs
+++ b/tests/e2e_help.rs
@@ -11,6 +11,10 @@
 //! a single-token file-content marker. So it passes identically whether or not glow/delta/bat are
 //! installed. The anchors are single tokens written into previously-blank cells, so ratatui's
 //! differential redraw cannot split them — making every `expect` robust and non-flaky.
+//!
+//! Unix-only: see `tests/cli_smoke.rs` for why this `expectrl`-pty e2e suite is not ported to
+//! Windows's `conpty` backend in this feature.
+#![cfg(unix)]
 
 mod common;
 

--- a/tests/e2e_keyboard.rs
+++ b/tests/e2e_keyboard.rs
@@ -13,6 +13,10 @@
 //! onto the revealed child, the child's content fills the empty pane — which can only happen
 //! if expand actually revealed it. Content markers are single tokens, so the syntax renderer
 //! (bat, when present) cannot split them and the assertion holds whether or not it is installed.
+//!
+//! Unix-only: see `tests/cli_smoke.rs` for why this `expectrl`-pty e2e suite is not ported to
+//! Windows's `conpty` backend in this feature.
+#![cfg(unix)]
 
 mod common;
 

--- a/tests/e2e_nongit.rs
+++ b/tests/e2e_nongit.rs
@@ -1,6 +1,10 @@
 //! e2e (pty): in a plain (non-git) directory the viewer degrades to a working file
 //! browser — the tree lists files and a file renders — while the git-only keys (changed-only,
 //! baseline) are inert and never error (AC-26).
+//!
+//! Unix-only: see `tests/cli_smoke.rs` for why this `expectrl`-pty e2e suite is not ported to
+//! Windows's `conpty` backend in this feature.
+#![cfg(unix)]
 
 mod common;
 

--- a/tests/editor.rs
+++ b/tests/editor.rs
@@ -76,6 +76,63 @@ fn open_splits_a_configured_editor_with_flags() {
 }
 
 #[test]
+fn open_keeps_a_double_quoted_program_path_with_spaces_as_one_argv0() {
+    // AC-8: a Windows-style `$EDITOR` value quotes a program path containing spaces (e.g.
+    // "C:\Program Files\...\Code.exe" --wait); the quote-aware tokenizer must keep that whole
+    // quoted path as argv[0], not split it on the embedded spaces.
+    let dir = TempDir::new();
+    let file = dir.path().join("notes.txt");
+    fs::write(&file, "content").unwrap();
+
+    let launcher = EditorLauncher::new(r#""C:\Program Files\Code\Code.exe" --wait"#);
+    let mut sp = FakeSpawner::default();
+    launcher.open(&file, &mut sp).unwrap();
+
+    assert_eq!(
+        sp.spawned,
+        vec![vec![
+            OsString::from(r"C:\Program Files\Code\Code.exe"),
+            OsString::from("--wait"),
+            file.clone().into_os_string(),
+        ]],
+    );
+}
+
+#[test]
+fn open_with_a_bare_unquoted_editor_launches_it_with_just_the_file() {
+    let dir = TempDir::new();
+    let file = dir.path().join("notes.txt");
+    fs::write(&file, "content").unwrap();
+
+    let launcher = EditorLauncher::new("vi");
+    let mut sp = FakeSpawner::default();
+    launcher.open(&file, &mut sp).unwrap();
+
+    assert_eq!(
+        sp.spawned,
+        vec![vec![OsString::from("vi"), file.clone().into_os_string()]]
+    );
+}
+
+#[test]
+fn open_with_an_empty_editor_still_attempts_a_launch_loudly() {
+    // An empty/whitespace-only `$EDITOR` must not silently exec the file as the program: the
+    // raw (empty) value is still passed through so the launch fails loudly.
+    let dir = TempDir::new();
+    let file = dir.path().join("notes.txt");
+    fs::write(&file, "content").unwrap();
+
+    let launcher = EditorLauncher::new("");
+    let mut sp = FakeSpawner::default();
+    launcher.open(&file, &mut sp).unwrap();
+
+    assert_eq!(
+        sp.spawned,
+        vec![vec![OsString::from(""), file.clone().into_os_string()]]
+    );
+}
+
+#[test]
 fn launch_failure_is_an_error_not_a_panic_and_leaves_the_file_intact() {
     // A failed launch surfaces as `SpawnError::NotLaunched` (the controller turns it into a
     // non-fatal "could not open editor" notice), never a panic — and the file is untouched

--- a/tests/fetch_or_build.rs
+++ b/tests/fetch_or_build.rs
@@ -530,6 +530,14 @@ function Invoke-WebRequest {{
     /// - `serve_binary == false` → the mocked download throws (simulates a 404 / missing asset).
     /// - `corrupt_sums == true`  → the published SHA256SUMS holds a wrong hash (checksum mismatch).
     fn run(version: &str, serve_binary: bool, corrupt_sums: bool) -> Outcome {
+        // Default to the coreutils TEXT-mode two-space separator.
+        run_sep(version, serve_binary, corrupt_sums, "  ")
+    }
+
+    /// Like [`run`], but with an explicit SHA256SUMS hash→filename separator, so a test can feed
+    /// the BINARY-mode ` *` marker that Git-for-Windows `sha256sum` emits on the release runner
+    /// (vs the two-space text form Linux/macOS produce).
+    fn run_sep(version: &str, serve_binary: bool, corrupt_sums: bool, sums_sep: &str) -> Outcome {
         let root = tmp("root-ps1");
         let stub = root.join("bin");
         let server = root.join("server");
@@ -555,7 +563,11 @@ function Invoke-WebRequest {{
         } else {
             real_hash
         };
-        fs::write(server.join("SHA256SUMS"), format!("{hash}  {asset}\n")).unwrap();
+        fs::write(
+            server.join("SHA256SUMS"),
+            format!("{hash}{sums_sep}{asset}\n"),
+        )
+        .unwrap();
         // No COMMIT fixture: FV_REPO_ROOT below is not a git work tree, so the ahead-note path
         // is skipped and the platform/download/verify logic is what's under test (mirrors the
         // sh test's default `run`).
@@ -633,6 +645,25 @@ function Invoke-WebRequest {{
             o.urls.iter().any(|u| u.ends_with("/v1.2.0/SHA256SUMS")),
             "urls: {:?}",
             o.urls
+        );
+    }
+
+    /// (a') the SHA256SUMS line uses the BINARY-mode ` *` marker (what Git-for-Windows
+    /// `sha256sum` emits on the release runner) — the parser must still match it and install the
+    /// verified prebuilt, never fall back to a source build. Regression guard against the
+    /// two-space-only parser that would have made EVERY real Windows install source-build.
+    #[test]
+    fn binary_mode_checksum_marker_still_installs_prebuilt() {
+        let o = run_sep("1.2.0", true, false, " *");
+        assert!(
+            o.installed_prebuilt(),
+            "binary-mode `*` checksum line must still verify; stdout: {}\nstderr: {}",
+            o.stdout,
+            o.stderr
+        );
+        assert!(
+            !o.fell_back(),
+            "must not source-build when the prebuilt's binary-mode `*` line is valid"
         );
     }
 

--- a/tests/fetch_or_build.rs
+++ b/tests/fetch_or_build.rs
@@ -1,19 +1,16 @@
-//! Hermetic test for scripts/fetch-or-build.sh — the install-time [[build]] step.
-//! Stubs uname/curl/cargo via PATH and serves a local fixture "release"; uses the real
-//! sha256sum/shasum, mktemp, grep, etc. No network, no real cargo build, no new deps.
+//! Hermetic tests for the install-time `[[build]]` step: `scripts/fetch-or-build.sh` (unix) and
+//! `scripts/fetch-or-build.ps1` (Windows, T-7 — AC-11, AC-12, AC-13). Each platform's tests stub
+//! its own platform's download/build tools and serve a local fixture "release"; no network, no
+//! real cargo build, no new deps.
 
 use std::fs;
-use std::os::unix::fs::PermissionsExt;
-use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 static N: AtomicU64 = AtomicU64::new(0);
 
-fn script_path() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("scripts/fetch-or-build.sh")
-}
-
+/// A fresh empty temp dir, distinct per `label` so parallel tests don't collide. Shared by both
+/// platforms' test modules below.
 fn tmp(label: &str) -> PathBuf {
     let n = N.fetch_add(1, Ordering::Relaxed);
     let p = std::env::temp_dir().join(format!("fv-fob-{}-{}-{}", std::process::id(), label, n));
@@ -21,398 +18,713 @@ fn tmp(label: &str) -> PathBuf {
     p
 }
 
-fn write_exec(path: &Path, body: &str) {
-    fs::write(path, body).unwrap();
-    let mut perm = fs::metadata(path).unwrap().permissions();
-    perm.set_mode(0o755);
-    fs::set_permissions(path, perm).unwrap();
-}
+// ===============================================================================================
+// unix: scripts/fetch-or-build.sh
+// ===============================================================================================
 
-/// Hex sha-256 of a file using whatever tool exists (matches the script's preference order).
-fn sha256_of(file: &Path) -> String {
-    if let Ok(out) = Command::new("sha256sum").arg(file).output()
-        && out.status.success()
-    {
+#[cfg(unix)]
+mod unix_sh {
+    use super::tmp;
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::{Path, PathBuf};
+    use std::process::Command;
+
+    fn script_path() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("scripts/fetch-or-build.sh")
+    }
+
+    fn write_exec(path: &Path, body: &str) {
+        fs::write(path, body).unwrap();
+        let mut perm = fs::metadata(path).unwrap().permissions();
+        perm.set_mode(0o755);
+        fs::set_permissions(path, perm).unwrap();
+    }
+
+    /// Hex sha-256 of a file using whatever tool exists (matches the script's preference order).
+    fn sha256_of(file: &Path) -> String {
+        if let Ok(out) = Command::new("sha256sum").arg(file).output()
+            && out.status.success()
+        {
+            let s = String::from_utf8_lossy(&out.stdout);
+            return s.split_whitespace().next().unwrap().to_string();
+        }
+        let out = Command::new("shasum")
+            .args(["-a", "256"])
+            .arg(file)
+            .output()
+            .expect("need sha256sum or shasum to run this test");
         let s = String::from_utf8_lossy(&out.stdout);
-        return s.split_whitespace().next().unwrap().to_string();
+        s.split_whitespace().next().unwrap().to_string()
     }
-    let out = Command::new("shasum")
-        .args(["-a", "256"])
-        .arg(file)
-        .output()
-        .expect("need sha256sum or shasum to run this test");
-    let s = String::from_utf8_lossy(&out.stdout);
-    s.split_whitespace().next().unwrap().to_string()
-}
 
-struct Outcome {
-    stdout: String,
-    stderr: String,
-    placed: Option<Vec<u8>>,
-    urls: Vec<String>,
-}
-
-impl Outcome {
-    fn installed_prebuilt(&self) -> bool {
-        self.stdout.contains("installed prebuilt")
+    struct Outcome {
+        stdout: String,
+        stderr: String,
+        placed: Option<Vec<u8>>,
+        urls: Vec<String>,
     }
-    fn fell_back(&self) -> bool {
-        self.stdout.contains("FAKE_CARGO_BUILD")
+
+    impl Outcome {
+        fn installed_prebuilt(&self) -> bool {
+            self.stdout.contains("installed prebuilt")
+        }
+        fn fell_back(&self) -> bool {
+            self.stdout.contains("FAKE_CARGO_BUILD")
+        }
     }
-}
 
-/// Run the script with stubbed uname/curl/cargo.
-/// - `serve_binary == false` → fake curl fails the binary fetch (simulates a 404 / missing asset).
-/// - `corrupt_sums == true`  → the published SHA256SUMS holds a wrong hash (checksum mismatch).
-fn run_impl(
-    os: &str,
-    arch: &str,
-    version: &str,
-    serve_binary: bool,
-    corrupt_sums: bool,
-    repo_root: Option<&Path>,
-    commit_marker: Option<&str>,
-) -> Outcome {
-    let root = tmp("root");
-    let stub = root.join("bin");
-    let server = root.join("server");
-    let out = root.join("target/release/herdr-file-viewer");
-    let urllog = root.join("urls.log");
-    fs::create_dir_all(&stub).unwrap();
-    fs::create_dir_all(&server).unwrap();
+    /// Run the script with stubbed uname/curl/cargo.
+    /// - `serve_binary == false` → fake curl fails the binary fetch (simulates a 404 / missing asset).
+    /// - `corrupt_sums == true`  → the published SHA256SUMS holds a wrong hash (checksum mismatch).
+    fn run_impl(
+        os: &str,
+        arch: &str,
+        version: &str,
+        serve_binary: bool,
+        corrupt_sums: bool,
+        repo_root: Option<&Path>,
+        commit_marker: Option<&str>,
+    ) -> Outcome {
+        let root = tmp("root");
+        let stub = root.join("bin");
+        let server = root.join("server");
+        let out = root.join("target/release/herdr-file-viewer");
+        let urllog = root.join("urls.log");
+        fs::create_dir_all(&stub).unwrap();
+        fs::create_dir_all(&server).unwrap();
 
-    let cargo_toml = root.join("Cargo.toml");
-    fs::write(
-        &cargo_toml,
-        format!("[package]\nname = \"herdr-file-viewer\"\nversion = \"{version}\"\n"),
-    )
-    .unwrap();
-
-    // The triple the script will resolve — kept in lockstep with the script's mapping.
-    let triple = match (os, arch) {
-        ("Darwin", "arm64") | ("Darwin", "aarch64") => "aarch64-apple-darwin",
-        ("Darwin", "x86_64") => "x86_64-apple-darwin",
-        ("Linux", "x86_64") => "x86_64-unknown-linux-musl",
-        _ => "",
-    };
-
-    let bin_blob: &[u8] = b"#!/bin/sh\necho prebuilt-viewer\n";
-    fs::write(server.join("bin"), bin_blob).unwrap();
-    if !triple.is_empty() {
-        let real = sha256_of(&server.join("bin"));
-        let hash = if corrupt_sums { "0".repeat(64) } else { real };
+        let cargo_toml = root.join("Cargo.toml");
         fs::write(
-            server.join("SHA256SUMS"),
-            format!("{hash}  herdr-file-viewer-{triple}\n"),
+            &cargo_toml,
+            format!("[package]\nname = \"herdr-file-viewer\"\nversion = \"{version}\"\n"),
         )
         .unwrap();
-    }
 
-    // The COMMIT marker the release publishes; the gate compares the checkout's HEAD to it.
-    if let Some(c) = commit_marker {
-        fs::write(server.join("COMMIT"), format!("{c}\n")).unwrap();
-    }
+        // The triple the script will resolve — kept in lockstep with the script's mapping.
+        let triple = match (os, arch) {
+            ("Darwin", "arm64") | ("Darwin", "aarch64") => "aarch64-apple-darwin",
+            ("Darwin", "x86_64") => "x86_64-apple-darwin",
+            ("Linux", "x86_64") => "x86_64-unknown-linux-musl",
+            _ => "",
+        };
 
-    write_exec(
-        &stub.join("uname"),
-        &format!(
-            "#!/bin/sh\ncase \"$1\" in\n  -s) echo {os} ;;\n  -m) echo {arch} ;;\n  *) echo {os} ;;\nesac\n"
-        ),
-    );
+        let bin_blob: &[u8] = b"#!/bin/sh\necho prebuilt-viewer\n";
+        fs::write(server.join("bin"), bin_blob).unwrap();
+        if !triple.is_empty() {
+            let real = sha256_of(&server.join("bin"));
+            let hash = if corrupt_sums { "0".repeat(64) } else { real };
+            fs::write(
+                server.join("SHA256SUMS"),
+                format!("{hash}  herdr-file-viewer-{triple}\n"),
+            )
+            .unwrap();
+        }
 
-    let bin_rule = if serve_binary {
-        format!("cp \"{}/bin\" \"$dest\"", server.display())
-    } else {
-        "exit 22".to_string() // curl -f exits 22 on HTTP >= 400
-    };
-    write_exec(
-        &stub.join("curl"),
-        &format!(
-            "#!/bin/sh\ndest=\"\"; url=\"\"\n\
+        // The COMMIT marker the release publishes; the gate compares the checkout's HEAD to it.
+        if let Some(c) = commit_marker {
+            fs::write(server.join("COMMIT"), format!("{c}\n")).unwrap();
+        }
+
+        write_exec(
+            &stub.join("uname"),
+            &format!(
+                "#!/bin/sh\ncase \"$1\" in\n  -s) echo {os} ;;\n  -m) echo {arch} ;;\n  *) echo {os} ;;\nesac\n"
+            ),
+        );
+
+        let bin_rule = if serve_binary {
+            format!("cp \"{}/bin\" \"$dest\"", server.display())
+        } else {
+            "exit 22".to_string() // curl -f exits 22 on HTTP >= 400
+        };
+        write_exec(
+            &stub.join("curl"),
+            &format!(
+                "#!/bin/sh\ndest=\"\"; url=\"\"\n\
              while [ $# -gt 0 ]; do case \"$1\" in -o) dest=\"$2\"; shift 2 ;; -*) shift ;; *) url=\"$1\"; shift ;; esac; done\n\
              echo \"$url\" >> \"{log}\"\n\
              case \"$url\" in\n  */COMMIT) cp \"{srv}/COMMIT\" \"$dest\" ;;\n  */SHA256SUMS) cp \"{srv}/SHA256SUMS\" \"$dest\" ;;\n  *) {bin_rule} ;;\nesac\n",
-            log = urllog.display(),
-            srv = server.display(),
-        ),
-    );
-
-    write_exec(
-        &stub.join("cargo"),
-        "#!/bin/sh\necho FAKE_CARGO_BUILD \"$@\"\nexit 0\n",
-    );
-
-    // The ahead-note logic inspects FV_REPO_ROOT as a git work tree. By default point it at the
-    // (non-git) temp root so it is skipped and the platform/download/verify logic is what's under
-    // test; the git-checkout tests pass a real git repo here.
-    let fv_repo_root: &Path = repo_root.unwrap_or(root.as_path());
-    let path = format!("{}:{}", stub.display(), std::env::var("PATH").unwrap());
-    let output = Command::new("sh")
-        .arg(script_path())
-        .env("PATH", path)
-        .env("HOME", &root) // no ~/.cargo/env here, so the fallback uses the stubbed cargo
-        .env("FV_REPO_ROOT", fv_repo_root)
-        .env("FV_CARGO_TOML", &cargo_toml)
-        .env("FV_OUT", &out)
-        .env("FV_BASE_URL", "https://example.invalid/releases/download")
-        .output()
-        .expect("run fetch-or-build.sh");
-
-    let urls = fs::read_to_string(&urllog)
-        .unwrap_or_default()
-        .lines()
-        .map(|s| s.to_string())
-        .collect();
-    let placed = fs::read(&out).ok();
-    let o = Outcome {
-        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
-        stderr: String::from_utf8_lossy(&output.stderr).to_string(),
-        placed,
-        urls,
-    };
-    let _ = fs::remove_dir_all(&root);
-    o
-}
-
-/// Default runner: no git work tree at FV_REPO_ROOT, so the release-tag gate is skipped and the
-/// platform/download/verify path is exercised directly.
-fn run(os: &str, arch: &str, version: &str, serve_binary: bool, corrupt_sums: bool) -> Outcome {
-    run_impl(os, arch, version, serve_binary, corrupt_sums, None, None)
-}
-
-/// Throwaway git repo at `dir` with a single commit and NO tag — exactly like herdr's install
-/// checkout (a work tree at the cloned commit, without local tags). Returns the HEAD commit SHA,
-/// which the ahead-note logic compares against the release's published COMMIT marker.
-fn make_git_repo(dir: &Path) -> String {
-    fs::create_dir_all(dir).unwrap();
-    let g = |args: &[&str]| -> std::process::Output {
-        let o = Command::new("git")
-            .arg("-C")
-            .arg(dir)
-            .args(args)
-            .env("GIT_CONFIG_GLOBAL", "/dev/null")
-            .env("GIT_CONFIG_SYSTEM", "/dev/null")
-            .env("GIT_AUTHOR_NAME", "t")
-            .env("GIT_AUTHOR_EMAIL", "t@e")
-            .env("GIT_COMMITTER_NAME", "t")
-            .env("GIT_COMMITTER_EMAIL", "t@e")
-            .output()
-            .unwrap();
-        assert!(
-            o.status.success(),
-            "git {args:?}: {}",
-            String::from_utf8_lossy(&o.stderr)
+                log = urllog.display(),
+                srv = server.display(),
+            ),
         );
+
+        write_exec(
+            &stub.join("cargo"),
+            "#!/bin/sh\necho FAKE_CARGO_BUILD \"$@\"\nexit 0\n",
+        );
+
+        // The ahead-note logic inspects FV_REPO_ROOT as a git work tree. By default point it at the
+        // (non-git) temp root so it is skipped and the platform/download/verify logic is what's under
+        // test; the git-checkout tests pass a real git repo here.
+        let fv_repo_root: &Path = repo_root.unwrap_or(root.as_path());
+        let path = format!("{}:{}", stub.display(), std::env::var("PATH").unwrap());
+        let output = Command::new("sh")
+            .arg(script_path())
+            .env("PATH", path)
+            .env("HOME", &root) // no ~/.cargo/env here, so the fallback uses the stubbed cargo
+            .env("FV_REPO_ROOT", fv_repo_root)
+            .env("FV_CARGO_TOML", &cargo_toml)
+            .env("FV_OUT", &out)
+            .env("FV_BASE_URL", "https://example.invalid/releases/download")
+            .output()
+            .expect("run fetch-or-build.sh");
+
+        let urls = fs::read_to_string(&urllog)
+            .unwrap_or_default()
+            .lines()
+            .map(|s| s.to_string())
+            .collect();
+        let placed = fs::read(&out).ok();
+        let o = Outcome {
+            stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+            placed,
+            urls,
+        };
+        let _ = fs::remove_dir_all(&root);
         o
-    };
-    g(&["init", "-q"]);
-    fs::write(dir.join("f.txt"), "1").unwrap();
-    g(&["add", "-A"]);
-    g(&["commit", "-q", "-m", "release"]);
-    let head = g(&["rev-parse", "HEAD"]);
-    String::from_utf8_lossy(&head.stdout).trim().to_string()
-}
+    }
 
-#[test]
-fn fast_path_installs_verified_binary_on_apple_silicon() {
-    let o = run("Darwin", "arm64", "1.2.0", true, false);
-    assert!(
-        o.installed_prebuilt(),
-        "stdout: {}\nstderr: {}",
-        o.stdout,
-        o.stderr
-    );
-    assert!(
-        !o.fell_back(),
-        "must not build from source on the fast path"
-    );
-    assert_eq!(
-        o.placed.as_deref(),
-        Some(&b"#!/bin/sh\necho prebuilt-viewer\n"[..])
-    );
-    assert!(
-        o.urls
-            .iter()
-            .any(|u| u.ends_with("/v1.2.0/herdr-file-viewer-aarch64-apple-darwin")),
-        "fetched exactly the version+triple asset, never 'latest'; urls: {:?}",
-        o.urls
-    );
-    assert!(
-        o.urls.iter().any(|u| u.ends_with("/v1.2.0/SHA256SUMS")),
-        "urls: {:?}",
-        o.urls
-    );
-}
+    /// Default runner: no git work tree at FV_REPO_ROOT, so the release-tag gate is skipped and the
+    /// platform/download/verify path is exercised directly.
+    fn run(os: &str, arch: &str, version: &str, serve_binary: bool, corrupt_sums: bool) -> Outcome {
+        run_impl(os, arch, version, serve_binary, corrupt_sums, None, None)
+    }
 
-#[test]
-fn maps_intel_mac_to_x86_64_apple_darwin() {
-    let o = run("Darwin", "x86_64", "1.2.0", true, false);
-    assert!(o.installed_prebuilt(), "{}", o.stderr);
-    assert!(
-        o.urls
-            .iter()
-            .any(|u| u.ends_with("/v1.2.0/herdr-file-viewer-x86_64-apple-darwin")),
-        "urls: {:?}",
-        o.urls
-    );
-}
+    /// Throwaway git repo at `dir` with a single commit and NO tag — exactly like herdr's install
+    /// checkout (a work tree at the cloned commit, without local tags). Returns the HEAD commit SHA,
+    /// which the ahead-note logic compares against the release's published COMMIT marker.
+    fn make_git_repo(dir: &Path) -> String {
+        fs::create_dir_all(dir).unwrap();
+        let g = |args: &[&str]| -> std::process::Output {
+            let o = Command::new("git")
+                .arg("-C")
+                .arg(dir)
+                .args(args)
+                .env("GIT_CONFIG_GLOBAL", "/dev/null")
+                .env("GIT_CONFIG_SYSTEM", "/dev/null")
+                .env("GIT_AUTHOR_NAME", "t")
+                .env("GIT_AUTHOR_EMAIL", "t@e")
+                .env("GIT_COMMITTER_NAME", "t")
+                .env("GIT_COMMITTER_EMAIL", "t@e")
+                .output()
+                .unwrap();
+            assert!(
+                o.status.success(),
+                "git {args:?}: {}",
+                String::from_utf8_lossy(&o.stderr)
+            );
+            o
+        };
+        g(&["init", "-q"]);
+        fs::write(dir.join("f.txt"), "1").unwrap();
+        g(&["add", "-A"]);
+        g(&["commit", "-q", "-m", "release"]);
+        let head = g(&["rev-parse", "HEAD"]);
+        String::from_utf8_lossy(&head.stdout).trim().to_string()
+    }
 
-#[test]
-fn maps_linux_to_static_musl_triple() {
-    let o = run("Linux", "x86_64", "1.2.0", true, false);
-    assert!(o.installed_prebuilt(), "{}", o.stderr);
-    assert!(
-        o.urls
-            .iter()
-            .any(|u| u.ends_with("/v1.2.0/herdr-file-viewer-x86_64-unknown-linux-musl")),
-        "urls: {:?}",
-        o.urls
-    );
-}
+    #[test]
+    fn fast_path_installs_verified_binary_on_apple_silicon() {
+        let o = run("Darwin", "arm64", "1.2.0", true, false);
+        assert!(
+            o.installed_prebuilt(),
+            "stdout: {}\nstderr: {}",
+            o.stdout,
+            o.stderr
+        );
+        assert!(
+            !o.fell_back(),
+            "must not build from source on the fast path"
+        );
+        assert_eq!(
+            o.placed.as_deref(),
+            Some(&b"#!/bin/sh\necho prebuilt-viewer\n"[..])
+        );
+        assert!(
+            o.urls
+                .iter()
+                .any(|u| u.ends_with("/v1.2.0/herdr-file-viewer-aarch64-apple-darwin")),
+            "fetched exactly the version+triple asset, never 'latest'; urls: {:?}",
+            o.urls
+        );
+        assert!(
+            o.urls.iter().any(|u| u.ends_with("/v1.2.0/SHA256SUMS")),
+            "urls: {:?}",
+            o.urls
+        );
+    }
 
-#[test]
-fn checksum_mismatch_falls_back_and_installs_nothing() {
-    let o = run("Linux", "x86_64", "1.2.0", true, true);
-    assert!(o.fell_back(), "stdout: {}", o.stdout);
-    assert!(o.placed.is_none(), "must not install an unverified binary");
-    assert!(
-        o.stderr.contains("checksum mismatch"),
-        "stderr: {}",
-        o.stderr
-    );
-}
+    #[test]
+    fn maps_intel_mac_to_x86_64_apple_darwin() {
+        let o = run("Darwin", "x86_64", "1.2.0", true, false);
+        assert!(o.installed_prebuilt(), "{}", o.stderr);
+        assert!(
+            o.urls
+                .iter()
+                .any(|u| u.ends_with("/v1.2.0/herdr-file-viewer-x86_64-apple-darwin")),
+            "urls: {:?}",
+            o.urls
+        );
+    }
 
-#[test]
-fn missing_release_asset_falls_back_to_source_build() {
-    let o = run("Linux", "x86_64", "9.9.9", false, false);
-    assert!(o.fell_back(), "stdout: {}", o.stdout);
-    assert!(o.placed.is_none());
-    assert!(o.stderr.contains("not available"), "stderr: {}", o.stderr);
-}
+    #[test]
+    fn maps_linux_to_static_musl_triple() {
+        let o = run("Linux", "x86_64", "1.2.0", true, false);
+        assert!(o.installed_prebuilt(), "{}", o.stderr);
+        assert!(
+            o.urls
+                .iter()
+                .any(|u| u.ends_with("/v1.2.0/herdr-file-viewer-x86_64-unknown-linux-musl")),
+            "urls: {:?}",
+            o.urls
+        );
+    }
 
-#[test]
-fn unmapped_platform_falls_back_without_downloading() {
-    let o = run("Linux", "riscv64", "1.2.0", true, false);
-    assert!(o.fell_back(), "stdout: {}", o.stdout);
-    assert!(
-        o.urls.is_empty(),
-        "must not download for an unsupported platform; urls: {:?}",
-        o.urls
-    );
-    assert!(
-        o.stderr.contains("no prebuilt binary"),
-        "stderr: {}",
-        o.stderr
-    );
-}
+    #[test]
+    fn checksum_mismatch_falls_back_and_installs_nothing() {
+        let o = run("Linux", "x86_64", "1.2.0", true, true);
+        assert!(o.fell_back(), "stdout: {}", o.stdout);
+        assert!(o.placed.is_none(), "must not install an unverified binary");
+        assert!(
+            o.stderr.contains("checksum mismatch"),
+            "stderr: {}",
+            o.stderr
+        );
+    }
 
-#[test]
-fn script_preserves_the_cargo_source_build_fallback() {
-    let s = fs::read_to_string(script_path()).unwrap();
-    assert!(
-        s.contains("cargo build --release"),
-        "fallback must still build from source"
-    );
-    assert!(
-        s.contains(".cargo/env"),
-        "fallback must source ~/.cargo/env like the original build step"
-    );
-}
+    #[test]
+    fn missing_release_asset_falls_back_to_source_build() {
+        let o = run("Linux", "x86_64", "9.9.9", false, false);
+        assert!(o.fell_back(), "stdout: {}", o.stdout);
+        assert!(o.placed.is_none());
+        assert!(o.stderr.contains("not available"), "stderr: {}", o.stderr);
+    }
 
-// Matching commit: when the checkout IS the released commit, the prebuilt installs cleanly and
-// (because HEAD == COMMIT) no "ahead" note is emitted.
-#[test]
-fn uses_prebuilt_when_head_matches_the_release_commit() {
-    let gitdir = tmp("gitrepo-match");
-    let head = make_git_repo(&gitdir); // tagless work tree, like herdr's install checkout
-    let o = run_impl(
-        "Linux",
-        "x86_64",
-        "1.2.0",
-        true,
-        false,
-        Some(&gitdir),
-        Some(&head),
-    );
-    assert!(
-        o.installed_prebuilt(),
-        "HEAD matches the release COMMIT → prebuilt must be used\nstdout:{}\nstderr:{}",
-        o.stdout,
-        o.stderr
-    );
-    assert!(!o.fell_back(), "must not build from source");
-    assert!(
-        !o.stdout.contains("ahead of"),
-        "no ahead-note when the checkout IS the released commit; stdout: {}",
-        o.stdout
-    );
-    let _ = fs::remove_dir_all(&gitdir);
-}
+    #[test]
+    fn unmapped_platform_falls_back_without_downloading() {
+        let o = run("Linux", "riscv64", "1.2.0", true, false);
+        assert!(o.fell_back(), "stdout: {}", o.stdout);
+        assert!(
+            o.urls.is_empty(),
+            "must not download for an unsupported platform; urls: {:?}",
+            o.urls
+        );
+        assert!(
+            o.stderr.contains("no prebuilt binary"),
+            "stderr: {}",
+            o.stderr
+        );
+    }
 
-// Version-only behavior: when the checkout's HEAD is AHEAD of the release commit (e.g. main has
-// merged work that isn't tagged yet), the prebuilt for the declared version is STILL installed —
-// landing a PR no longer forces new users to compile — and a transparency note records that the
-// working tree carries newer, unreleased source than the binary.
-#[test]
-fn uses_prebuilt_when_head_is_ahead_of_the_release_commit() {
-    let gitdir = tmp("gitrepo-ahead");
-    let _head = make_git_repo(&gitdir);
-    let other = "0000000000000000000000000000000000000000"; // a commit this checkout is NOT at
-    let o = run_impl(
-        "Linux",
-        "x86_64",
-        "1.2.0",
-        true,
-        false,
-        Some(&gitdir),
-        Some(other),
-    );
-    assert!(
-        o.installed_prebuilt(),
-        "HEAD ahead of the release commit must still use the prebuilt\nstdout:{}\nstderr:{}",
-        o.stdout,
-        o.stderr
-    );
-    assert!(
-        !o.fell_back(),
-        "must not build from source merely because the checkout is ahead of the tag"
-    );
-    assert_eq!(
-        o.placed.as_deref(),
-        Some(&b"#!/bin/sh\necho prebuilt-viewer\n"[..]),
-        "the verified prebuilt must be installed"
-    );
-    assert!(
-        o.urls
-            .iter()
-            .any(|u| u.contains("herdr-file-viewer-x86_64-unknown-linux-musl")),
-        "the binary download must happen (no commit gate before it); urls: {:?}",
-        o.urls
-    );
-    assert!(
-        o.stdout.contains("ahead of"),
-        "must note that the checkout is ahead of the release commit; stdout: {}",
-        o.stdout
-    );
-    let _ = fs::remove_dir_all(&gitdir);
-}
+    #[test]
+    fn script_preserves_the_cargo_source_build_fallback() {
+        let s = fs::read_to_string(script_path()).unwrap();
+        assert!(
+            s.contains("cargo build --release"),
+            "fallback must still build from source"
+        );
+        assert!(
+            s.contains(".cargo/env"),
+            "fallback must source ~/.cargo/env like the original build step"
+        );
+    }
 
-// A version with NO published release still falls back to source even from a git checkout — the
-// asset download 404s, so we never silently install a binary whose version differs from the source.
-#[test]
-fn version_with_no_release_still_falls_back_from_a_git_checkout() {
-    let gitdir = tmp("gitrepo-norelease");
-    let head = make_git_repo(&gitdir);
-    let o = run_impl(
-        "Linux",
-        "x86_64",
-        "9.9.9",
-        false, // serve_binary = false → the asset 404s
-        false,
-        Some(&gitdir),
-        Some(&head),
-    );
-    assert!(o.fell_back(), "stdout: {}\nstderr: {}", o.stdout, o.stderr);
-    assert!(o.placed.is_none(), "must not install anything");
-    let _ = fs::remove_dir_all(&gitdir);
+    // Matching commit: when the checkout IS the released commit, the prebuilt installs cleanly and
+    // (because HEAD == COMMIT) no "ahead" note is emitted.
+    #[test]
+    fn uses_prebuilt_when_head_matches_the_release_commit() {
+        let gitdir = tmp("gitrepo-match");
+        let head = make_git_repo(&gitdir); // tagless work tree, like herdr's install checkout
+        let o = run_impl(
+            "Linux",
+            "x86_64",
+            "1.2.0",
+            true,
+            false,
+            Some(&gitdir),
+            Some(&head),
+        );
+        assert!(
+            o.installed_prebuilt(),
+            "HEAD matches the release COMMIT → prebuilt must be used\nstdout:{}\nstderr:{}",
+            o.stdout,
+            o.stderr
+        );
+        assert!(!o.fell_back(), "must not build from source");
+        assert!(
+            !o.stdout.contains("ahead of"),
+            "no ahead-note when the checkout IS the released commit; stdout: {}",
+            o.stdout
+        );
+        let _ = fs::remove_dir_all(&gitdir);
+    }
+
+    // Version-only behavior: when the checkout's HEAD is AHEAD of the release commit (e.g. main has
+    // merged work that isn't tagged yet), the prebuilt for the declared version is STILL installed —
+    // landing a PR no longer forces new users to compile — and a transparency note records that the
+    // working tree carries newer, unreleased source than the binary.
+    #[test]
+    fn uses_prebuilt_when_head_is_ahead_of_the_release_commit() {
+        let gitdir = tmp("gitrepo-ahead");
+        let _head = make_git_repo(&gitdir);
+        let other = "0000000000000000000000000000000000000000"; // a commit this checkout is NOT at
+        let o = run_impl(
+            "Linux",
+            "x86_64",
+            "1.2.0",
+            true,
+            false,
+            Some(&gitdir),
+            Some(other),
+        );
+        assert!(
+            o.installed_prebuilt(),
+            "HEAD ahead of the release commit must still use the prebuilt\nstdout:{}\nstderr:{}",
+            o.stdout,
+            o.stderr
+        );
+        assert!(
+            !o.fell_back(),
+            "must not build from source merely because the checkout is ahead of the tag"
+        );
+        assert_eq!(
+            o.placed.as_deref(),
+            Some(&b"#!/bin/sh\necho prebuilt-viewer\n"[..]),
+            "the verified prebuilt must be installed"
+        );
+        assert!(
+            o.urls
+                .iter()
+                .any(|u| u.contains("herdr-file-viewer-x86_64-unknown-linux-musl")),
+            "the binary download must happen (no commit gate before it); urls: {:?}",
+            o.urls
+        );
+        assert!(
+            o.stdout.contains("ahead of"),
+            "must note that the checkout is ahead of the release commit; stdout: {}",
+            o.stdout
+        );
+        let _ = fs::remove_dir_all(&gitdir);
+    }
+
+    // A version with NO published release still falls back to source even from a git checkout — the
+    // asset download 404s, so we never silently install a binary whose version differs from the source.
+    #[test]
+    fn version_with_no_release_still_falls_back_from_a_git_checkout() {
+        let gitdir = tmp("gitrepo-norelease");
+        let head = make_git_repo(&gitdir);
+        let o = run_impl(
+            "Linux",
+            "x86_64",
+            "9.9.9",
+            false, // serve_binary = false → the asset 404s
+            false,
+            Some(&gitdir),
+            Some(&head),
+        );
+        assert!(o.fell_back(), "stdout: {}\nstderr: {}", o.stdout, o.stderr);
+        assert!(o.placed.is_none(), "must not install anything");
+        let _ = fs::remove_dir_all(&gitdir);
+    }
+} // mod unix_sh
+
+// ===============================================================================================
+// Windows: scripts/fetch-or-build.ps1 (T-7 — AC-11, AC-12, AC-13)
+// ===============================================================================================
+//
+// PowerShell functions take precedence over cmdlets of the same name in the calling scope (the
+// same mechanism Pester's mocking uses), so the hermetic test shadows `Invoke-WebRequest` with a
+// mock that serves a local fixture, then dot-sources the real script — no production-code seam
+// beyond the FV_* env vars is needed. `cargo` is stubbed via a `.cmd` shim prepended onto PATH
+// (no chmod/exec-bit ceremony needed on Windows). Real `Get-FileHash`/`certutil` run unmocked —
+// both are purely local/file-based, so they need no network stubbing to stay hermetic.
+#[cfg(windows)]
+mod windows_ps1 {
+    use super::tmp;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::process::Command;
+
+    fn script_path() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("scripts/fetch-or-build.ps1")
+    }
+
+    /// Hex SHA-256 of a file via the built-in `certutil` (no new Cargo dep for the test either).
+    fn sha256_of(file: &Path) -> String {
+        let out = Command::new("certutil")
+            .args(["-hashfile"])
+            .arg(file)
+            .arg("SHA256")
+            .output()
+            .expect("certutil is available on every Windows host");
+        let text = String::from_utf8_lossy(&out.stdout);
+        text.lines()
+            .map(str::trim)
+            .find(|l| l.len() == 64 && l.bytes().all(|b| b.is_ascii_hexdigit()))
+            .expect("certutil prints the 64-hex-char digest line")
+            .to_lowercase()
+    }
+
+    /// Build the mock `Invoke-WebRequest` + dot-source driver script. The mock serves
+    /// `server\bin`/`SHA256SUMS`/`COMMIT` by URL suffix, mirroring the sh test's curl stub
+    /// `case`/`esac`, and logs every requested URL to `urllog` for the "fetched exactly the
+    /// expected asset" assertions.
+    fn write_driver(
+        driver_path: &Path,
+        real_script: &Path,
+        server: &Path,
+        urllog: &Path,
+        serve_binary: bool,
+    ) {
+        let bin_rule = if serve_binary {
+            format!(
+                r#"Copy-Item -Path '{}' -Destination $OutFile -Force"#,
+                server.join("bin").display()
+            )
+        } else {
+            "throw 'simulated 404'".to_string()
+        };
+        let driver = format!(
+            r#"
+function Invoke-WebRequest {{
+    param($Uri, $OutFile, [switch]$UseBasicParsing, $ErrorAction)
+    Add-Content -Path '{urllog}' -Value $Uri
+    if ($Uri -like '*/COMMIT') {{
+        Copy-Item -Path '{commit_src}' -Destination $OutFile -Force
+    }} elseif ($Uri -like '*/SHA256SUMS') {{
+        Copy-Item -Path '{sums_src}' -Destination $OutFile -Force
+    }} else {{
+        {bin_rule}
+    }}
+}}
+. '{script}'
+"#,
+            urllog = urllog.display(),
+            commit_src = server.join("COMMIT").display(),
+            sums_src = server.join("SHA256SUMS").display(),
+            script = real_script.display(),
+        );
+        fs::write(driver_path, driver).unwrap();
+    }
+
+    struct Outcome {
+        stdout: String,
+        stderr: String,
+        placed: Option<Vec<u8>>,
+        urls: Vec<String>,
+    }
+
+    impl Outcome {
+        fn installed_prebuilt(&self) -> bool {
+            self.stdout.contains("installed prebuilt")
+        }
+        fn fell_back(&self) -> bool {
+            self.stdout.contains("FAKE_CARGO_BUILD")
+        }
+    }
+
+    /// Run the (mocked) script for a fixture release at `version`.
+    /// - `serve_binary == false` → the mocked download throws (simulates a 404 / missing asset).
+    /// - `corrupt_sums == true`  → the published SHA256SUMS holds a wrong hash (checksum mismatch).
+    fn run(version: &str, serve_binary: bool, corrupt_sums: bool) -> Outcome {
+        let root = tmp("root-ps1");
+        let stub = root.join("bin");
+        let server = root.join("server");
+        let out = root.join("target/release/herdr-file-viewer.exe");
+        let urllog = root.join("urls.log");
+        fs::create_dir_all(&stub).unwrap();
+        fs::create_dir_all(&server).unwrap();
+
+        let cargo_toml = root.join("Cargo.toml");
+        fs::write(
+            &cargo_toml,
+            format!("[package]\nname = \"herdr-file-viewer\"\nversion = \"{version}\"\n"),
+        )
+        .unwrap();
+
+        let triple = "x86_64-pc-windows-msvc";
+        let asset = format!("herdr-file-viewer-{triple}.exe");
+        let bin_blob: &[u8] = b"fake windows prebuilt binary\r\n";
+        fs::write(server.join("bin"), bin_blob).unwrap();
+        let real_hash = sha256_of(&server.join("bin"));
+        let hash = if corrupt_sums {
+            "0".repeat(64)
+        } else {
+            real_hash
+        };
+        fs::write(server.join("SHA256SUMS"), format!("{hash}  {asset}\n")).unwrap();
+        // No COMMIT fixture: FV_REPO_ROOT below is not a git work tree, so the ahead-note path
+        // is skipped and the platform/download/verify logic is what's under test (mirrors the
+        // sh test's default `run`).
+        fs::write(server.join("COMMIT"), "unused\n").unwrap();
+
+        // Stub `cargo` via a `.cmd` shim on PATH — no chmod/exec-bit needed on Windows.
+        fs::write(
+            stub.join("cargo.cmd"),
+            "@echo off\r\necho FAKE_CARGO_BUILD %*\r\nexit /b 0\r\n",
+        )
+        .unwrap();
+
+        let driver = root.join("driver.ps1");
+        write_driver(&driver, &script_path(), &server, &urllog, serve_binary);
+
+        let path = format!(
+            "{};{}",
+            stub.display(),
+            std::env::var("PATH").unwrap_or_default()
+        );
+        let output = Command::new("powershell.exe")
+            .args(["-NoProfile", "-ExecutionPolicy", "Bypass", "-File"])
+            .arg(&driver)
+            .env("PATH", path)
+            .env("PROCESSOR_ARCHITECTURE", "AMD64")
+            .env("FV_REPO_ROOT", &root) // not a git work tree → ahead-note path is skipped
+            .env("FV_CARGO_TOML", &cargo_toml)
+            .env("FV_OUT", &out)
+            .env("FV_BASE_URL", "https://example.invalid/releases/download")
+            .output()
+            .expect("run fetch-or-build.ps1 via the mock driver");
+
+        let urls = fs::read_to_string(&urllog)
+            .unwrap_or_default()
+            .lines()
+            .map(|s| s.to_string())
+            .collect();
+        let placed = fs::read(&out).ok();
+        let o = Outcome {
+            stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+            placed,
+            urls,
+        };
+        let _ = fs::remove_dir_all(&root);
+        o
+    }
+
+    /// (a) matching prebuilt + correct SHA → installs to FV_OUT, exits 0 without invoking cargo.
+    #[test]
+    fn fast_path_installs_verified_binary() {
+        let o = run("1.2.0", true, false);
+        assert!(
+            o.installed_prebuilt(),
+            "stdout: {}\nstderr: {}",
+            o.stdout,
+            o.stderr
+        );
+        assert!(
+            !o.fell_back(),
+            "must not build from source on the fast path"
+        );
+        assert_eq!(
+            o.placed.as_deref(),
+            Some(&b"fake windows prebuilt binary\r\n"[..])
+        );
+        assert!(
+            o.urls
+                .iter()
+                .any(|u| u.ends_with("/v1.2.0/herdr-file-viewer-x86_64-pc-windows-msvc.exe")),
+            "fetched exactly the version+triple .exe asset, never 'latest'; urls: {:?}",
+            o.urls
+        );
+        assert!(
+            o.urls.iter().any(|u| u.ends_with("/v1.2.0/SHA256SUMS")),
+            "urls: {:?}",
+            o.urls
+        );
+    }
+
+    /// (b) missing asset (404) → source-build fallback.
+    #[test]
+    fn missing_release_asset_falls_back_to_source_build() {
+        let o = run("9.9.9", false, false);
+        assert!(o.fell_back(), "stdout: {}\nstderr: {}", o.stdout, o.stderr);
+        assert!(o.placed.is_none());
+    }
+
+    /// (c) checksum mismatch → fallback (never installs the unverified binary).
+    #[test]
+    fn checksum_mismatch_falls_back_and_installs_nothing() {
+        let o = run("1.2.0", true, true);
+        assert!(o.fell_back(), "stdout: {}\nstderr: {}", o.stdout, o.stderr);
+        assert!(o.placed.is_none(), "must not install an unverified binary");
+        assert!(
+            o.stderr.contains("checksum mismatch"),
+            "stderr: {}",
+            o.stderr
+        );
+    }
+
+    /// An unmapped architecture (no x86_64 Windows match — AC-N4 means no aarch64 support)
+    /// falls back without ever attempting a download.
+    #[test]
+    fn unmapped_architecture_falls_back_without_downloading() {
+        let root = tmp("root-ps1-unmapped");
+        let stub = root.join("bin");
+        let server = root.join("server");
+        let out = root.join("target/release/herdr-file-viewer.exe");
+        let urllog = root.join("urls.log");
+        fs::create_dir_all(&stub).unwrap();
+        fs::create_dir_all(&server).unwrap();
+        let cargo_toml = root.join("Cargo.toml");
+        fs::write(
+            &cargo_toml,
+            "[package]\nname = \"herdr-file-viewer\"\nversion = \"1.2.0\"\n",
+        )
+        .unwrap();
+        fs::write(
+            stub.join("cargo.cmd"),
+            "@echo off\r\necho FAKE_CARGO_BUILD %*\r\nexit /b 0\r\n",
+        )
+        .unwrap();
+        let driver = root.join("driver.ps1");
+        write_driver(&driver, &script_path(), &server, &urllog, true);
+
+        let path = format!(
+            "{};{}",
+            stub.display(),
+            std::env::var("PATH").unwrap_or_default()
+        );
+        let output = Command::new("powershell.exe")
+            .args(["-NoProfile", "-ExecutionPolicy", "Bypass", "-File"])
+            .arg(&driver)
+            .env("PATH", path)
+            .env("PROCESSOR_ARCHITECTURE", "ARM64") // unsupported in v1 (AC-N4)
+            .env("FV_REPO_ROOT", &root)
+            .env("FV_CARGO_TOML", &cargo_toml)
+            .env("FV_OUT", &out)
+            .env("FV_BASE_URL", "https://example.invalid/releases/download")
+            .output()
+            .expect("run fetch-or-build.ps1 via the mock driver");
+
+        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        let urls = fs::read_to_string(&urllog).unwrap_or_default();
+        assert!(
+            stdout.contains("FAKE_CARGO_BUILD"),
+            "stdout: {stdout}\nstderr: {stderr}"
+        );
+        assert!(
+            urls.is_empty(),
+            "must not download for an unsupported architecture; urls log: {urls:?}"
+        );
+        assert!(stderr.contains("no prebuilt binary"), "stderr: {stderr}");
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    /// The fallback preserves the cargo source-build path, like the sh script.
+    #[test]
+    fn script_preserves_the_cargo_source_build_fallback() {
+        let s = fs::read_to_string(script_path()).unwrap();
+        assert!(
+            s.contains("cargo build --release"),
+            "fallback must still build from source"
+        );
+        assert!(
+            s.contains("rustup.rs"),
+            "the no-cargo message must point at how to get Rust, like the sh script"
+        );
+    }
 }

--- a/tests/git_baseline.rs
+++ b/tests/git_baseline.rs
@@ -4,7 +4,9 @@
 mod common;
 
 use common::{TempDir, git};
-use herdr_file_viewer::git::{Baseline, Status, changed_set, default_baseline, diff, status};
+#[cfg(unix)]
+use herdr_file_viewer::git::status;
+use herdr_file_viewer::git::{Baseline, Status, changed_set, default_baseline, diff};
 use herdr_file_viewer::root::Resolved;
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/tests/git_baseline.rs
+++ b/tests/git_baseline.rs
@@ -358,6 +358,11 @@ fn diff_refuses_paths_outside_the_root() {
     );
 }
 
+// The malicious payload is a `#!/bin/sh` script made executable via unix permission bits; the
+// hardening it exercises (core.fsmonitor/core.hooksPath/textconv neutralization) is
+// platform-agnostic and already covered by `git_command_applies_every_untrusted_repo_guard` in
+// `src/git.rs`, which runs on every platform.
+#[cfg(unix)]
 #[test]
 fn malicious_repo_config_is_not_executed_during_queries() {
     // A planted .git/config must not run programs via fsmonitor/textconv when the viewer
@@ -403,6 +408,10 @@ fn malicious_repo_config_is_not_executed_during_queries() {
     );
 }
 
+// Creating a symlink reliably without elevated privilege is a unix assumption (Windows
+// symlink creation needs Developer Mode or admin rights, not guaranteed on a CI runner); the
+// escape-via-symlink guard itself (`is_within_root`'s canonicalize check) is platform-agnostic.
+#[cfg(unix)]
 #[test]
 fn diff_refuses_symlink_escaping_the_root() {
     // A symlinked intermediate directory must not let a path resolve outside the root.

--- a/tests/herdr.rs
+++ b/tests/herdr.rs
@@ -23,6 +23,21 @@ fn exit_failure() -> ExitStatus {
     ExitStatus::from_raw(1)
 }
 
+// Windows `ExitStatusExt::from_raw` takes the raw u32 process exit code directly (no
+// unix-style encoded signal/exit-byte split), so 0/1 give the same success/failure shape
+// these hermetic tests need.
+#[cfg(windows)]
+fn exit_success() -> ExitStatus {
+    use std::os::windows::process::ExitStatusExt;
+    ExitStatus::from_raw(0)
+}
+
+#[cfg(windows)]
+fn exit_failure() -> ExitStatus {
+    use std::os::windows::process::ExitStatusExt;
+    ExitStatus::from_raw(1)
+}
+
 fn make_output(status: ExitStatus, stdout: &str) -> Output {
     Output {
         status,

--- a/tests/herdr.rs
+++ b/tests/herdr.rs
@@ -138,11 +138,32 @@ fn run_json_returns_err_on_non_zero_exit() {
 // Test 3: resolve_program — pure helper, testable without touching the env
 // ---------------------------------------------------------------------------
 
+// unix/macOS: an explicit configured path is used exactly as given (AC-3, unchanged). On
+// Windows the same input now goes through the `.exe`-suffix seam (AC-9) — a non-existent
+// extension-less explicit path resolves to its `.exe` form, so this exact assertion would no
+// longer hold there; the Windows-specific wiring is covered by the companion test below
+// (hermetic coverage of the seam itself lives in `src/herdr.rs`'s inline test module).
+#[cfg(unix)]
 #[test]
 fn resolve_program_uses_herdr_bin_path_when_set() {
     use herdr_file_viewer::herdr::resolve_program;
     let result = resolve_program(Some("/custom/herdr".to_string()));
     assert_eq!(result, std::ffi::OsString::from("/custom/herdr"));
+}
+
+// Windows: the same kind of input (an explicit path lacking an extension that does not exist
+// on this CI runner) resolves through the live `Path::exists` wiring to its `.exe` form,
+// proving `resolve_program` (the public, real-filesystem entry point) actually applies the
+// seam — not just the injected-predicate unit tests in `src/herdr.rs`.
+#[cfg(windows)]
+#[test]
+fn resolve_program_uses_herdr_bin_path_when_set() {
+    use herdr_file_viewer::herdr::resolve_program;
+    let result = resolve_program(Some(r"C:\definitely\not\a\real\path\herdr".to_string()));
+    assert_eq!(
+        result,
+        std::ffi::OsString::from(r"C:\definitely\not\a\real\path\herdr.exe")
+    );
 }
 
 #[test]

--- a/tests/launcher_content.rs
+++ b/tests/launcher_content.rs
@@ -1,0 +1,42 @@
+//! Cross-platform regression guard for the Windows launcher spawn form (GH #58).
+//!
+//! `launcher_ps1.rs` parse-checks the scripts, but it is `#![cfg(windows)]` and so runs only on
+//! the advisory Windows CI job. This content check is deliberately **not** gated to Windows: it
+//! reads the launcher text and runs on the *required* (Linux/macOS) matrix, so a regression to the
+//! bare-path spawn fails a blocking check.
+//!
+//! Why it matters: herdr's `pane run <id> <command>` types `<command>` into the pane's shell
+//! (PowerShell on Windows). A bare or plain-quoted path like `pane run $np "$ViewerBin"` splits on
+//! a space in the install path (e.g. `C:\Users\First Last\...`), so the viewer never launches —
+//! reproduced live on real Windows. The fix runs the viewer via the PowerShell call operator with
+//! a quoted absolute path: `pane run $np "& \"$ViewerBin\""`.
+
+use std::path::PathBuf;
+
+fn read_script(name: &str) -> String {
+    let p = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("scripts")
+        .join(name);
+    std::fs::read_to_string(&p).unwrap_or_else(|e| panic!("read {}: {e}", p.display()))
+}
+
+#[test]
+fn windows_launchers_spawn_via_call_operator_not_a_bare_path() {
+    for name in ["open-file-viewer.ps1", "open-file-viewer-tab.ps1"] {
+        let s = read_script(name);
+
+        // The bare form that splits on a space in the install path must be gone.
+        assert!(
+            !s.contains(r#"pane run $np "$ViewerBin""#),
+            "{name} still spawns with the bare `pane run $np \"$ViewerBin\"` form — it splits on a \
+             space in the install path (GH #58). Use the call-operator form."
+        );
+
+        // The viewer must be spawned via the call operator (`& ...`) so a quoted, spaced path runs.
+        assert!(
+            s.contains(r#"pane run $np "& "#),
+            "{name} must spawn the viewer via the PowerShell call operator: \
+             pane run $np \"& \\\"$ViewerBin\\\"\""
+        );
+    }
+}

--- a/tests/launcher_ps1.rs
+++ b/tests/launcher_ps1.rs
@@ -93,7 +93,7 @@ fn manifest_windows_action_commands_parse() {
     let payloads: Vec<&str> = manifest
         .lines()
         .map(str::trim)
-        .filter(|l| l.contains("[IO.Directory]::GetCurrentDirectory()"))
+        .filter(|l| l.contains("ConvertFrom-Json"))
         .map(|l| l.trim_end_matches(',').trim_matches('\'').trim())
         .collect();
 

--- a/tests/launcher_ps1.rs
+++ b/tests/launcher_ps1.rs
@@ -25,10 +25,11 @@ fn assert_parses(name: &str) {
     let path = script_path(name);
     assert!(path.is_file(), "{name} must exist at {}", path.display());
 
-    let cmd = format!(
-        "$null = [ScriptBlock]::Create((Get-Content -Raw -LiteralPath '{}'))",
-        path.display()
-    );
+    // Single-quote the path for PowerShell and escape any embedded `'` by doubling it, so a repo
+    // checked out under a path containing a quote can't terminate the literal (defensive — these
+    // are our own fixed-name scripts, but the interpolation should still be robust).
+    let quoted = path.display().to_string().replace('\'', "''");
+    let cmd = format!("$null = [ScriptBlock]::Create((Get-Content -Raw -LiteralPath '{quoted}'))");
     let output = Command::new("powershell.exe")
         .args(["-NoProfile", "-Command", &cmd])
         .output()

--- a/tests/launcher_ps1.rs
+++ b/tests/launcher_ps1.rs
@@ -1,0 +1,61 @@
+//! Parse-only test for the Windows launcher scripts (T-8 — AC-16).
+//!
+//! `scripts/open-file-viewer.ps1` and `scripts/open-file-viewer-tab.ps1` are thin glue over the
+//! already-unit-tested, portable launch-decision logic (`src/launch.rs`). The end-to-end
+//! launch-or-focus-or-close toggle needs a live herdr on Windows and is reviewer-checked
+//! (AC-16); what we CAN cheaply assert here, hermetically, is that each script is syntactically
+//! valid PowerShell — `[ScriptBlock]::Create` parses the script text without executing it, so a
+//! syntax error (a typo, an unbalanced brace, …) fails this test immediately instead of only
+//! surfacing the first time someone presses the launcher's key on real Windows.
+
+#![cfg(windows)]
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn script_path(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("scripts")
+        .join(name)
+}
+
+/// Parse `script` with `[ScriptBlock]::Create`, asserting it succeeds (exit 0) and reports no
+/// error on stderr. Never executes the script's body.
+fn assert_parses(name: &str) {
+    let path = script_path(name);
+    assert!(path.is_file(), "{name} must exist at {}", path.display());
+
+    let cmd = format!(
+        "$null = [ScriptBlock]::Create((Get-Content -Raw -LiteralPath '{}'))",
+        path.display()
+    );
+    let output = Command::new("powershell.exe")
+        .args(["-NoProfile", "-Command", &cmd])
+        .output()
+        .expect("run powershell.exe to parse the script");
+
+    assert!(
+        output.status.success(),
+        "{name} failed to parse: stdout={}\nstderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn open_file_viewer_ps1_parses() {
+    assert_parses("open-file-viewer.ps1");
+}
+
+#[test]
+fn open_file_viewer_tab_ps1_parses() {
+    assert_parses("open-file-viewer-tab.ps1");
+}
+
+#[test]
+fn fetch_or_build_ps1_parses() {
+    // Not a launcher, but the same hermetic parse-check is cheap insurance for the other
+    // Windows-only script (T-7) — a syntax error there would otherwise only surface on a real
+    // Windows install.
+    assert_parses("fetch-or-build.ps1");
+}

--- a/tests/launcher_ps1.rs
+++ b/tests/launcher_ps1.rs
@@ -60,3 +60,50 @@ fn fetch_or_build_ps1_parses() {
     // Windows install.
     assert_parses("fetch-or-build.ps1");
 }
+
+/// Parse an inline PowerShell string with `[ScriptBlock]::Create`, asserting success without
+/// executing it.
+fn assert_ps_parses(label: &str, script: &str) {
+    let quoted = script.replace('\'', "''");
+    let cmd = format!("$null = [ScriptBlock]::Create('{quoted}')");
+    let output = Command::new("powershell.exe")
+        .args(["-NoProfile", "-Command", &cmd])
+        .output()
+        .expect("run powershell.exe to parse the inline command");
+    assert!(
+        output.status.success(),
+        "{label} failed to parse: stdout={}\nstderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn manifest_windows_action_commands_parse() {
+    // The Windows [[actions]] run an inline `-Command` (not a `-File`) that re-derives the
+    // launcher's absolute path from the `\\?\` server cwd. That PowerShell lives in the manifest
+    // TOML, so the .ps1 parse-checks above don't cover it — a syntax error there would first
+    // surface when the tester presses the key on real Windows. Extract each such payload (the
+    // line carrying the de-verbatim marker, unwrapped from its TOML literal) and parse it here.
+    let manifest = std::fs::read_to_string(
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("herdr-plugin.toml"),
+    )
+    .expect("read manifest");
+
+    let payloads: Vec<&str> = manifest
+        .lines()
+        .map(str::trim)
+        .filter(|l| l.contains("[IO.Directory]::GetCurrentDirectory()"))
+        .map(|l| l.trim_end_matches(',').trim_matches('\'').trim())
+        .collect();
+
+    assert_eq!(
+        payloads.len(),
+        2,
+        "expected exactly the two Windows action -Command payloads, found {}: {payloads:?}",
+        payloads.len()
+    );
+    for p in payloads {
+        assert_ps_parses("manifest Windows action -Command", p);
+    }
+}

--- a/tests/manifest.rs
+++ b/tests/manifest.rs
@@ -46,19 +46,20 @@ fn declares_split_pane_launching_the_release_binary() {
 }
 
 #[test]
-fn declares_a_windows_pane_naming_the_exe_explicitly() {
-    // herdr does NOT append `.exe` (verified on real Windows, GH #58), so the Windows pane entry
-    // names it. It carries a distinct id (`file-viewer-windows`) since herdr rejects duplicates;
-    // the Windows launcher opens THIS entrypoint (with a clean `--cwd`), leaving the unix pane
-    // untouched.
+fn declares_no_windows_pane_entry() {
+    // On Windows herdr cannot spawn the manifest's relative pane command (CreateProcessW resolves a
+    // relative program against herdr's own dir, not any `--cwd`), so there is deliberately NO Windows
+    // [[panes]] entry — the Windows launchers spawn the viewer by absolute path via
+    // `pane split`/`tab create` + `pane run` (verified on real hardware, GH #58). Guard that we
+    // didn't leave a dead `.exe` pane entry behind.
     let m = manifest();
     assert!(
-        m.contains(r#"id = "file-viewer-windows""#),
-        "manifest must declare a distinct Windows pane id file-viewer-windows: {m}"
+        !m.contains(r#"id = "file-viewer-windows""#),
+        "there must be no Windows pane entry (absolute-spawn launcher, not a manifest pane): {m}"
     );
     assert!(
-        m.contains(r#"command = ["./target/release/herdr-file-viewer.exe"]"#),
-        "the Windows pane command must name the .exe explicitly (herdr does not append it): {m}"
+        !m.contains("herdr-file-viewer.exe\"]"),
+        "no [[panes]] command should name the .exe (the launcher spawns it by absolute path): {m}"
     );
 }
 
@@ -156,11 +157,11 @@ fn open_file_viewer_action_is_platform_gated_unix_and_windows() {
         m.contains("id = \"open-file-viewer-windows\"\nplatforms = [\"windows\"]"),
         "open-file-viewer's Windows variant must use the distinct id open-file-viewer-windows, gated to [\"windows\"]: {m}"
     );
-    // The Windows action runs the launcher via `-Command`, re-deriving its ABSOLUTE path from the
-    // (possibly `\\?\`-prefixed) cwd — a relative `-File` fails under herdr's verbatim server cwd.
+    // The Windows action runs the launcher via `-Command`, locating it by asking herdr for its own
+    // plugin root (`plugin list`), since the action's cwd is unreliable under herdr's `\\?\` server cwd.
     assert!(
-        m.contains("[IO.Directory]::GetCurrentDirectory()") && m.contains("'open-file-viewer.ps1'"),
-        "open-file-viewer's Windows variant must re-derive its absolute path from the cwd and run the .ps1 launcher: {m}"
+        m.contains("plugin list --json") && m.contains("'open-file-viewer.ps1'"),
+        "open-file-viewer's Windows variant must locate the .ps1 via herdr's plugin root: {m}"
     );
 }
 
@@ -177,9 +178,8 @@ fn open_file_viewer_tab_action_is_platform_gated_unix_and_windows() {
         "open-file-viewer-tab's Windows variant must use the distinct id open-file-viewer-tab-windows, gated to [\"windows\"]: {m}"
     );
     assert!(
-        m.contains("[IO.Directory]::GetCurrentDirectory()")
-            && m.contains("'open-file-viewer-tab.ps1'"),
-        "open-file-viewer-tab's Windows variant must re-derive its absolute path from the cwd and run the .ps1 launcher: {m}"
+        m.contains("plugin list --json") && m.contains("'open-file-viewer-tab.ps1'"),
+        "open-file-viewer-tab's Windows variant must locate the .ps1 via herdr's plugin root: {m}"
     );
 }
 

--- a/tests/manifest.rs
+++ b/tests/manifest.rs
@@ -124,8 +124,11 @@ fn build_step_is_platform_gated_unix_and_windows() {
 
 #[test]
 fn open_file_viewer_action_is_platform_gated_unix_and_windows() {
-    // AC-14, AC-16: the open-file-viewer action has a unix (bash .sh) and a Windows
-    // (PowerShell .ps1) variant, each gated to its platform.
+    // AC-14, AC-16: the open-file-viewer action has a unix (bash .sh) variant and a Windows
+    // (PowerShell .ps1) variant, each gated to its platform. The Windows variant carries a
+    // DISTINCT id (`open-file-viewer-windows`) because herdr rejects a duplicate action id at
+    // load time regardless of platform (verified live against herdr 0.7.1) — a same-id pair
+    // would fail to load on EVERY platform.
     let m = manifest();
     assert!(
         m.contains("id = \"open-file-viewer\"\nplatforms = [\"linux\", \"macos\"]")
@@ -133,9 +136,9 @@ fn open_file_viewer_action_is_platform_gated_unix_and_windows() {
         "open-file-viewer's unix variant must be gated to [\"linux\", \"macos\"] and run the .sh launcher: {m}"
     );
     assert!(
-        m.contains("id = \"open-file-viewer\"\nplatforms = [\"windows\"]")
+        m.contains("id = \"open-file-viewer-windows\"\nplatforms = [\"windows\"]")
             && m.contains("command = [\"powershell\", \"-NoProfile\", \"-ExecutionPolicy\", \"Bypass\", \"-File\", \"scripts/open-file-viewer.ps1\"]"),
-        "open-file-viewer's Windows variant must be gated to [\"windows\"] and run the .ps1 launcher: {m}"
+        "open-file-viewer's Windows variant must use the distinct id open-file-viewer-windows, gated to [\"windows\"], running the .ps1 launcher: {m}"
     );
 }
 
@@ -148,9 +151,33 @@ fn open_file_viewer_tab_action_is_platform_gated_unix_and_windows() {
         "open-file-viewer-tab's unix variant must be gated to [\"linux\", \"macos\"] and run the .sh launcher: {m}"
     );
     assert!(
-        m.contains("id = \"open-file-viewer-tab\"\nplatforms = [\"windows\"]")
+        m.contains("id = \"open-file-viewer-tab-windows\"\nplatforms = [\"windows\"]")
             && m.contains("command = [\"powershell\", \"-NoProfile\", \"-ExecutionPolicy\", \"Bypass\", \"-File\", \"scripts/open-file-viewer-tab.ps1\"]"),
-        "open-file-viewer-tab's Windows variant must be gated to [\"windows\"] and run the .ps1 launcher: {m}"
+        "open-file-viewer-tab's Windows variant must use the distinct id open-file-viewer-tab-windows, gated to [\"windows\"], running the .ps1 launcher: {m}"
+    );
+}
+
+#[test]
+fn action_ids_are_unique() {
+    // herdr rejects a manifest with two [[actions]] sharing an id (`duplicate_plugin_action_id`)
+    // at LOAD time — before any platform filtering — so a same-id-per-platform pair would break
+    // `herdr plugin install` on EVERY platform, not just Windows. Guard that every declared
+    // action id is unique. (Verified live against herdr 0.7.1.)
+    let m = manifest();
+    let mut ids: Vec<&str> = m
+        .lines()
+        .filter_map(|l| l.trim().strip_prefix("id = \""))
+        .filter_map(|s| s.strip_suffix('"'))
+        // the [[panes]] entry also has an `id`; only action/pane ids share the key space we care
+        // about here — dedupe checks all declared `id = "..."` values, which must each be unique.
+        .collect();
+    let n = ids.len();
+    ids.sort_unstable();
+    ids.dedup();
+    assert_eq!(
+        n,
+        ids.len(),
+        "every declared id in the manifest must be unique (herdr rejects duplicates at load)"
     );
 }
 

--- a/tests/manifest.rs
+++ b/tests/manifest.rs
@@ -98,10 +98,69 @@ fn declares_a_release_build_command() {
 }
 
 #[test]
-fn declares_linux_and_macos_platforms() {
+fn declares_linux_macos_and_windows_platforms() {
+    // AC-20: Windows is a declared platform, alongside the existing two.
     assert!(
-        manifest().contains(r#"platforms = ["linux", "macos"]"#),
-        "manifest must declare platforms = [\"linux\", \"macos\"]"
+        manifest().contains(r#"platforms = ["linux", "macos", "windows"]"#),
+        "manifest must declare platforms = [\"linux\", \"macos\", \"windows\"]"
+    );
+}
+
+#[test]
+fn build_step_is_platform_gated_unix_and_windows() {
+    // AC-14: exactly one [[build]] entry runs per host — the /bin/sh entry on unix, the
+    // PowerShell entry on Windows — via herdr's platform filter on the item-level `platforms`
+    // key (which overrides the top-level list).
+    let m = manifest();
+    assert!(
+        m.contains("[[build]]\nplatforms = [\"linux\", \"macos\"]\ncommand = [\"/bin/sh\", \"scripts/fetch-or-build.sh\"]"),
+        "unix [[build]] must be gated to [\"linux\", \"macos\"] and run fetch-or-build.sh: {m}"
+    );
+    assert!(
+        m.contains("[[build]]\nplatforms = [\"windows\"]\ncommand = [\"powershell\", \"-NoProfile\", \"-ExecutionPolicy\", \"Bypass\", \"-File\", \"scripts/fetch-or-build.ps1\"]"),
+        "Windows [[build]] must be gated to [\"windows\"] and run fetch-or-build.ps1: {m}"
+    );
+}
+
+#[test]
+fn open_file_viewer_action_is_platform_gated_unix_and_windows() {
+    // AC-14, AC-16: the open-file-viewer action has a unix (bash .sh) and a Windows
+    // (PowerShell .ps1) variant, each gated to its platform.
+    let m = manifest();
+    assert!(
+        m.contains("id = \"open-file-viewer\"\nplatforms = [\"linux\", \"macos\"]")
+            && m.contains("command = [\"bash\", \"scripts/open-file-viewer.sh\"]"),
+        "open-file-viewer's unix variant must be gated to [\"linux\", \"macos\"] and run the .sh launcher: {m}"
+    );
+    assert!(
+        m.contains("id = \"open-file-viewer\"\nplatforms = [\"windows\"]")
+            && m.contains("command = [\"powershell\", \"-NoProfile\", \"-ExecutionPolicy\", \"Bypass\", \"-File\", \"scripts/open-file-viewer.ps1\"]"),
+        "open-file-viewer's Windows variant must be gated to [\"windows\"] and run the .ps1 launcher: {m}"
+    );
+}
+
+#[test]
+fn open_file_viewer_tab_action_is_platform_gated_unix_and_windows() {
+    let m = manifest();
+    assert!(
+        m.contains("id = \"open-file-viewer-tab\"\nplatforms = [\"linux\", \"macos\"]")
+            && m.contains("command = [\"bash\", \"scripts/open-file-viewer-tab.sh\"]"),
+        "open-file-viewer-tab's unix variant must be gated to [\"linux\", \"macos\"] and run the .sh launcher: {m}"
+    );
+    assert!(
+        m.contains("id = \"open-file-viewer-tab\"\nplatforms = [\"windows\"]")
+            && m.contains("command = [\"powershell\", \"-NoProfile\", \"-ExecutionPolicy\", \"Bypass\", \"-File\", \"scripts/open-file-viewer-tab.ps1\"]"),
+        "open-file-viewer-tab's Windows variant must be gated to [\"windows\"] and run the .ps1 launcher: {m}"
+    );
+}
+
+#[test]
+fn no_entry_declares_an_aarch64_windows_target() {
+    // AC-N4: v1 targets x86_64-pc-windows-msvc only — no Windows-on-ARM declaration (comments
+    // are stripped first, so this checks actual entries, not explanatory prose).
+    assert!(
+        !manifest().contains("aarch64"),
+        "manifest must not declare any aarch64 (Windows-on-ARM) target"
     );
 }
 

--- a/tests/manifest.rs
+++ b/tests/manifest.rs
@@ -46,6 +46,23 @@ fn declares_split_pane_launching_the_release_binary() {
 }
 
 #[test]
+fn declares_a_windows_pane_naming_the_exe_explicitly() {
+    // herdr does NOT append `.exe` (verified on real Windows, GH #58), so the Windows pane entry
+    // names it. It carries a distinct id (`file-viewer-windows`) since herdr rejects duplicates;
+    // the Windows launcher opens THIS entrypoint (with a clean `--cwd`), leaving the unix pane
+    // untouched.
+    let m = manifest();
+    assert!(
+        m.contains(r#"id = "file-viewer-windows""#),
+        "manifest must declare a distinct Windows pane id file-viewer-windows: {m}"
+    );
+    assert!(
+        m.contains(r#"command = ["./target/release/herdr-file-viewer.exe"]"#),
+        "the Windows pane command must name the .exe explicitly (herdr does not append it): {m}"
+    );
+}
+
+#[test]
 fn declares_at_least_one_action() {
     assert!(
         manifest().contains("[[actions]]"),
@@ -136,9 +153,14 @@ fn open_file_viewer_action_is_platform_gated_unix_and_windows() {
         "open-file-viewer's unix variant must be gated to [\"linux\", \"macos\"] and run the .sh launcher: {m}"
     );
     assert!(
-        m.contains("id = \"open-file-viewer-windows\"\nplatforms = [\"windows\"]")
-            && m.contains("command = [\"powershell\", \"-NoProfile\", \"-ExecutionPolicy\", \"Bypass\", \"-File\", \"scripts/open-file-viewer.ps1\"]"),
-        "open-file-viewer's Windows variant must use the distinct id open-file-viewer-windows, gated to [\"windows\"], running the .ps1 launcher: {m}"
+        m.contains("id = \"open-file-viewer-windows\"\nplatforms = [\"windows\"]"),
+        "open-file-viewer's Windows variant must use the distinct id open-file-viewer-windows, gated to [\"windows\"]: {m}"
+    );
+    // The Windows action runs the launcher via `-Command`, re-deriving its ABSOLUTE path from the
+    // (possibly `\\?\`-prefixed) cwd — a relative `-File` fails under herdr's verbatim server cwd.
+    assert!(
+        m.contains("[IO.Directory]::GetCurrentDirectory()") && m.contains("'open-file-viewer.ps1'"),
+        "open-file-viewer's Windows variant must re-derive its absolute path from the cwd and run the .ps1 launcher: {m}"
     );
 }
 
@@ -151,9 +173,13 @@ fn open_file_viewer_tab_action_is_platform_gated_unix_and_windows() {
         "open-file-viewer-tab's unix variant must be gated to [\"linux\", \"macos\"] and run the .sh launcher: {m}"
     );
     assert!(
-        m.contains("id = \"open-file-viewer-tab-windows\"\nplatforms = [\"windows\"]")
-            && m.contains("command = [\"powershell\", \"-NoProfile\", \"-ExecutionPolicy\", \"Bypass\", \"-File\", \"scripts/open-file-viewer-tab.ps1\"]"),
-        "open-file-viewer-tab's Windows variant must use the distinct id open-file-viewer-tab-windows, gated to [\"windows\"], running the .ps1 launcher: {m}"
+        m.contains("id = \"open-file-viewer-tab-windows\"\nplatforms = [\"windows\"]"),
+        "open-file-viewer-tab's Windows variant must use the distinct id open-file-viewer-tab-windows, gated to [\"windows\"]: {m}"
+    );
+    assert!(
+        m.contains("[IO.Directory]::GetCurrentDirectory()")
+            && m.contains("'open-file-viewer-tab.ps1'"),
+        "open-file-viewer-tab's Windows variant must re-derive its absolute path from the cwd and run the .ps1 launcher: {m}"
     );
 }
 

--- a/tests/release_workflow.rs
+++ b/tests/release_workflow.rs
@@ -1,7 +1,8 @@
 //! The release workflow's contract, asserted as text (mirrors tests/manifest.rs): it triggers on
-//! version tags, builds the three published targets, guards the tag against the crate version, and
-//! publishes a SHA256SUMS. These are the invariants scripts/fetch-or-build.sh relies on; GitHub
-//! Actions itself is exercised by cutting a real tag (a manual verification step).
+//! version tags, builds the four published targets (incl. x86_64-pc-windows-msvc, preview —
+//! T-10), guards the tag against the crate version, and publishes a SHA256SUMS. These are the
+//! invariants scripts/fetch-or-build.sh and fetch-or-build.ps1 rely on; GitHub Actions itself is
+//! exercised by cutting a real tag (a manual verification step).
 
 use std::fs;
 use std::path::PathBuf;
@@ -19,15 +20,34 @@ fn triggers_on_version_tags() {
 }
 
 #[test]
-fn builds_the_three_published_targets() {
+fn builds_the_four_published_targets() {
     let w = workflow();
     for triple in [
         "aarch64-apple-darwin",
         "x86_64-apple-darwin",
         "x86_64-unknown-linux-musl",
+        "x86_64-pc-windows-msvc",
     ] {
         assert!(w.contains(triple), "release must build {triple}");
     }
+}
+
+#[test]
+fn publishes_the_windows_exe_asset() {
+    // AC-18: the Windows target publishes a herdr-file-viewer-x86_64-pc-windows-msvc.exe asset.
+    assert!(
+        workflow().contains("herdr-file-viewer-$triple.exe"),
+        "release must stage the Windows asset with its .exe suffix"
+    );
+}
+
+#[test]
+fn does_not_declare_an_aarch64_windows_target() {
+    // AC-N4: v1 targets x86_64-pc-windows-msvc only — no Windows-on-ARM in the matrix.
+    assert!(
+        !workflow().contains("aarch64-pc-windows"),
+        "release must not declare an aarch64 Windows target"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Native Windows support (preview)

Makes the viewer build, test (on CI), and run on **native Windows** (`x86_64-pc-windows-msvc`), declared a herdr manifest platform at a best-effort **preview** bar — mirroring herdr's own Windows posture. Closes the work tracked for external request #58.

Built through the full Agent SDLC pipeline (idea → criteria → design → techstack → plan → **gate PASSED**) — spec is local-only; this PR is the build of plan tasks **T-1…T-11**, one PR as designed. **Zero new Cargo dependencies.**

### Platform seams (cfg-gated pure helpers, Linux/macOS paths byte-identical)
- **`git` path decode** — `path_from_git_bytes`: unix keeps the lossless `OsStr::from_bytes` mapping; Windows decodes git's UTF-8 path bytes (drops invalid without panicking). Removes the unix-only `OsStrExt` **compile-blocker**. (AC-5)
- **`git` null device** — `NULL_DEVICE` constant (`/dev/null` | `NUL`) for the untracked-diff base and `core.hooksPath` hardening. (AC-6)
- **update cache dir** — `%LOCALAPPDATA%` on Windows when `HOME`/`XDG` are unset; unix unchanged. (AC-7)
- **editor argv** — a quote-aware tokenizer (cross-platform) so a `"C:\Program Files\…\Code.exe"` path stays one argv[0]; `notepad.exe` default when `$EDITOR` is unset on Windows (unix stays `None`). (AC-8)
- **herdr exe resolution** — `.exe`-suffix resolution for an explicit, extension-less, not-found path; bare names still defer to PATH. (AC-9)

### Install + launch parity
- **`scripts/fetch-or-build.ps1`** (PowerShell 5.1) — version-matched prebuilt download → SHA-256 verify (`Get-FileHash`, `certutil` fallback) → `cargo build` fallback on any miss; `FV_*` env seams; no toolchain required. (AC-11/12/13)
- **`scripts/open-file-viewer.ps1` + `-tab.ps1`** — thin glue over the already-tested `--launch-decision` logic. (AC-16)
- **`herdr-plugin.toml`** — `platforms += "windows"`; `[[build]]`/`[[actions]]` duplicated and item-level platform-gated; `[[panes]]` stays platform-agnostic; no aarch64. (AC-14/15/20/N4)

### CI / release
- **`ci.yml`** — advisory (`continue-on-error`) `windows-latest` test job, deliberately separate from the required matrix so a Windows-only flake can't block unrelated PRs. (AC-19/N2)
- **`release.yml`** — `x86_64-pc-windows-msvc` row producing `herdr-file-viewer-x86_64-pc-windows-msvc.exe` + its `SHA256SUMS` line. (AC-18)

### Docs
- README platforms badge + a **Windows (preview)** section (preview status, herdr preview-channel requirement, WSL interim); `CHANGELOG` `[Unreleased]` entry. (AC-21/22, preview label retained AC-N1, WSL docs-only AC-N3)

### Verification
- Green bar verified locally on Linux: `fmt` · `clippy -D warnings` · `build --release` · full `cargo test` (39 binaries, 0 failures).
- **Windows arms type-checked locally** via `cargo check --target x86_64-pc-windows-gnu --all-targets` (+ clippy) — clean. Their runtime pass is the advisory `windows-latest` job here (no Windows dev host; honest-oracle by design).
- Read-only invariant (AC-10) holds — every seam is a pure transform / resolution / relocated cache read-write.

> Preview = best-effort, community-validated (the #58 requester validates on real hardware); not a parity guarantee. The `windows-latest` job is advisory while preview.
