### PR TITLE
feat: reveal in file manager / open with default app (O / R keys)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -51,6 +51,7 @@ is unit-testable with stubs.
 | `app` | The event loop (`run()`): assemble the live components, then `draw → poll input → route to the controller (or the active modal) → drain finished renders`, until the user closes the viewer. |
 | `update` | The bounded, read-only, fail-silent update check: at most once per 24h a hardened `git ls-remote --tags` (off the UI thread, in a private temp dir) compares the latest release to the running build and feeds the dismissable "update available" banner; opt out via `HERDR_FILE_VIEWER_NO_UPDATE_CHECK`. |
 | `editor` | Hand a file off to `$EDITOR` (launch only — never reads or writes the file). |
+| `opener` | Read-only OS hand-off for the `O` / `R` keys: a pure per-OS argv builder (open-with-default-app / reveal-in-file-manager) plus an `Opener` seam over the reused editor `Spawner`, spawned **non-blocking** (no terminal takeover, stdio nulled) so the TUI keeps running. |
 | `launch` | The "launch-or-focus-or-toggle" decision behind the shell launch scripts (pure, hermetically testable). |
 
 ## Data flow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Reveal in file manager / open with default app** — new `O` (open the selected file or directory
+  with the OS default application) and `R` (reveal the selected entry in the OS file manager) keyboard
+  shortcuts, each a read-only, non-blocking hand-off to the host OS (macOS `open`/`open -R`, Linux
+  `xdg-open`, Windows `explorer`). Requested in #68.
+
 ## [1.9.0] - 2026-07-06
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,9 +221,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ PowerShell launcher scripts.
 | `b` | Toggle the diff baseline (base branch ⇄ `HEAD`) |
 | `v` | Cycle the content view mode |
 | `e` | Open the selected file in `$EDITOR` |
+| `O` (Shift+`o`) | **Open with default app** — hand the selected file or directory to the OS default application (e.g. an image opens in the system viewer). Read-only hand-off; non-blocking (the viewer keeps running) |
+| `R` (Shift+`r`) | **Reveal in file manager** — open the OS file manager (Finder / Explorer / a Linux file manager) with the selected entry highlighted where supported, so you can drag it out (e.g. into Slack). Read-only hand-off |
 | `f` | **Go to file** — open a fuzzy finder over every file in the tree; type to filter, `↑` / `↓` move, `Enter` opens the selected file, `Esc` cancels (`←` / `→` scroll long paths) |
 | `:` | **Go to line** — open a prompt and jump the content pane to a source line by number (`Enter` jumps, `Esc` cancels; out-of-range clamps to the last line). Works in any view; in a rendered-markdown or diff view, confirming switches to the line-numbered content view and jumps there |
 | `/` | **Search in file** — open a prompt and highlight every match in the content pane as you type; `Enter` commits the search (highlights persist), `Esc` clears it and restores the scroll. Smartcase (a lowercase query is case-insensitive; a capital makes it case-sensitive). Works in any view |
@@ -185,7 +187,7 @@ content scroll.)
 
 Character keys act only when no control chord is held (so terminal chords like `Ctrl+C` are
 never intercepted); `Shift` is permitted, for keys such as `<` and `>` (and `y`/`Y`, `W`, `N`,
-`?`, `H`/`L`, and `J`/`K` in line-select mode).
+`O`, `R`, `?`, `H`/`L`, and `J`/`K` in line-select mode).
 
 **Copy a path (`y` / `Y`).** `y` copies the selected file's repo-relative path; `Y` copies its
 absolute path — handy for pasting into a prompt, a command, or an agent. The copy uses the

--- a/src/app.rs
+++ b/src/app.rs
@@ -473,28 +473,29 @@ impl Spawner for ProcessSpawner {
     }
 }
 
-/// Spawns the OS opener with stdio redirected to null so a chatty opener (e.g. `xdg-open`
-/// printing a warning) cannot draw onto the live TUI screen. Blocking on the opener command
-/// itself is fine — `open`/`xdg-open`/`explorer` dispatch to the GUI app and return promptly;
-/// crucially the TUI is NOT suspended (unlike the editor hand-off).
+/// Spawns the OS opener **fire-and-forget**: the child is launched with stdio redirected to null
+/// (so a chatty opener like `xdg-open` printing a warning cannot draw onto the live TUI) and is
+/// NOT waited on — so pressing `O`/`R` returns to the event loop immediately and can never freeze
+/// the viewer even if an opener is slow or hangs (AC-6, non-blocking). `open`/`xdg-open`/`explorer`
+/// are short-lived launchers that dispatch to the GUI app and exit on their own. A launch failure
+/// (e.g. the opener binary is missing) is reported as `NotLaunched` (AC-7); a post-launch exit code
+/// is intentionally NOT observed (that is what fire-and-forget means), unlike the blocking editor
+/// hand-off's `ProcessSpawner`, which waits and can surface a `NonZeroExit`.
 struct OpenerSpawner;
 impl Spawner for OpenerSpawner {
     fn spawn(&mut self, argv: &[OsString]) -> Result<(), SpawnError> {
         let (prog, args) = argv
             .split_first()
             .ok_or_else(|| SpawnError::NotLaunched(io::Error::other("empty opener command")))?;
-        let status = Command::new(prog)
+        // `spawn` (not `status`): launch and return immediately, never blocking the event loop.
+        Command::new(prog)
             .args(args)
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::null())
-            .status()
-            .map_err(SpawnError::NotLaunched)?;
-        if status.success() {
-            Ok(())
-        } else {
-            Err(SpawnError::NonZeroExit(format!("{status}")))
-        }
+            .spawn()
+            .map(drop)
+            .map_err(SpawnError::NotLaunched)
     }
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -474,13 +474,19 @@ impl Spawner for ProcessSpawner {
 }
 
 /// Spawns the OS opener **fire-and-forget**: the child is launched with stdio redirected to null
-/// (so a chatty opener like `xdg-open` printing a warning cannot draw onto the live TUI) and is
-/// NOT waited on — so pressing `O`/`R` returns to the event loop immediately and can never freeze
-/// the viewer even if an opener is slow or hangs (AC-6, non-blocking). `open`/`xdg-open`/`explorer`
+/// (so a chatty opener like `xdg-open` printing a warning cannot draw onto the live TUI) and the
+/// **event loop is never blocked** — pressing `O`/`R` returns immediately and cannot freeze the
+/// viewer even if an opener is slow or hangs (AC-6, non-blocking). `open`/`xdg-open`/`explorer`
 /// are short-lived launchers that dispatch to the GUI app and exit on their own. A launch failure
 /// (e.g. the opener binary is missing) is reported as `NotLaunched` (AC-7); a post-launch exit code
 /// is intentionally NOT observed (that is what fire-and-forget means), unlike the blocking editor
 /// hand-off's `ProcessSpawner`, which waits and can surface a `NonZeroExit`.
