### PR TITLE
test(windows): gate hostile-filename copy-path test to unix

### DIFF
--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -2146,6 +2146,11 @@ fn y_and_capital_y_copy_path_unchanged() {
     );
 }
 
+// Unix-only: this end-to-end check needs a file whose *name* carries control bytes (ESC/BEL/newline),
+// which Windows forbids — `fs::write` fails there before the copy path is even reached. The
+// `sanitize_control` defense itself is platform-agnostic and directly unit-tested in `text_layout.rs`,
+// so Windows keeps full coverage of the sanitizer; only this filesystem-level repro is gated.
+#[cfg(unix)]
 #[test]
 fn copy_path_strips_control_bytes_from_a_hostile_filename() {
     // A filename is attacker-controllable in a browsed repo and may legally contain control bytes —

--- a/tests/lineselect.rs
+++ b/tests/lineselect.rs
@@ -599,6 +599,11 @@ fn range_copies_start_end() {
     );
 }
 
+// Unix-only: this repro needs a file whose *name* carries an ESC byte, which Windows forbids —
+// `fs::write` fails there before the copy path runs. The `sanitize_control` defense is
+// platform-agnostic and directly unit-tested in `text_layout.rs` (runs on every platform), so
+// Windows keeps full sanitizer coverage; only the filesystem-level repro is gated.
+#[cfg(unix)]
 #[test]
 fn control_bytes_in_path_are_sanitized() {
     // AC-16: the path segment is untrusted — a crafted file name can carry an ESC byte. The whole


### PR DESCRIPTION
## What

The `test (windows-latest, advisory)` CI job has been failing on a **pre-existing, test-only** quirk unrelated to any feature: `copy_path_strips_control_bytes_from_a_hostile_filename` builds a file whose *name* contains control bytes (ESC/BEL/newline) to prove the copy path strips them. Those bytes are legal in unix filenames but **forbidden on Windows**, so `fs::write` panics before the code under test is even reached.

## Fix

Gate the end-to-end repro with `#[cfg(unix)]`, mirroring its already-gated sibling `y_and_capital_y_copy_path_unchanged` a few lines above.

**No Windows coverage is lost:** the `sanitize_control` defense this test exercises is platform-agnostic and **directly unit-tested** in `src/text_layout.rs` (`sanitize_control_strips_control_bytes_keeps_printable`), which runs on every platform. Only the filesystem-level repro — which *cannot exist* on Windows — is gated.

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets -D warnings` clean
- `cargo test --test controller` → 222 passed
- Expect the `windows-latest, advisory` check to go green on this PR