### PR TITLE
docs(changelog): drop empty [Unreleased] heading after v1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
 ## [1.9.0] - 2026-07-06
 
 ### Added


### PR DESCRIPTION
Dating the copy-line-reference block as `## [1.9.0] - 2026-07-06` in the release PR left a bare, empty `## [Unreleased]` heading at the top of `CHANGELOG.md` with nothing under it.

Per the repo's changelog convention that heading is removed on release (the next feature PR re-adds it). The docs-consistency guard was already re-keyed to the permanent `## [1.9.0]` section in the release, so nothing depends on `[Unreleased]` existing.

Docs-only; `cargo test --test docs_consistency` green.