+///
+/// The launched child is **reaped on a throwaway thread** (`std::thread` — the same off-thread
+/// idiom the renderer uses) rather than by dropping its handle: on unix, dropping a `Child`
+/// without waiting leaves the exited launcher as a **zombie** until the viewer itself exits, so a
+/// long session with many `O`/`R` presses would accumulate defunct processes (constitution §5,
+/// good plugin citizen). `wait()` runs off the input thread, so this stays non-blocking.
 struct OpenerSpawner;
 impl Spawner for OpenerSpawner {
     fn spawn(&mut self, argv: &[OsString]) -> Result<(), SpawnError> {
@@ -488,14 +494,23 @@ impl Spawner for OpenerSpawner {
             .split_first()
             .ok_or_else(|| SpawnError::NotLaunched(io::Error::other("empty opener command")))?;
         // `spawn` (not `status`): launch and return immediately, never blocking the event loop.
-        Command::new(prog)
+        let mut child = Command::new(prog)
             .args(args)
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .spawn()
-            .map(drop)
-            .map_err(SpawnError::NotLaunched)
+            .map_err(SpawnError::NotLaunched)?;
+        // Reap the short-lived launcher off the input thread so it doesn't linger as a zombie.
+        // The thread ends as soon as the child exits (~immediately); its status is discarded
+        // (fire-and-forget). A failed reaper thread-spawn is non-fatal — worst case is the same
+        // zombie we accept today, never a blocked or crashed viewer.
+        let _ = std::thread::Builder::new()
+            .name("opener-reaper".into())
+            .spawn(move || {
+                let _ = child.wait();
+            });
+        Ok(())
     }
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -30,7 +30,7 @@ use std::ffi::{OsStr, OsString};
 use std::io;
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -95,6 +95,13 @@ pub fn run() -> io::Result<()> {
         Box::new(crate::herdr::LiveHerdr::from_env()),
         ctx.workspace_id.clone(),
     );
+    // Inject the live OS opener for the `O` / `R` hand-offs (AC-13). Non-blocking: unlike the
+    // editor hand-off it does NOT suspend the TUI; the opener runs with stdio redirected to null
+    // so it cannot draw onto our screen.
+    controller.set_opener(Box::new(crate::opener::CommandOpener::new(
+        current_os_kind(),
+        Box::new(OpenerSpawner),
+    )));
 
     let mut terminal = ratatui::try_init()?;
     // Mouse is additive to the keyboard-first design (AC-18): herdr forwards mouse events to a
@@ -463,6 +470,43 @@ impl Spawner for ProcessSpawner {
             // so the controller says "editor exited with …", not "could not open editor".
             Err(SpawnError::NonZeroExit(format!("{status}")))
         }
+    }
+}
+
+/// Spawns the OS opener with stdio redirected to null so a chatty opener (e.g. `xdg-open`
+/// printing a warning) cannot draw onto the live TUI screen. Blocking on the opener command
+/// itself is fine — `open`/`xdg-open`/`explorer` dispatch to the GUI app and return promptly;
+/// crucially the TUI is NOT suspended (unlike the editor hand-off).
+struct OpenerSpawner;
+impl Spawner for OpenerSpawner {
+    fn spawn(&mut self, argv: &[OsString]) -> Result<(), SpawnError> {
+        let (prog, args) = argv
+            .split_first()
+            .ok_or_else(|| SpawnError::NotLaunched(io::Error::other("empty opener command")))?;
+        let status = Command::new(prog)
+            .args(args)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .map_err(SpawnError::NotLaunched)?;
+        if status.success() {
+            Ok(())
+        } else {
+            Err(SpawnError::NonZeroExit(format!("{status}")))
+        }
+    }
+}
+
+/// Map the compile-time build target to the [`OsKind`](crate::opener::OsKind) whose opener
+/// convention to build for. `xdg-open` is the freedesktop default on non-mac/non-windows unixes.
+fn current_os_kind() -> crate::opener::OsKind {
+    if cfg!(target_os = "macos") {
+        crate::opener::OsKind::Mac
+    } else if cfg!(target_os = "windows") {
+        crate::opener::OsKind::Windows
+    } else {
+        crate::opener::OsKind::Linux
     }
 }
 

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -475,6 +475,13 @@ pub struct Controller {
     /// search + its highlighting (AC-20). The incremental-typing path (`refresh_search`) does NOT
     /// call `dispatch_render`, so live typing is never wiped by that clear.
     search: Option<SearchState>,
+    /// The OS opener seam used by the `O` / `R` hand-offs (open-with-default-app / reveal-in-file-
+    /// manager). Injected post-construction via [`set_opener`](Self::set_opener) (like
+    /// [`herdr`](Self::herdr)) so the controller stays hermetic in tests. `None` until then.
+    // Wired here (T-4) but only *read* by the `O`/`R` handlers, which land in a later task —
+    // until then the field is write-only, so silence the dead-code lint rather than gate CI.
+    #[allow(dead_code)]
+    opener: Option<Box<dyn crate::opener::Opener>>,
 }
 
 impl Controller {
@@ -567,6 +574,7 @@ impl Controller {
             our_workspace_id: None,
             base_branch,
             current_branch,
+            opener: None,
         };
         ctrl.refresh_git_state();
         ctrl.dispatch_render();
@@ -868,6 +876,13 @@ impl Controller {
     pub fn set_host(&mut self, herdr: Box<dyn HerdrCli>, workspace_id: Option<String>) {
         self.herdr = Some(herdr);
         self.our_workspace_id = workspace_id;
+    }
+
+    /// Inject the OS opener seam used by the `O` / `R` hand-offs (open-with-default-app /
+    /// reveal-in-file-manager). Injected post-construction (like `set_host`) so the controller
+    /// stays hermetic in tests — a test injects a fake; production injects the live opener (AC-13).
+    pub fn set_opener(&mut self, opener: Box<dyn crate::opener::Opener>) {
+        self.opener = Some(opener);
     }
 
     /// Record the content viewport `(width, height)` the Presenter last drew into, so content

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -478,9 +478,6 @@ pub struct Controller {
     /// The OS opener seam used by the `O` / `R` hand-offs (open-with-default-app / reveal-in-file-
     /// manager). Injected post-construction via [`set_opener`](Self::set_opener) (like
     /// [`herdr`](Self::herdr)) so the controller stays hermetic in tests. `None` until then.
-    // Wired here (T-4) but only *read* by the `O`/`R` handlers, which land in a later task —
-    // until then the field is write-only, so silence the dead-code lint rather than gate CI.
-    #[allow(dead_code)]
     opener: Option<Box<dyn crate::opener::Opener>>,
 }
 
@@ -1455,14 +1452,55 @@ impl Controller {
         Effects::redraw()
     }
 
-    /// Open the selected entry with the OS default app (`O`). Stub — real hand-off wired in T-5.
+    /// Open the selected entry with the OS default app (`O`).
     fn open_with_app(&mut self) -> Effects {
-        Effects::noop()
+        self.hand_off_to_opener(false)
     }
 
-    /// Reveal the selected entry in the OS file manager (`R`). Stub — real hand-off wired in T-5.
+    /// Reveal the selected entry in the OS file manager (`R`).
     fn reveal_in_file_manager(&mut self) -> Effects {
-        Effects::noop()
+        self.hand_off_to_opener(true)
+    }
+
+    /// Hand the selected entry off to the OS opener (open-with-default-app or reveal-in-file-
+    /// manager). Read-only: resolves the tree selection (file OR directory, focus-independent) and
+    /// launches an external process via the injected opener — never reads or writes the file
+    /// (AC-1/2/3/4/12). Non-blocking: a successful hand-off does NOT take over the terminal (no
+    /// `clear`), unlike the editor path (AC-6). A missing selection or absent opener is an inert
+    /// no-op (AC-5).
+    fn hand_off_to_opener(&mut self, reveal: bool) -> Effects {
+        // Resolve the selection FIRST and clone its path, so the immutable tree borrow is released
+        // before we take a mutable borrow of self.opener (borrow-checker).
+        let Some(path) = self.tree.selected().map(|n| n.path.clone()) else {
+            return Effects::noop(); // AC-5: nothing selected
+        };
+        let Some(opener) = self.opener.as_mut() else {
+            return Effects::noop(); // no opener injected (defensive; production always injects one)
+        };
+        let outcome = if reveal {
+            opener.reveal(&path)
+        } else {
+            opener.open(&path)
+        };
+        match outcome {
+            crate::opener::OpenerOutcome::Launched => Effects::redraw(), // AC-6: no `clear`
+            crate::opener::OpenerOutcome::NotLaunched(reason) => {
+                self.action_notice = Some(if reveal {
+                    format!("Could not reveal in file manager: {reason}")
+                } else {
+                    format!("Could not open with default app: {reason}")
+                });
+                Effects::redraw()
+            }
+            crate::opener::OpenerOutcome::NonZeroExit(detail) => {
+                self.action_notice = Some(if reveal {
+                    format!("File manager exited with {detail}")
+                } else {
+                    format!("Opener exited with {detail}")
+                });
+                Effects::redraw()
+            }
+        }
     }
 
     fn open_in_editor(&mut self) -> Effects {

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -1130,6 +1130,8 @@ impl Controller {
             Intent::ToggleBaseline => self.toggle_baseline(),
             Intent::CycleView => self.cycle_view(),
             Intent::OpenInEditor => self.open_in_editor(),
+            Intent::OpenWithApp => self.open_with_app(),
+            Intent::RevealInFileManager => self.reveal_in_file_manager(),
             Intent::CopyRepoPath => self.copy_path(PathKind::Repo),
             Intent::CopyAbsPath => self.copy_path(PathKind::Absolute),
             Intent::ToggleFocus => self.toggle_focus(),
@@ -1436,6 +1438,16 @@ impl Controller {
         self.overrides.insert(node.path.clone(), next);
         self.dispatch_render();
         Effects::redraw()
+    }
+
+    /// Open the selected entry with the OS default app (`O`). Stub — real hand-off wired in T-5.
+    fn open_with_app(&mut self) -> Effects {
+        Effects::noop()
+    }
+
+    /// Reveal the selected entry in the OS file manager (`R`). Stub — real hand-off wired in T-5.
+    fn reveal_in_file_manager(&mut self) -> Effects {
+        Effects::noop()
     }
 
     fn open_in_editor(&mut self) -> Effects {

--- a/src/input.rs
+++ b/src/input.rs
@@ -36,6 +36,8 @@ pub fn map_key(key: KeyEvent) -> Option<Intent> {
         KeyCode::Char('N') => Some(Intent::PrevMatch),
         KeyCode::Char('H') => Some(Intent::TreeScrollLeft),
         KeyCode::Char('L') => Some(Intent::TreeScrollRight),
+        KeyCode::Char('O') => Some(Intent::OpenWithApp),
+        KeyCode::Char('R') => Some(Intent::RevealInFileManager),
         KeyCode::Char('y') => Some(Intent::CopyRepoPath),
         KeyCode::Char('Y') => Some(Intent::CopyAbsPath),
         KeyCode::Char('W') => Some(Intent::SwitchWorktree),
@@ -85,6 +87,8 @@ mod tests {
         (KeyCode::Char('N'), Intent::PrevMatch),
         (KeyCode::Char('H'), Intent::TreeScrollLeft),
         (KeyCode::Char('L'), Intent::TreeScrollRight),
+        (KeyCode::Char('O'), Intent::OpenWithApp),
+        (KeyCode::Char('R'), Intent::RevealInFileManager),
         (KeyCode::Char('y'), Intent::CopyRepoPath),
         (KeyCode::Char('Y'), Intent::CopyAbsPath),
         (KeyCode::Char('W'), Intent::SwitchWorktree),
@@ -329,5 +333,40 @@ mod tests {
         // Lowercase h/l stay Collapse/Expand (no collision).
         assert_eq!(map_key(k(KeyCode::Char('h'))), Some(Intent::Collapse));
         assert_eq!(map_key(k(KeyCode::Char('l'))), Some(Intent::Expand));
+    }
+
+    #[test]
+    fn shift_o_r_map_to_open_and_reveal_and_lowercase_o_is_unbound() {
+        // `O` (Shift+o) opens the selected entry with the OS default app; `R` (Shift+r) reveals
+        // it in the OS file manager. Lowercase `o` stays unbound (`r` is Refresh — untouched).
+        // A Ctrl chord on either capital key must fire nothing.
+        assert_eq!(map_key(k(KeyCode::Char('O'))), Some(Intent::OpenWithApp));
+        assert_eq!(
+            map_key(KeyEvent::new(KeyCode::Char('O'), KeyModifiers::SHIFT)),
+            Some(Intent::OpenWithApp),
+            "O with SHIFT bit set still maps to OpenWithApp"
+        );
+        assert_eq!(
+            map_key(k(KeyCode::Char('R'))),
+            Some(Intent::RevealInFileManager)
+        );
+        assert_eq!(
+            map_key(KeyEvent::new(KeyCode::Char('R'), KeyModifiers::SHIFT)),
+            Some(Intent::RevealInFileManager),
+            "R with SHIFT bit set still maps to RevealInFileManager"
+        );
+        assert_eq!(
+            map_key(KeyEvent::new(KeyCode::Char('O'), KeyModifiers::CONTROL)),
+            None,
+            "Ctrl-O must not fire an intent"
+        );
+        assert_eq!(
+            map_key(KeyEvent::new(KeyCode::Char('R'), KeyModifiers::CONTROL)),
+            None,
+            "Ctrl-R must not fire an intent"
+        );
+        // Lowercase `o` stays unbound; `r` stays Refresh (no collision).
+        assert_eq!(map_key(k(KeyCode::Char('o'))), None);
+        assert_eq!(map_key(k(KeyCode::Char('r'))), Some(Intent::Refresh));
     }
 }

--- a/src/intent.rs
+++ b/src/intent.rs
@@ -33,6 +33,13 @@ pub enum Intent {
     CycleView,
     /// Hand the selected file off to an external editor (AC-19).
     OpenInEditor,
+    /// Open the selected entry with the OS default application (`O`). Read-only external
+    /// hand-off — launches another process, never modifies the file (AC-1, AC-N1). Non-blocking
+    /// (does not suspend the TUI).
+    OpenWithApp,
+    /// Reveal the selected entry in the OS file manager (`R`). Read-only external hand-off
+    /// (AC-2, AC-N1). Non-blocking.
+    RevealInFileManager,
     /// Copy the selected node's **repo-relative** path to the clipboard (e.g. `src/app.rs`).
     /// Read-only — it copies a path string, never reads or writes the file's contents (AC-N3).
     CopyRepoPath,
@@ -108,7 +115,7 @@ pub enum Intent {
 impl Intent {
     /// Every intent variant — lets the dispatcher and tests enumerate the closed set so
     /// keyboard-completeness (AC-18) and the no-edit invariant (AC-N3) stay checkable.
-    pub const ALL: [Intent; 30] = [
+    pub const ALL: [Intent; 32] = [
         Intent::NavUp,
         Intent::NavDown,
         Intent::Expand,
@@ -120,6 +127,8 @@ impl Intent {
         Intent::ToggleBaseline,
         Intent::CycleView,
         Intent::OpenInEditor,
+        Intent::OpenWithApp,
+        Intent::RevealInFileManager,
         Intent::CopyRepoPath,
         Intent::CopyAbsPath,
         Intent::ToggleFocus,
@@ -166,6 +175,8 @@ mod tests {
                 | Intent::ToggleBaseline
                 | Intent::CycleView
                 | Intent::OpenInEditor
+                | Intent::OpenWithApp
+                | Intent::RevealInFileManager
                 | Intent::CopyRepoPath
                 | Intent::CopyAbsPath
                 | Intent::ToggleFocus
@@ -252,11 +263,23 @@ mod tests {
     }
 
     #[test]
-    fn all_length_is_30() {
+    fn all_length_is_32() {
         assert_eq!(
             Intent::ALL.len(),
-            30,
-            "Intent::ALL must have exactly 30 variants after adding TreeScrollLeft/Right"
+            32,
+            "Intent::ALL must have exactly 32 variants after adding OpenWithApp/RevealInFileManager"
+        );
+    }
+
+    #[test]
+    fn reveal_open_intents_are_in_all() {
+        assert!(
+            Intent::ALL.contains(&Intent::OpenWithApp),
+            "Intent::ALL must contain OpenWithApp"
+        );
+        assert!(
+            Intent::ALL.contains(&Intent::RevealInFileManager),
+            "Intent::ALL must contain RevealInFileManager"
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub mod infile;
 pub mod input;
 pub mod intent;
 pub mod launch;
+pub mod opener;
 pub mod picker;
 pub mod presenter;
 pub mod proc;

--- a/src/opener.rs
+++ b/src/opener.rs
@@ -1,16 +1,18 @@
 //! Opener — the read-only OS-opener argv builder (AC-9, AC-10).
 //!
-//! The pure core of the Opener component: given an [`OsKind`], an [`OpenAction`], and a
-//! path, it produces the exact argv to hand a file/dir off to the OS default app or file
-//! manager. It is pure — no process spawning, no I/O, no trait — and never mutates the file
-//! (AC-N1); a later task wires the spawn. The target OS is an explicit parameter (not
-//! `cfg!(target_os)`) so all three platforms are unit-testable on any host, and the path is
+//! The core of the Opener component: given an [`OsKind`], an [`OpenAction`], and a path,
+//! [`opener_argv`] produces the exact argv to hand a file/dir off to the OS default app or file
+//! manager, and the [`Opener`] seam ([`CommandOpener`]) spawns it through the injected editor
+//! [`Spawner`]. It never mutates the file (AC-N1). The target OS is an explicit parameter (not
+//! `cfg!(target_os)`) so all three platforms' argv are unit-testable on any host, and the path is
 //! always carried as a single, un-shell-split argv element to keep spaces and metacharacters
-//! literal (AC-9).
+//! literal (AC-9). The one non-pure input is reading `%SystemRoot%` on Windows to resolve
+//! Explorer's absolute path (a security fix, not a hijackable bare name — see
+//! [`windows_explorer_program`]).
 
 use crate::editor::{SpawnError, Spawner};
 use std::ffi::OsString;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 /// The target operating system whose opener convention to build for. An explicit parameter
 /// (rather than compile-time `cfg!`) so every platform's argv is testable on any host.
@@ -33,7 +35,10 @@ pub enum OpenAction {
 /// The path is always placed as ONE argv element, never shell-split, so spaces and shell
 /// metacharacters stay literal (AC-9). `OsString`s are built directly so non-UTF-8 paths are
 /// preserved. On Linux, "reveal" opens the containing folder (there is no universal
-/// select-in-file-manager); a path with no parent (e.g. `/`) falls back to itself.
+/// select-in-file-manager); a path with no parent (e.g. `/`) falls back to itself. On Windows
+/// the Explorer program is resolved to its **absolute** `%SystemRoot%\explorer.exe` (not a
+/// hijackable bare name — see [`windows_explorer_program`]); this is the one non-pure input
+/// (reading `%SystemRoot%`), unset on unix so the mapping stays host-testable.
 pub fn opener_argv(os: OsKind, action: OpenAction, path: &Path) -> Vec<OsString> {
     match (os, action) {
         (OsKind::Mac, OpenAction::Open) => {
@@ -52,13 +57,39 @@ pub fn opener_argv(os: OsKind, action: OpenAction, path: &Path) -> Vec<OsString>
             vec![OsString::from("xdg-open"), target.as_os_str().to_owned()]
         }
         (OsKind::Windows, OpenAction::Open) => {
-            vec![OsString::from("explorer"), path.as_os_str().to_owned()]
+            vec![
+                windows_explorer_program(system_root().as_deref()),
+                path.as_os_str().to_owned(),
+            ]
         }
         (OsKind::Windows, OpenAction::Reveal) => {
             let mut s = OsString::from("/select,");
             s.push(path);
-            vec![OsString::from("explorer"), s]
+            vec![windows_explorer_program(system_root().as_deref()), s]
         }
+    }
+}
+
+/// The current process's `%SystemRoot%`, if set and non-empty. Only meaningful on Windows;
+/// unset on unix (so the Windows-arm tests resolve the bare-name fallback on a unix CI host).
+fn system_root() -> Option<PathBuf> {
+    std::env::var_os("SystemRoot")
+        .filter(|r| !r.is_empty())
+        .map(PathBuf::from)
+}
+
+/// Resolve the Windows Explorer program to an **absolute** `%SystemRoot%\explorer.exe`.
+///
+/// A bare `explorer` program name is subject to Windows' executable search order, which can
+/// include the process working directory — here an *untrusted* browsed repo. An `explorer.exe`
+/// planted in the repo could then be spawned when the user presses `O`/`R`, executing repo code
+/// and breaking the read-only / no-repo-code boundary (constitution §1). Resolving via
+/// `%SystemRoot%` closes that hole, mirroring the editor's Notepad default. Falls back to the
+/// bare name only when `SystemRoot` is unset/empty (effectively never on real Windows).
+fn windows_explorer_program(system_root: Option<&Path>) -> OsString {
+    match system_root {
+        Some(root) if !root.as_os_str().is_empty() => root.join("explorer.exe").into_os_string(),
+        _ => OsString::from("explorer"),
     }
 }
 
@@ -302,25 +333,50 @@ mod tests {
 
     #[test]
     fn windows_open_argv() {
+        // argv[0] is the resolved Explorer program — bare `explorer` when `%SystemRoot%` is
+        // unset (a unix CI host), the absolute `explorer.exe` on real Windows. Compute the
+        // expected program the same way so the assertion is correct on either host.
+        let prog = windows_explorer_program(system_root().as_deref());
         let path = Path::new("/abs/dir/file.rs");
         assert_eq!(
             opener_argv(OsKind::Windows, OpenAction::Open, path),
-            vec![
-                OsString::from("explorer"),
-                OsString::from("/abs/dir/file.rs")
-            ]
+            vec![prog, OsString::from("/abs/dir/file.rs")]
         );
     }
 
     #[test]
     fn windows_reveal_argv_is_select_prefix() {
+        let prog = windows_explorer_program(system_root().as_deref());
         let path = Path::new("/abs/dir/file.rs");
         assert_eq!(
             opener_argv(OsKind::Windows, OpenAction::Reveal, path),
-            vec![
-                OsString::from("explorer"),
-                OsString::from("/select,/abs/dir/file.rs"),
-            ]
+            vec![prog, OsString::from("/select,/abs/dir/file.rs")]
+        );
+    }
+
+    #[test]
+    fn windows_explorer_program_absolute_from_system_root() {
+        // With `%SystemRoot%` set, Explorer resolves under that root (its `explorer.exe`) — not
+        // a hijackable bare name that Windows' search order could resolve from an untrusted repo
+        // dir. Built via `join`, so the assertion is host-correct (the real `\` separation only
+        // happens on Windows, where this actually runs); the point is that the root is applied,
+        // not the bare fallback.
+        let root = Path::new("C:\\Windows");
+        let prog = windows_explorer_program(Some(root));
+        assert_eq!(prog, root.join("explorer.exe").into_os_string());
+        assert_ne!(
+            prog,
+            OsString::from("explorer"),
+            "must not be the bare name"
+        );
+    }
+
+    #[test]
+    fn windows_explorer_program_falls_back_to_bare_when_unset_or_empty() {
+        assert_eq!(windows_explorer_program(None), OsString::from("explorer"));
+        assert_eq!(
+            windows_explorer_program(Some(Path::new(""))),
+            OsString::from("explorer")
         );
     }
 

--- a/src/opener.rs
+++ b/src/opener.rs
@@ -1,0 +1,171 @@
+//! Opener — the read-only OS-opener argv builder (AC-9, AC-10).
+//!
+//! The pure core of the Opener component: given an [`OsKind`], an [`OpenAction`], and a
+//! path, it produces the exact argv to hand a file/dir off to the OS default app or file
+//! manager. It is pure — no process spawning, no I/O, no trait — and never mutates the file
+//! (AC-N1); a later task wires the spawn. The target OS is an explicit parameter (not
+//! `cfg!(target_os)`) so all three platforms are unit-testable on any host, and the path is
+//! always carried as a single, un-shell-split argv element to keep spaces and metacharacters
+//! literal (AC-9).
+
+use std::ffi::OsString;
+use std::path::Path;
+
+/// The target operating system whose opener convention to build for. An explicit parameter
+/// (rather than compile-time `cfg!`) so every platform's argv is testable on any host.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OsKind {
+    Mac,
+    Linux,
+    Windows,
+}
+
+/// What to do with the path: open it in the default app, or reveal it in a file manager.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OpenAction {
+    Open,
+    Reveal,
+}
+
+/// Build the per-OS argv (argv[0] = program, rest = args) to open or reveal `path`.
+///
+/// The path is always placed as ONE argv element, never shell-split, so spaces and shell
+/// metacharacters stay literal (AC-9). `OsString`s are built directly so non-UTF-8 paths are
+/// preserved. On Linux, "reveal" opens the containing folder (there is no universal
+/// select-in-file-manager); a path with no parent (e.g. `/`) falls back to itself.
+pub fn opener_argv(os: OsKind, action: OpenAction, path: &Path) -> Vec<OsString> {
+    match (os, action) {
+        (OsKind::Mac, OpenAction::Open) => {
+            vec![OsString::from("open"), path.as_os_str().to_owned()]
+        }
+        (OsKind::Mac, OpenAction::Reveal) => vec![
+            OsString::from("open"),
+            OsString::from("-R"),
+            path.as_os_str().to_owned(),
+        ],
+        (OsKind::Linux, OpenAction::Open) => {
+            vec![OsString::from("xdg-open"), path.as_os_str().to_owned()]
+        }
+        (OsKind::Linux, OpenAction::Reveal) => {
+            let target = path.parent().unwrap_or(path);
+            vec![OsString::from("xdg-open"), target.as_os_str().to_owned()]
+        }
+        (OsKind::Windows, OpenAction::Open) => {
+            vec![OsString::from("explorer"), path.as_os_str().to_owned()]
+        }
+        (OsKind::Windows, OpenAction::Reveal) => {
+            let mut s = OsString::from("/select,");
+            s.push(path);
+            vec![OsString::from("explorer"), s]
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mac_open_argv() {
+        let path = Path::new("/abs/dir/file.rs");
+        assert_eq!(
+            opener_argv(OsKind::Mac, OpenAction::Open, path),
+            vec![OsString::from("open"), OsString::from("/abs/dir/file.rs")]
+        );
+    }
+
+    #[test]
+    fn mac_reveal_argv() {
+        let path = Path::new("/abs/dir/file.rs");
+        assert_eq!(
+            opener_argv(OsKind::Mac, OpenAction::Reveal, path),
+            vec![
+                OsString::from("open"),
+                OsString::from("-R"),
+                OsString::from("/abs/dir/file.rs"),
+            ]
+        );
+    }
+
+    #[test]
+    fn linux_open_argv() {
+        let path = Path::new("/abs/dir/file.rs");
+        assert_eq!(
+            opener_argv(OsKind::Linux, OpenAction::Open, path),
+            vec![
+                OsString::from("xdg-open"),
+                OsString::from("/abs/dir/file.rs")
+            ]
+        );
+    }
+
+    #[test]
+    fn linux_reveal_argv_is_parent() {
+        let path = Path::new("/abs/dir/file.rs");
+        assert_eq!(
+            opener_argv(OsKind::Linux, OpenAction::Reveal, path),
+            vec![OsString::from("xdg-open"), OsString::from("/abs/dir")]
+        );
+    }
+
+    #[test]
+    fn linux_reveal_parent_fallback_is_self() {
+        let path = Path::new("/");
+        assert_eq!(
+            opener_argv(OsKind::Linux, OpenAction::Reveal, path),
+            vec![OsString::from("xdg-open"), OsString::from("/")]
+        );
+    }
+
+    #[test]
+    fn windows_open_argv() {
+        let path = Path::new("/abs/dir/file.rs");
+        assert_eq!(
+            opener_argv(OsKind::Windows, OpenAction::Open, path),
+            vec![
+                OsString::from("explorer"),
+                OsString::from("/abs/dir/file.rs")
+            ]
+        );
+    }
+
+    #[test]
+    fn windows_reveal_argv_is_select_prefix() {
+        let path = Path::new("/abs/dir/file.rs");
+        assert_eq!(
+            opener_argv(OsKind::Windows, OpenAction::Reveal, path),
+            vec![
+                OsString::from("explorer"),
+                OsString::from("/select,/abs/dir/file.rs"),
+            ]
+        );
+    }
+
+    #[test]
+    fn path_is_single_unmodified_element_open() {
+        // Spaces, a leading-dash-looking component, and a shell metacharacter must stay
+        // literal and un-split (AC-9). The path is absolute.
+        let path = Path::new("/tmp/a dir/-weird;name.txt");
+        let expected = path.as_os_str().to_owned();
+
+        for os in [OsKind::Mac, OsKind::Linux, OsKind::Windows] {
+            let argv = opener_argv(os, OpenAction::Open, path);
+            assert_eq!(argv.len(), 2, "{os:?} Open argv should be [prog, path]");
+            assert_eq!(
+                argv[1], expected,
+                "{os:?} path must be one unmodified element"
+            );
+        }
+    }
+
+    #[test]
+    fn windows_reveal_path_stays_single_element() {
+        let path = Path::new("/tmp/a dir/-weird;name.txt");
+        let argv = opener_argv(OsKind::Windows, OpenAction::Reveal, path);
+        assert_eq!(argv.len(), 2);
+        assert_eq!(
+            argv[1],
+            OsString::from("/select,/tmp/a dir/-weird;name.txt")
+        );
+    }
+}

--- a/src/opener.rs
+++ b/src/opener.rs
@@ -8,6 +8,7 @@
 //! always carried as a single, un-shell-split argv element to keep spaces and metacharacters
 //! literal (AC-9).
 
+use crate::editor::{SpawnError, Spawner};
 use std::ffi::OsString;
 use std::path::Path;
 
@@ -61,9 +62,191 @@ pub fn opener_argv(os: OsKind, action: OpenAction, path: &Path) -> Vec<OsString>
     }
 }
 
+/// The result of an OS hand-off attempt through the [`Opener`] seam. Mirrors the editor's
+/// [`SpawnError`] split so the controller can word its notice accurately:
+/// [`OpenerOutcome::NotLaunched`] means nothing ran (e.g. `xdg-open` missing) — "could not
+/// open"; [`OpenerOutcome::NonZeroExit`] means the opener ran and returned a failing status.
+#[derive(Debug, PartialEq, Eq)]
+pub enum OpenerOutcome {
+    /// The opener was spawned successfully (non-blocking success — the TUI keeps running).
+    Launched,
+    /// The opener process could not be started at all; the carried string is a human-readable
+    /// reason (from the underlying `io::Error`).
+    NotLaunched(String),
+    /// The opener launched but exited non-zero; the carried string is a human-readable detail.
+    NonZeroExit(String),
+}
+
+/// The read-only OS hand-off seam: open a path with its default app, or reveal it in the
+/// file manager. Unlike the editor hand-off, these are **non-blocking** — they do not suspend
+/// or take over the TUI's terminal (AC-1, AC-2, AC-7, AC-8). Never mutates the file (AC-N1).
+pub trait Opener {
+    /// Open `path` with the OS default application (non-blocking). (AC-1)
+    fn open(&mut self, path: &Path) -> OpenerOutcome;
+    /// Reveal `path` in the OS file manager (non-blocking). (AC-2)
+    fn reveal(&mut self, path: &Path) -> OpenerOutcome;
+}
+
+/// The concrete [`Opener`]: builds the per-OS argv via [`opener_argv`] and hands it to the
+/// injected [`Spawner`] (the same low-level seam the editor launcher reuses), so tests stay
+/// hermetic — no real process is ever spawned here.
+pub struct CommandOpener {
+    os: OsKind,
+    spawner: Box<dyn Spawner>,
+}
+
+impl CommandOpener {
+    /// Create an opener for the given target OS, spawning through `spawner`.
+    pub fn new(os: OsKind, spawner: Box<dyn Spawner>) -> Self {
+        Self { os, spawner }
+    }
+
+    /// Build the argv for `action`/`path`, spawn it, and map the spawn result onto an
+    /// [`OpenerOutcome`]. The only external effect goes through the injected [`Spawner`].
+    fn run(&mut self, action: OpenAction, path: &Path) -> OpenerOutcome {
+        let argv = opener_argv(self.os, action, path);
+        match self.spawner.spawn(&argv) {
+            Ok(()) => OpenerOutcome::Launched,
+            Err(SpawnError::NotLaunched(e)) => OpenerOutcome::NotLaunched(e.to_string()),
+            Err(SpawnError::NonZeroExit(d)) => OpenerOutcome::NonZeroExit(d),
+        }
+    }
+}
+
+impl Opener for CommandOpener {
+    fn open(&mut self, path: &Path) -> OpenerOutcome {
+        self.run(OpenAction::Open, path)
+    }
+
+    fn reveal(&mut self, path: &Path) -> OpenerOutcome {
+        self.run(OpenAction::Reveal, path)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::editor::{SpawnError, Spawner};
+    use std::cell::RefCell;
+    use std::io;
+    use std::rc::Rc;
+
+    /// Which result the recorder returns for each `spawn` call.
+    #[derive(Clone, Copy)]
+    enum SpawnResult {
+        Ok,
+        NotLaunched,
+        NonZeroExit,
+    }
+
+    /// A test double for [`Spawner`] that records every argv it is handed (into a shared
+    /// `Vec` the test still holds after boxing) and returns a preconfigured result — the only
+    /// spawn path, so no real process is ever launched (AC-13 hermeticity).
+    struct RecordingSpawner {
+        calls: Rc<RefCell<Vec<Vec<OsString>>>>,
+        result: SpawnResult,
+    }
+
+    impl RecordingSpawner {
+        fn new(result: SpawnResult) -> (Self, Rc<RefCell<Vec<Vec<OsString>>>>) {
+            let calls = Rc::new(RefCell::new(Vec::new()));
+            (
+                Self {
+                    calls: Rc::clone(&calls),
+                    result,
+                },
+                calls,
+            )
+        }
+    }
+
+    impl Spawner for RecordingSpawner {
+        fn spawn(&mut self, argv: &[OsString]) -> Result<(), SpawnError> {
+            self.calls.borrow_mut().push(argv.to_vec());
+            match self.result {
+                SpawnResult::Ok => Ok(()),
+                SpawnResult::NotLaunched => {
+                    Err(SpawnError::NotLaunched(io::Error::other("missing")))
+                }
+                SpawnResult::NonZeroExit => Err(SpawnError::NonZeroExit("code 1".into())),
+            }
+        }
+    }
+
+    #[test]
+    fn command_opener_open_spawns_open_argv() {
+        let (recorder, calls) = RecordingSpawner::new(SpawnResult::Ok);
+        let mut opener = CommandOpener::new(OsKind::Linux, Box::new(recorder));
+        let outcome = opener.open(Path::new("/a/b.txt"));
+        assert_eq!(outcome, OpenerOutcome::Launched);
+        let calls = calls.borrow();
+        assert_eq!(calls.len(), 1, "exactly one spawn call");
+        assert_eq!(
+            calls[0],
+            opener_argv(OsKind::Linux, OpenAction::Open, Path::new("/a/b.txt"))
+        );
+        assert_eq!(
+            calls[0],
+            vec![OsString::from("xdg-open"), OsString::from("/a/b.txt")]
+        );
+    }
+
+    #[test]
+    fn command_opener_reveal_spawns_reveal_argv() {
+        let (recorder, calls) = RecordingSpawner::new(SpawnResult::Ok);
+        let mut opener = CommandOpener::new(OsKind::Linux, Box::new(recorder));
+        let outcome = opener.reveal(Path::new("/a/b.txt"));
+        assert_eq!(outcome, OpenerOutcome::Launched);
+        let calls = calls.borrow();
+        assert_eq!(calls.len(), 1, "exactly one spawn call");
+        assert_eq!(
+            calls[0],
+            opener_argv(OsKind::Linux, OpenAction::Reveal, Path::new("/a/b.txt"))
+        );
+        // Linux reveal opens the parent directory.
+        assert_eq!(
+            calls[0],
+            vec![OsString::from("xdg-open"), OsString::from("/a")]
+        );
+    }
+
+    #[test]
+    fn command_opener_maps_not_launched() {
+        let (recorder, _calls) = RecordingSpawner::new(SpawnResult::NotLaunched);
+        let mut opener = CommandOpener::new(OsKind::Linux, Box::new(recorder));
+        match opener.open(Path::new("/a/b.txt")) {
+            OpenerOutcome::NotLaunched(msg) => assert!(
+                msg.contains("missing"),
+                "message should carry the io::Error detail, got {msg:?}"
+            ),
+            other => panic!("expected NotLaunched, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn command_opener_maps_non_zero_exit() {
+        let (recorder, _calls) = RecordingSpawner::new(SpawnResult::NonZeroExit);
+        let mut opener = CommandOpener::new(OsKind::Linux, Box::new(recorder));
+        assert_eq!(
+            opener.open(Path::new("/a/b.txt")),
+            OpenerOutcome::NonZeroExit("code 1".into())
+        );
+    }
+
+    #[test]
+    fn command_opener_uses_only_injected_spawner() {
+        // The injected recorder is the sole spawn path: it captures the call and no real
+        // process runs (AC-13 hermeticity).
+        let (recorder, calls) = RecordingSpawner::new(SpawnResult::Ok);
+        let mut opener = CommandOpener::new(OsKind::Linux, Box::new(recorder));
+        let outcome = opener.open(Path::new("/a/b.txt"));
+        assert_eq!(outcome, OpenerOutcome::Launched);
+        assert_eq!(
+            calls.borrow().len(),
+            1,
+            "the recorder captured the call; nothing else spawned"
+        );
+    }
 
     #[test]
     fn mac_open_argv() {

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -9023,3 +9023,24 @@ fn open_non_zero_exit_sets_a_non_fatal_notice() {
     );
     assert!(!fx.quit, "AC-8: a non-zero exit does not end the session");
 }
+
+#[test]
+fn reveal_non_zero_exit_sets_a_non_fatal_notice() {
+    // AC-8, reveal branch: the controller words a non-zero exit differently for reveal
+    // ("File manager exited with …") vs open ("Opener exited with …"); exercise the reveal
+    // wording too so an open/reveal string swap can't slip through (mirrors the open test +
+    // reveal_launch_failure_sets_a_non_fatal_notice).
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.rs"), "x\n").unwrap();
+    let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
+    let (opener, _log) = FakeOpener::new(OutcomeKind::NonZeroExit);
+    ctrl.set_opener(Box::new(opener));
+
+    let fx = ctrl.handle(Intent::RevealInFileManager);
+    let notice = ctrl.action_notice().unwrap_or("");
+    assert!(
+        notice.contains("File manager exited with"),
+        "AC-8: reveal non-zero exit sets the reveal-specific notice, got: {notice:?}"
+    );
+    assert!(!fx.quit, "AC-8: a non-zero exit does not end the session");
+}

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -15,6 +15,7 @@ use herdr_file_viewer::controller::{
 use herdr_file_viewer::git::{Baseline, Status};
 use herdr_file_viewer::herdr::HerdrCli;
 use herdr_file_viewer::intent::Intent;
+use herdr_file_viewer::opener::{Opener, OpenerOutcome};
 use herdr_file_viewer::presenter::{Focus, PaneGeometry};
 use herdr_file_viewer::render::Renderers;
 use herdr_file_viewer::view_policy::ViewMode;
@@ -8725,4 +8726,47 @@ fn help_path_reads_cached_update_status_and_issues_no_network_probe() {
         about.contains("Up to date") && !about.contains("Update available"),
         "AC-N5: with the cached status None, About shows 'Up to date' — no probe ran: {about:.120}"
     );
+}
+
+/// A test double for the OS [`Opener`] seam: records every path it is asked to open/reveal and
+/// returns a configurable [`OpenerOutcome`] (defaulting to `Launched`), so the controller can be
+/// injected with a fake instead of ever spawning a real `xdg-open`/`open`/`explorer` (AC-13).
+#[derive(Default)]
+struct FakeOpener {
+    opened: Vec<PathBuf>,
+    revealed: Vec<PathBuf>,
+    /// The outcome each call returns; `None` ⇒ `OpenerOutcome::Launched`.
+    outcome: Option<OpenerOutcome>,
+}
+
+impl FakeOpener {
+    fn result(&self) -> OpenerOutcome {
+        match &self.outcome {
+            Some(OpenerOutcome::Launched) | None => OpenerOutcome::Launched,
+            Some(OpenerOutcome::NotLaunched(s)) => OpenerOutcome::NotLaunched(s.clone()),
+            Some(OpenerOutcome::NonZeroExit(s)) => OpenerOutcome::NonZeroExit(s.clone()),
+        }
+    }
+}
+
+impl Opener for FakeOpener {
+    fn open(&mut self, path: &Path) -> OpenerOutcome {
+        self.opened.push(path.to_path_buf());
+        self.result()
+    }
+    fn reveal(&mut self, path: &Path) -> OpenerOutcome {
+        self.revealed.push(path.to_path_buf());
+        self.result()
+    }
+}
+
+#[test]
+fn set_opener_injects_a_reachable_opener() {
+    // T-4 wires `set_opener` as a post-construction seam (mirroring `set_host`). The `O`/`R`
+    // handlers are still stubs in this task, so we can't yet assert an invocation — a fuller
+    // behavior test (that pressing `O`/`R` calls through to the injected opener) lands in the
+    // next task. Here we only prove the seam exists, accepts a fake, and doesn't panic.
+    let dir = TempDir::new();
+    let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
+    ctrl.set_opener(Box::new(FakeOpener::default()));
 }

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -8893,6 +8893,31 @@ fn hand_off_target_is_focus_independent() {
 }
 
 #[test]
+fn reveal_target_is_focus_independent() {
+    // AC-4 applies to BOTH keys: with the content pane focused, `R` still reveals the tree
+    // selection (guards against reveal accidentally depending on tree focus).
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.rs"), "x\n").unwrap();
+    let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
+    let file = dir.path().join("a.rs");
+    let (opener, log) = FakeOpener::new(OutcomeKind::Launched);
+    ctrl.set_opener(Box::new(opener));
+
+    ctrl.handle(Intent::ToggleFocus);
+    assert_eq!(
+        ctrl.focus(),
+        Focus::Content,
+        "focus moved to the content pane"
+    );
+    ctrl.handle(Intent::RevealInFileManager);
+    assert_eq!(
+        log.borrow().revealed,
+        vec![file],
+        "AC-4: the selection is revealed even with the content pane focused"
+    );
+}
+
+#[test]
 fn open_with_no_selection_is_inert() {
     // AC-5: with an empty tree (no selection), both `O` and `R` do nothing — no opener call,
     // no notice, no panic.

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -21,9 +21,11 @@ use herdr_file_viewer::render::Renderers;
 use herdr_file_viewer::view_policy::ViewMode;
 use ratatui::layout::Rect;
 use ratatui::text::Text;
+use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::io;
 use std::path::{Path, PathBuf};
+use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -8728,45 +8730,271 @@ fn help_path_reads_cached_update_status_and_issues_no_network_probe() {
     );
 }
 
-/// A test double for the OS [`Opener`] seam: records every path it is asked to open/reveal and
-/// returns a configurable [`OpenerOutcome`] (defaulting to `Launched`), so the controller can be
-/// injected with a fake instead of ever spawning a real `xdg-open`/`open`/`explorer` (AC-13).
-#[derive(Default)]
-struct FakeOpener {
+/// The paths a [`FakeOpener`] was asked to open/reveal, recorded into a shared handle the test
+/// still holds after the fake is boxed into the controller via `set_opener` — so a test can
+/// assert what the `O`/`R` handlers pushed through the seam.
+#[derive(Clone, Default)]
+struct OpenerLog {
     opened: Vec<PathBuf>,
     revealed: Vec<PathBuf>,
-    /// The outcome each call returns; `None` ⇒ `OpenerOutcome::Launched`.
-    outcome: Option<OpenerOutcome>,
+}
+
+/// Which [`OpenerOutcome`] the fake returns for every open/reveal call.
+#[derive(Clone, Copy)]
+enum OutcomeKind {
+    Launched,
+    NotLaunched,
+    NonZeroExit,
+}
+
+/// A test double for the OS [`Opener`] seam: records every path it is asked to open/reveal into a
+/// shared [`OpenerLog`] and returns a preconfigured [`OpenerOutcome`], so the controller is never
+/// wired to a real `xdg-open`/`open`/`explorer` (AC-13 hermeticity).
+struct FakeOpener {
+    log: Rc<RefCell<OpenerLog>>,
+    outcome_kind: OutcomeKind,
 }
 
 impl FakeOpener {
-    fn result(&self) -> OpenerOutcome {
-        match &self.outcome {
-            Some(OpenerOutcome::Launched) | None => OpenerOutcome::Launched,
-            Some(OpenerOutcome::NotLaunched(s)) => OpenerOutcome::NotLaunched(s.clone()),
-            Some(OpenerOutcome::NonZeroExit(s)) => OpenerOutcome::NonZeroExit(s.clone()),
+    /// Build a fake plus a shared handle onto its log that the test keeps to assert against.
+    fn new(outcome_kind: OutcomeKind) -> (Self, Rc<RefCell<OpenerLog>>) {
+        let log = Rc::new(RefCell::new(OpenerLog::default()));
+        (
+            Self {
+                log: Rc::clone(&log),
+                outcome_kind,
+            },
+            log,
+        )
+    }
+
+    fn outcome(&self) -> OpenerOutcome {
+        match self.outcome_kind {
+            OutcomeKind::Launched => OpenerOutcome::Launched,
+            OutcomeKind::NotLaunched => OpenerOutcome::NotLaunched("opener not on PATH".into()),
+            OutcomeKind::NonZeroExit => OpenerOutcome::NonZeroExit("exit status: 1".into()),
         }
     }
 }
 
 impl Opener for FakeOpener {
     fn open(&mut self, path: &Path) -> OpenerOutcome {
-        self.opened.push(path.to_path_buf());
-        self.result()
+        self.log.borrow_mut().opened.push(path.to_path_buf());
+        self.outcome()
     }
     fn reveal(&mut self, path: &Path) -> OpenerOutcome {
-        self.revealed.push(path.to_path_buf());
-        self.result()
+        self.log.borrow_mut().revealed.push(path.to_path_buf());
+        self.outcome()
     }
 }
 
 #[test]
 fn set_opener_injects_a_reachable_opener() {
-    // T-4 wires `set_opener` as a post-construction seam (mirroring `set_host`). The `O`/`R`
-    // handlers are still stubs in this task, so we can't yet assert an invocation — a fuller
-    // behavior test (that pressing `O`/`R` calls through to the injected opener) lands in the
-    // next task. Here we only prove the seam exists, accepts a fake, and doesn't panic.
+    // `set_opener` is a post-construction seam (mirroring `set_host`). Here we only prove the
+    // seam exists, accepts a fake, and doesn't panic; the behavioral tests below assert the
+    // `O`/`R` handlers actually call through to the injected opener.
     let dir = TempDir::new();
     let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
-    ctrl.set_opener(Box::new(FakeOpener::default()));
+    let (opener, _log) = FakeOpener::new(OutcomeKind::Launched);
+    ctrl.set_opener(Box::new(opener));
+}
+
+#[test]
+fn open_with_app_invokes_opener_open_on_selected_file() {
+    // AC-1: with the cursor on a file, `O` resolves the selection and calls the opener's `open`.
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.rs"), "x\n").unwrap();
+    let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
+    let file = dir.path().join("a.rs");
+    let (opener, log) = FakeOpener::new(OutcomeKind::Launched);
+    ctrl.set_opener(Box::new(opener));
+
+    ctrl.handle(Intent::OpenWithApp);
+    assert_eq!(log.borrow().opened, vec![file], "AC-1: the file was opened");
+    assert!(log.borrow().revealed.is_empty(), "reveal was not called");
+    assert!(
+        ctrl.action_notice().is_none(),
+        "a successful open sets no notice"
+    );
+}
+
+#[test]
+fn reveal_invokes_opener_reveal_on_selected_file() {
+    // AC-2: with the cursor on a file, `R` resolves the selection and calls the opener's `reveal`.
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.rs"), "x\n").unwrap();
+    let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
+    let file = dir.path().join("a.rs");
+    let (opener, log) = FakeOpener::new(OutcomeKind::Launched);
+    ctrl.set_opener(Box::new(opener));
+
+    ctrl.handle(Intent::RevealInFileManager);
+    assert_eq!(
+        log.borrow().revealed,
+        vec![file],
+        "AC-2: the file was revealed"
+    );
+    assert!(log.borrow().opened.is_empty(), "open was not called");
+}
+
+#[test]
+fn open_and_reveal_accept_a_directory_target() {
+    // AC-3: the hand-off targets the selection whether it is a file OR a directory — unlike the
+    // editor path, which is file-only. A single directory is the sole (and thus selected) node.
+    let dir = TempDir::new();
+    std::fs::create_dir(dir.path().join("sub")).unwrap();
+    let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
+    let sub = dir.path().join("sub");
+    assert_eq!(
+        ctrl.tree().selected().unwrap().path,
+        sub,
+        "precondition: the directory is selected"
+    );
+    let (opener, log) = FakeOpener::new(OutcomeKind::Launched);
+    ctrl.set_opener(Box::new(opener));
+
+    ctrl.handle(Intent::OpenWithApp);
+    ctrl.handle(Intent::RevealInFileManager);
+    assert_eq!(
+        log.borrow().opened,
+        vec![sub.clone()],
+        "AC-3: O accepts the directory"
+    );
+    assert_eq!(
+        log.borrow().revealed,
+        vec![sub],
+        "AC-3: R accepts the directory"
+    );
+}
+
+#[test]
+fn hand_off_target_is_focus_independent() {
+    // AC-4: the hand-off resolves the tree selection regardless of which pane is focused — with
+    // focus on the content pane, `O` still opens the selected file.
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.rs"), "x\n").unwrap();
+    let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
+    let file = dir.path().join("a.rs");
+    let (opener, log) = FakeOpener::new(OutcomeKind::Launched);
+    ctrl.set_opener(Box::new(opener));
+
+    ctrl.handle(Intent::ToggleFocus);
+    assert_eq!(
+        ctrl.focus(),
+        Focus::Content,
+        "focus moved to the content pane"
+    );
+    ctrl.handle(Intent::OpenWithApp);
+    assert_eq!(
+        log.borrow().opened,
+        vec![file],
+        "AC-4: the selection is opened even with the content pane focused"
+    );
+}
+
+#[test]
+fn open_with_no_selection_is_inert() {
+    // AC-5: with an empty tree (no selection), both `O` and `R` do nothing — no opener call,
+    // no notice, no panic.
+    let dir = TempDir::new(); // empty directory → no visible nodes → no selection
+    let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
+    assert!(
+        ctrl.tree().selected().is_none(),
+        "precondition: nothing is selected in an empty tree"
+    );
+    let (opener, log) = FakeOpener::new(OutcomeKind::Launched);
+    ctrl.set_opener(Box::new(opener));
+
+    ctrl.handle(Intent::OpenWithApp);
+    ctrl.handle(Intent::RevealInFileManager);
+    assert!(
+        log.borrow().opened.is_empty() && log.borrow().revealed.is_empty(),
+        "AC-5: no opener call when nothing is selected"
+    );
+    assert!(
+        ctrl.action_notice().is_none(),
+        "AC-5: an inert hand-off sets no notice"
+    );
+}
+
+#[test]
+fn successful_hand_off_does_not_take_over_the_terminal() {
+    // AC-6: a successful OS hand-off is non-blocking — it does NOT suspend/clear the terminal,
+    // unlike the editor takeover path (which sets `clear: true`, asserted elsewhere). So the
+    // returned Effects redraw but never set `clear`.
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.rs"), "x\n").unwrap();
+    let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
+    let (opener, _log) = FakeOpener::new(OutcomeKind::Launched);
+    ctrl.set_opener(Box::new(opener));
+
+    let fx = ctrl.handle(Intent::OpenWithApp);
+    assert!(
+        !fx.clear,
+        "AC-6: a successful hand-off does not take over the terminal (no clear)"
+    );
+    assert!(fx.redraw, "the frame still repaints (notice/none refresh)");
+}
+
+#[test]
+fn open_launch_failure_sets_a_non_fatal_notice() {
+    // AC-7: if the opener could not be launched (e.g. missing `xdg-open`), a non-fatal notice is
+    // shown — no panic, session continues.
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.rs"), "x\n").unwrap();
+    let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
+    let (opener, _log) = FakeOpener::new(OutcomeKind::NotLaunched);
+    ctrl.set_opener(Box::new(opener));
+
+    let fx = ctrl.handle(Intent::OpenWithApp);
+    let notice = ctrl
+        .action_notice()
+        .expect("AC-7: a launch failure sets a notice");
+    assert!(
+        notice.contains("Could not open"),
+        "AC-7: launch-failure wording (got {notice:?})"
+    );
+    assert!(!fx.quit, "AC-7: a launch failure does not end the session");
+}
+
+#[test]
+fn reveal_launch_failure_sets_a_non_fatal_notice() {
+    // AC-7 (reveal branch): if the opener could not be launched, RevealInFileManager shows the
+    // reveal-specific non-fatal notice — no panic, session continues. Guards against an
+    // open/reveal wording swap.
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.rs"), "x\n").unwrap();
+    let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
+    let (opener, _log) = FakeOpener::new(OutcomeKind::NotLaunched);
+    ctrl.set_opener(Box::new(opener));
+
+    let fx = ctrl.handle(Intent::RevealInFileManager);
+    let notice = ctrl
+        .action_notice()
+        .expect("AC-7: a reveal launch failure sets a notice");
+    assert!(
+        notice.contains("Could not reveal in file manager"),
+        "AC-7: reveal launch-failure wording (got {notice:?})"
+    );
+    assert!(
+        !fx.quit,
+        "AC-7: a reveal launch failure does not end the session"
+    );
+}
+
+#[test]
+fn open_non_zero_exit_sets_a_non_fatal_notice() {
+    // AC-8: if the opener ran but exited non-zero, a non-fatal notice is shown — no panic.
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.rs"), "x\n").unwrap();
+    let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
+    let (opener, _log) = FakeOpener::new(OutcomeKind::NonZeroExit);
+    ctrl.set_opener(Box::new(opener));
+
+    let fx = ctrl.handle(Intent::OpenWithApp);
+    assert!(
+        ctrl.action_notice().is_some(),
+        "AC-8: a non-zero opener exit sets a notice"
+    );
+    assert!(!fx.quit, "AC-8: a non-zero exit does not end the session");
 }

--- a/tests/docs_consistency.rs
+++ b/tests/docs_consistency.rs
@@ -22,6 +22,31 @@ fn readme_documents_line_select_key() {
 }
 
 #[test]
+fn readme_documents_reveal_open_keys() {
+    assert!(
+        README.contains("`O`"),
+        "README.md must document the `O` open-with-default-app key"
+    );
+    assert!(
+        README.contains("`R`"),
+        "README.md must document the `R` reveal-in-file-manager key"
+    );
+    let lower = README.to_lowercase();
+    assert!(
+        lower.contains("open with default app"),
+        "README.md `## Keys` must describe the `O` key as 'open with default app'"
+    );
+    assert!(
+        lower.contains("reveal"),
+        "README.md must describe the `R` key as 'reveal'"
+    );
+    assert!(
+        lower.contains("file manager"),
+        "README.md must describe the `R` key as revealing in the OS 'file manager'"
+    );
+}
+
+#[test]
 fn changelog_documents_line_reference_release() {
     // The feature shipped in `[1.9.0]`; that section is its permanent CHANGELOG home. Slice from
     // its heading to the next release heading so the check stays anchored to this release's block.

--- a/tests/reveal_open.rs
+++ b/tests/reveal_open.rs
@@ -1,0 +1,361 @@
+//! End-to-end + read-only conformance for the `O` (open-with-app) / `R` (reveal-in-file-manager)
+//! OS opener hand-offs (T-7). These drive the two new keys through the REAL
+//! key → intent → controller → opener chain (`map_key` decode included, not `handle` directly)
+//! against a fake [`Opener`] seam, and prove the feature mutates nothing on disk or in git:
+//!
+//! * `o_and_r_drive_the_opener_end_to_end_via_map_key` — the full key path reaches the seam for
+//!   both a file and a directory target (AC-1/AC-2/AC-3, end to end).
+//! * `reveal_open_mutates_nothing_on_disk_or_in_git` — a full exercise (incl. a launch failure)
+//!   leaves every working file byte-for-byte identical and `git status --porcelain` still empty
+//!   (the mechanical AC-12 read-only evidence).
+//! * `reveal_open_uses_only_the_injected_opener_seam` — the injected fake is the sole hand-off
+//!   path; no real `open`/`xdg-open`/`explorer` is ever spawned (AC-13 hermeticity).
+//!
+//! Every hand-off goes through an injected [`FakeOpener`] wired in BEFORE any key is driven, so
+//! the tests stay deterministic and hermetic — a real OS opener is never invoked.
+
+mod common;
+
+use common::{TempDir, git, init_repo_with_commit};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use herdr_file_viewer::controller::{
+    Components, ContentProvider, Controller, EditorHandoff, EditorOutcome, GitService,
+    RenderResult, RootProviders,
+};
+use herdr_file_viewer::git::{Baseline, Status};
+use herdr_file_viewer::input::map_key;
+use herdr_file_viewer::intent::Intent;
+use herdr_file_viewer::opener::{Opener, OpenerOutcome};
+use herdr_file_viewer::view_policy::ViewMode;
+use ratatui::text::Text;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::rc::Rc;
+use std::sync::Arc;
+
+/// A key event with no modifier — the shape crossterm reports for a bare `O`/`R` keypress.
+fn key(code: KeyCode) -> KeyEvent {
+    KeyEvent::new(code, KeyModifiers::NONE)
+}
+
+// ── stubs (mirrored from tests/lineselect.rs; integration files are separate crates) ─────────
+
+/// A read-only Git Service stub: the on-disk repo is the source of truth for the read-only
+/// conformance snapshots, so the controller's git service can be inert.
+#[derive(Default, Clone)]
+struct StubGit;
+impl GitService for StubGit {
+    fn status(&self) -> BTreeMap<PathBuf, Status> {
+        BTreeMap::new()
+    }
+    fn changed_set(&self, _baseline: Baseline) -> BTreeMap<PathBuf, Status> {
+        BTreeMap::new()
+    }
+    fn diff(&self, _p: &Path, _b: Baseline, _full: bool) -> String {
+        String::new()
+    }
+}
+
+struct NoopEditor;
+impl EditorHandoff for NoopEditor {
+    fn open(&mut self, _file: &Path) -> EditorOutcome {
+        EditorOutcome::NoTakeover
+    }
+}
+
+/// A trivial content provider — the opener hand-offs never touch the content pane, so a fixed
+/// body is enough for the controller to construct.
+#[derive(Clone, Copy)]
+struct StubContent;
+impl ContentProvider for StubContent {
+    fn render(&self, _path: &Path, _mode: ViewMode, _raw_diff: Option<&str>) -> RenderResult {
+        RenderResult {
+            content: Text::raw("stub"),
+            notices: Vec::new(),
+        }
+    }
+}
+
+// ── fake opener (mirrors tests/controller.rs) ────────────────────────────────────────────────
+
+/// The paths a [`FakeOpener`] was asked to open/reveal, recorded into a shared handle the test
+/// still holds after the fake is boxed into the controller via `set_opener`.
+#[derive(Clone, Default)]
+struct OpenerLog {
+    opened: Vec<PathBuf>,
+    revealed: Vec<PathBuf>,
+}
+
+/// Which [`OpenerOutcome`] the fake returns for every open/reveal call.
+#[derive(Clone, Copy)]
+enum OutcomeKind {
+    Launched,
+    NotLaunched,
+}
+
+/// A test double for the OS [`Opener`] seam: records every path it is asked to open/reveal and
+/// returns a preconfigured outcome, so the controller is never wired to a real
+/// `xdg-open`/`open`/`explorer` (AC-13 hermeticity).
+struct FakeOpener {
+    log: Rc<RefCell<OpenerLog>>,
+    outcome_kind: OutcomeKind,
+}
+
+impl FakeOpener {
+    fn new(outcome_kind: OutcomeKind) -> (Self, Rc<RefCell<OpenerLog>>) {
+        let log = Rc::new(RefCell::new(OpenerLog::default()));
+        (
+            Self {
+                log: Rc::clone(&log),
+                outcome_kind,
+            },
+            log,
+        )
+    }
+
+    fn outcome(&self) -> OpenerOutcome {
+        match self.outcome_kind {
+            OutcomeKind::Launched => OpenerOutcome::Launched,
+            OutcomeKind::NotLaunched => OpenerOutcome::NotLaunched("opener not on PATH".into()),
+        }
+    }
+}
+
+impl Opener for FakeOpener {
+    fn open(&mut self, path: &Path) -> OpenerOutcome {
+        self.log.borrow_mut().opened.push(path.to_path_buf());
+        self.outcome()
+    }
+    fn reveal(&mut self, path: &Path) -> OpenerOutcome {
+        self.log.borrow_mut().revealed.push(path.to_path_buf());
+        self.outcome()
+    }
+}
+
+// ── controller builder (a small local mirror of lineselect's) ────────────────────────────────
+
+/// Build a controller over a real git repo `root`, with an inert git/content/editor stack.
+fn controller_over_repo(root: &Path) -> Controller {
+    let components = Components {
+        providers: Box::new(move |_resolved| RootProviders {
+            git: Arc::new(StubGit),
+            content: Box::new(StubContent),
+        }),
+        editor: Box::new(NoopEditor),
+        clipboard: Box::new(common::RecordingClipboard::default()),
+        renderers: None,
+    };
+    Controller::new(
+        common::resolved(root.to_path_buf(), true),
+        Baseline::Head,
+        components,
+    )
+}
+
+// ── tree-selection + fs-snapshot helpers ─────────────────────────────────────────────────────
+
+/// Move the tree cursor to the (first) visible node whose file name is `name`, returning its
+/// absolute path. Panics if no such node is visible.
+fn select_by_name(ctrl: &mut Controller, name: &str) -> PathBuf {
+    // Reset to the top of the visible list, then walk down to the target.
+    for _ in 0..ctrl.tree().visible_nodes().len() {
+        ctrl.handle(Intent::NavUp);
+    }
+    for _ in 0..ctrl.tree().visible_nodes().len() {
+        let sel = ctrl.tree().selected().expect("a node is selected");
+        if sel.path.file_name().is_some_and(|n| n == name) {
+            return sel.path.clone();
+        }
+        ctrl.handle(Intent::NavDown);
+    }
+    panic!("no visible tree node named {name:?}");
+}
+
+/// A sorted {relative path → file bytes} snapshot of every working file under `root`, EXCLUDING
+/// the `.git` directory — the byte-for-byte read-only fingerprint compared before/after.
+fn snapshot_files(root: &Path) -> BTreeMap<PathBuf, Vec<u8>> {
+    fn walk(base: &Path, dir: &Path, out: &mut BTreeMap<PathBuf, Vec<u8>>) {
+        for entry in std::fs::read_dir(dir).expect("read_dir") {
+            let entry = entry.expect("dir entry");
+            if entry.file_name() == ".git" {
+                continue; // exclude git's internal store from the working-file fingerprint
+            }
+            let path = entry.path();
+            if path.is_dir() {
+                walk(base, &path, out);
+            } else {
+                let rel = path.strip_prefix(base).expect("under base").to_path_buf();
+                out.insert(rel, std::fs::read(&path).expect("read file"));
+            }
+        }
+    }
+    let mut out = BTreeMap::new();
+    walk(root, root, &mut out);
+    out
+}
+
+/// Build a clean fixture repo with a file, a second file, and a subdirectory (all committed) so
+/// `git status --porcelain` is empty. Returns the temp dir.
+fn clean_repo_fixture() -> TempDir {
+    let dir = TempDir::new();
+    init_repo_with_commit(dir.path()); // seeds seed.txt + an initial commit
+    std::fs::write(dir.path().join("a.txt"), "alpha\n").unwrap();
+    std::fs::write(dir.path().join("b.rs"), "fn main() {}\n").unwrap();
+    std::fs::create_dir(dir.path().join("sub")).unwrap();
+    std::fs::write(dir.path().join("sub").join("c.txt"), "gamma\n").unwrap();
+    git(dir.path(), &["add", "-A"]);
+    git(
+        dir.path(),
+        &["commit", "-q", "-m", "fixture", "--no-gpg-sign"],
+    );
+    assert!(
+        git(dir.path(), &["status", "--porcelain"]).is_empty(),
+        "precondition: the fixture repo is clean"
+    );
+    dir
+}
+
+// ── tests ────────────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn o_and_r_drive_the_opener_end_to_end_via_map_key() {
+    // AC-1/AC-2/AC-3 end to end: `O`/`R` decode through the REAL dispatcher into their intents,
+    // and handling those intents reaches the injected opener with the selected node's absolute
+    // path — for a file AND for a directory.
+    let dir = clean_repo_fixture();
+    let mut ctrl = controller_over_repo(dir.path());
+    let (opener, log) = FakeOpener::new(OutcomeKind::Launched);
+    ctrl.set_opener(Box::new(opener));
+
+    // ── file target ──
+    let file = select_by_name(&mut ctrl, "a.txt");
+
+    let open_intent = map_key(key(KeyCode::Char('O')));
+    assert_eq!(
+        open_intent,
+        Some(Intent::OpenWithApp),
+        "the real dispatcher decodes `O` to OpenWithApp"
+    );
+    ctrl.handle(open_intent.unwrap());
+    assert_eq!(
+        log.borrow().opened,
+        vec![file.clone()],
+        "AC-1: `O` reached the opener with the selected file's absolute path"
+    );
+
+    let reveal_intent = map_key(key(KeyCode::Char('R')));
+    assert_eq!(
+        reveal_intent,
+        Some(Intent::RevealInFileManager),
+        "the real dispatcher decodes `R` to RevealInFileManager"
+    );
+    ctrl.handle(reveal_intent.unwrap());
+    assert_eq!(
+        log.borrow().revealed,
+        vec![file.clone()],
+        "AC-2: `R` reached the opener with the selected file's absolute path"
+    );
+
+    // ── directory target (AC-3: the hand-off accepts a directory, unlike the editor path) ──
+    let sub = select_by_name(&mut ctrl, "sub");
+    assert!(sub.is_dir(), "precondition: `sub` is a directory");
+
+    ctrl.handle(map_key(key(KeyCode::Char('O'))).unwrap());
+    ctrl.handle(map_key(key(KeyCode::Char('R'))).unwrap());
+    assert_eq!(
+        log.borrow().opened,
+        vec![file.clone(), sub.clone()],
+        "AC-3: `O` accepts the directory target end to end"
+    );
+    assert_eq!(
+        log.borrow().revealed,
+        vec![file, sub],
+        "AC-3: `R` accepts the directory target end to end"
+    );
+}
+
+#[test]
+fn reveal_open_mutates_nothing_on_disk_or_in_git() {
+    // AC-12: the whole feature is read-only. A full exercise of `O`/`R` (file + directory) plus a
+    // launch-failure path must leave every working file byte-for-byte identical and the git
+    // working tree still clean.
+    let dir = clean_repo_fixture();
+
+    // Snapshot BEFORE: working-file bytes + git porcelain (empty).
+    let files_before = snapshot_files(dir.path());
+    let status_before = git(dir.path(), &["status", "--porcelain"]);
+    assert!(status_before.is_empty(), "precondition: clean working tree");
+
+    let mut ctrl = controller_over_repo(dir.path());
+    let (opener, _log) = FakeOpener::new(OutcomeKind::Launched);
+    ctrl.set_opener(Box::new(opener));
+
+    // A full exercise: O and R on a file, O and R on the subdir.
+    select_by_name(&mut ctrl, "a.txt");
+    ctrl.handle(map_key(key(KeyCode::Char('O'))).unwrap());
+    ctrl.handle(map_key(key(KeyCode::Char('R'))).unwrap());
+    select_by_name(&mut ctrl, "sub");
+    ctrl.handle(map_key(key(KeyCode::Char('O'))).unwrap());
+    ctrl.handle(map_key(key(KeyCode::Char('R'))).unwrap());
+
+    // A failure case: an opener that cannot launch surfaces a notice but changes nothing on disk.
+    let (failing, _flog) = FakeOpener::new(OutcomeKind::NotLaunched);
+    ctrl.set_opener(Box::new(failing));
+    select_by_name(&mut ctrl, "a.txt");
+    ctrl.handle(map_key(key(KeyCode::Char('O'))).unwrap());
+    assert!(
+        ctrl.action_notice().is_some(),
+        "the launch failure surfaced a notice (still a read-only effect)"
+    );
+
+    // Snapshot AFTER: same fingerprint.
+    let files_after = snapshot_files(dir.path());
+    let status_after = git(dir.path(), &["status", "--porcelain"]);
+
+    assert_eq!(
+        files_before, files_after,
+        "AC-12: no working file's bytes changed across the full O/R exercise"
+    );
+    assert_eq!(
+        status_before, status_after,
+        "AC-12: git status --porcelain is still empty — no git mutation"
+    );
+    assert!(
+        status_after.is_empty(),
+        "AC-12: the working tree remains clean"
+    );
+}
+
+#[test]
+fn reveal_open_uses_only_the_injected_opener_seam() {
+    // AC-13: the hand-off is hermetic — every `O`/`R` reaches ONLY the injected fake (its log is
+    // the sole record of the hand-off). No real OS opener is ever spawned: the fake is wired in
+    // before any key is driven, so the seam is the only path a hand-off can take.
+    let dir = clean_repo_fixture();
+    let mut ctrl = controller_over_repo(dir.path());
+    let (opener, log) = FakeOpener::new(OutcomeKind::Launched);
+    ctrl.set_opener(Box::new(opener));
+
+    assert!(
+        log.borrow().opened.is_empty() && log.borrow().revealed.is_empty(),
+        "precondition: nothing recorded before any hand-off"
+    );
+
+    select_by_name(&mut ctrl, "a.txt");
+    ctrl.handle(map_key(key(KeyCode::Char('O'))).unwrap());
+    ctrl.handle(map_key(key(KeyCode::Char('R'))).unwrap());
+
+    // The injected fake's log is the ONLY evidence of the hand-off — proof the hand-off went
+    // through the seam and nowhere else (no real process was launched).
+    assert_eq!(
+        log.borrow().opened.len(),
+        1,
+        "AC-13: the open hand-off reached only the injected seam"
+    );
+    assert_eq!(
+        log.borrow().revealed.len(),
+        1,
+        "AC-13: the reveal hand-off reached only the injected seam"
+    );
+}


### PR DESCRIPTION
Closes #68.

## Summary

Adds two keyboard shortcuts to the viewer, each a read-only, **non-blocking** hand-off to the host OS on the selected tree entry (file *or* directory) — the GUI companions to the existing `$EDITOR` hand-off (`e`):

- **`O`** (Shift+`o`) — **open with default app**: launch the selected entry in the OS default application (e.g. an image in the system viewer).
- **`R`** (Shift+`r`) — **reveal in file manager**: surface the selected entry in the OS file manager (Finder / Explorer / a Linux file manager) so it can be dragged out (e.g. into Slack).

Requested by @amitav13 in #68 ("open images or just drag and drop files to share them in Slack"). The content pane can't render images/PDFs/binaries and a terminal can't drag-and-drop; these are the escape hatch.

**Zero new dependencies.** A new `opener` module holds a pure per-OS argv builder (macOS `open`/`open -R`, Linux `xdg-open`, Windows `explorer`/`explorer /select,`) and an `Opener` seam that **reuses the editor's `Spawner`/`SpawnError`** (ADR-0011). Unlike the editor, the opener is non-blocking — it does not suspend the TUI, and its live spawner nulls stdio so a chatty `xdg-open` can't draw on the live screen. Read-only contract intact.

## Acceptance criteria

- **AC-1/2** — `O`/`R` invoke the default-app / reveal opener on the selected entry's path.
- **AC-3** — a **directory** target is accepted (not files-only).
- **AC-4** — target = the tree selection, **focus-independent**.
- **AC-5** — no selection → inert no-op.
- **AC-6** — a successful hand-off does **not** take over the terminal (no `clear`; TUI not suspended).
- **AC-7/8** — opener launch-failure / non-zero-exit → a non-fatal notice, no panic.
- **AC-9** — the path is one un-shell-split, absolute argv element (metacharacters/`-`-leading names inert).
- **AC-10** — per-OS opener commands, pure-mapped and tested for all three OSes on any host.
- **AC-11** — README `## Keys` documents `O`/`R`.
- **AC-12** (reviewer) — no `O`/`R` code path mutates a file or git — strictly read-only.
- **AC-13** (reviewer) — the spawn is routed exclusively through the injected seam (hermetic).

Negative criteria: no user-configurable commands (deferred to Settings/SMA-49) · no remote/headless GUI forwarding · no guaranteed Linux highlight (reveal opens the folder) · not a file manager · no change to existing bindings (lowercase `o` stays unbound).

## Coverage (task → criterion)

| Task | Advances |
| --- | --- |
| T-1 pure per-OS argv builder | AC-9, AC-10 |
| T-2 Opener seam over reused spawner | AC-7, AC-8, AC-13 |
| T-3 O/R intents + key decode | AC-1, AC-2, AC-12 |
| T-4 non-blocking injection (`set_opener` + null-stdio spawner) | AC-6, AC-13 |
| T-5 controller handlers (resolve → invoke → map outcome) | AC-1..AC-8, AC-12 |
| T-6 docs + docs-consistency guard | AC-11 |
| T-7 e2e + read-only conformance | AC-12, AC-13 |

## Verification

Full suite green at ship: `cargo test` **767 passed, 0 failed**; `cargo clippy --all-targets -- -D warnings` clean; `cargo fmt --check` clean. `sdlc-check --require ledger --require verification-report` → **0 findings** (every test-backed row below appears verbatim in the build ledger's captured green-bar evidence).

| Criterion | Type | Proof |
| --- | --- | --- |
| AC-1 | test-backed | open_with_app_invokes_opener_open_on_selected_file, o_and_r_drive_the_opener_end_to_end_via_map_key |
| AC-2 | test-backed | reveal_invokes_opener_reveal_on_selected_file |
| AC-3 | test-backed | open_and_reveal_accept_a_directory_target |
| AC-4 | test-backed | hand_off_target_is_focus_independent |
| AC-5 | test-backed | open_with_no_selection_is_inert |
| AC-6 | test-backed | successful_hand_off_does_not_take_over_the_terminal |
| AC-7 | test-backed | open_launch_failure_sets_a_non_fatal_notice, reveal_launch_failure_sets_a_non_fatal_notice |
| AC-8 | test-backed | open_non_zero_exit_sets_a_non_fatal_notice |
| AC-9 | test-backed | path_is_single_unmodified_element_open, windows_reveal_path_stays_single_element |
| AC-10 | test-backed | mac_open_argv, mac_reveal_argv, linux_open_argv, linux_reveal_argv_is_parent, windows_open_argv, windows_reveal_argv_is_select_prefix |
| AC-11 | test-backed | readme_documents_reveal_open_keys |
| AC-12 | reviewer-checked | No fs/git-write reached on any `O`/`R` path; corroborated by reveal_open_mutates_nothing_on_disk_or_in_git (byte-for-byte fs + `git status` snapshot unchanged). |
| AC-13 | reviewer-checked | Every real spawn goes through the injected seam; corroborated by command_opener_uses_only_injected_spawner, reveal_open_uses_only_the_injected_opener_seam. |

**Release-time caveat (not a code defect):** the live macOS/Windows opener behavior is grounded in OS docs but not probed from the Linux build host — worth a quick real-platform smoke test before a release cut. The argv the code emits per OS *is* test-backed (AC-10) and runs on any host.

## Known compromises

None — the build recorded no deferred `SHORTCUT` ceilings.

## Notes

- Full agent-sdlc chain ran in-session (idea → gate → build); no ingested-plan provenance.
- Read-only viewer contract preserved; user-configurable opener commands are deferred to the Settings & customization feature.
- `main` is protected — this PR needs green CI (incl. the macOS/Windows matrix) before merge.

Spec (local-only, mirrored to Linear): `specs/reveal-open/reveal-open.md`; ADR-0011 `docs/adr/0011-non-blocking-os-opener-reuses-spawn-seam.md`.
