### PR TITLE
fix(windows): harden terminal/console restore on exit (candidate for #73)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Windows: terminal no longer wedges after the viewer is used.** On Windows the console mode is
+  shared state owned by the console, not the process, and crossterm's mouse-capture restore could
+  hand the input console back with a bit still changed — which survived the viewer's exit and left
+  `prefix+q` detach with an unresponsive shell (the file viewer having been opened once was enough).
+  The viewer now snapshots both console modes before it starts and restores them verbatim on every
+  exit path — a clean close, an error, or a panic — via a `Drop` guard, so it leaves the console
+  exactly as it found it. No effect on Linux/macOS beyond making terminal restore unconditional on
+  early-exit paths. ([#73](https://github.com/smarzban/herdr-file-viewer/issues/73))
+
 ## [1.9.0] - 2026-07-06
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,9 +221,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/src/app.rs
+++ b/src/app.rs
@@ -96,6 +96,15 @@ pub fn run() -> io::Result<()> {
         ctx.workspace_id.clone(),
     );
 
+    // Snapshot the host console's pre-viewer state, then restore it verbatim on EVERY exit path
+    // (a normal return, a `?` error, or a panic unwinding through `run`) via this guard's `Drop`.
+    // On Windows the console mode is shared state owned by the console rather than the process, so
+    // any bit the TUI setup leaves changed survives into the parent shell and wedges herdr's
+    // `prefix+q` detach (#73); handing the console back exactly as we found it makes the viewer
+    // transparent. Declared before `try_init` so the snapshot precedes any mutation, and before
+    // `terminal` so it drops last — the restore runs after the terminal backend is torn down.
+    let _restore_guard = TerminalGuard::capture();
+
     let mut terminal = ratatui::try_init()?;
     // Mouse is additive to the keyboard-first design (AC-18): herdr forwards mouse events to a
     // pane that requests capture, while reserving Shift+mouse for the terminal's own
@@ -106,18 +115,118 @@ pub fn run() -> io::Result<()> {
     let _ = execute!(io::stdout(), EnableFocusChange);
     // ratatui's panic hook restores the terminal but doesn't know we enabled mouse capture, so
     // chain a disable in front of it — otherwise a panic would leave the host terminal stuck in
-    // mouse-reporting mode.
+    // mouse-reporting mode. `_restore_guard` above still runs on the panic path (Drop unwinds), so
+    // raw mode / the alternate screen / the Windows console modes are restored too.
     let prev_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
         let _ = execute!(io::stdout(), DisableMouseCapture);
         let _ = execute!(io::stdout(), DisableFocusChange);
         prev_hook(info);
     }));
-    let outcome = event_loop(&mut terminal, &mut controller);
-    let _ = execute!(io::stdout(), DisableMouseCapture);
-    let _ = execute!(io::stdout(), DisableFocusChange);
-    ratatui::try_restore()?;
-    outcome
+    // The terminal is torn down by `_restore_guard`'s Drop, not here — so the restore is identical
+    // for a clean close, a `?` error, and a panic, and no early return can leave the host terminal
+    // wedged.
+    event_loop(&mut terminal, &mut controller)
+}
+
+/// Restores the host terminal to its pre-viewer state on drop — the single restore path for a
+/// normal return, a `?` error, or a panic unwinding through [`run`]. Every step is best-effort: a
+/// failing one never blocks the rest, since a half-restored terminal is worse than a fully-attempted
+/// one.
+///
+/// On Windows it also re-asserts the console modes captured before setup. crossterm's Windows
+/// mouse-capture path hard-overwrites the input console mode and restores it from a process-global
+/// cache captured mid-setup, so the modes it hands back are not guaranteed to equal what herdr had;
+/// a single leaked bit on the shared console outlives this process and wedges herdr's `prefix+q`
+/// detach (#73). Restoring the verbatim snapshot makes the viewer transparent to the console.
+struct TerminalGuard {
+    #[cfg(windows)]
+    input_mode: Option<u32>,
+    #[cfg(windows)]
+    output_mode: Option<u32>,
+}
+
+impl TerminalGuard {
+    /// Snapshot the console state BEFORE any TUI setup mutates it. Must be called ahead of
+    /// `ratatui::try_init`, which enables raw mode and enters the alternate screen.
+    fn capture() -> Self {
+        TerminalGuard {
+            #[cfg(windows)]
+            input_mode: win_console::get_mode(win_console::STD_INPUT_HANDLE),
+            #[cfg(windows)]
+            output_mode: win_console::get_mode(win_console::STD_OUTPUT_HANDLE),
+        }
+    }
+}
+
+impl Drop for TerminalGuard {
+    fn drop(&mut self) {
+        // Reverse of setup: drop the private modes we enabled, leave raw mode, leave the alternate
+        // screen, flush. Mirrors `ratatui::try_restore` plus our mouse/focus disables, but wholly
+        // best-effort so no earlier failure aborts the sequence.
+        let _ = execute!(io::stdout(), DisableMouseCapture);
+        let _ = execute!(io::stdout(), DisableFocusChange);
+        let _ = disable_raw_mode();
+        let _ = execute!(io::stdout(), LeaveAlternateScreen);
+        let _ = io::stdout().flush();
+        // Re-assert the exact pre-viewer console modes so a crossterm leftover bit can't survive
+        // into the parent shell / herdr's detach (#73). No-op on a redirected (non-console) handle.
+        #[cfg(windows)]
+        {
+            if let Some(mode) = self.input_mode {
+                win_console::set_mode(win_console::STD_INPUT_HANDLE, mode);
+            }
+            if let Some(mode) = self.output_mode {
+                win_console::set_mode(win_console::STD_OUTPUT_HANDLE, mode);
+            }
+        }
+    }
+}
+
+/// Minimal, dependency-free FFI to the Win32 console-mode API (kernel32): read and write the
+/// process's standard input/output console modes. Gated to Windows; nothing else calls it. Three
+/// small, stable symbols are hand-declared rather than pulling in `windows-sys`, to honour the
+/// crate's minimal-deps house style.
+#[cfg(windows)]
+mod win_console {
+    use std::ffi::c_void;
+
+    /// `STD_INPUT_HANDLE` — the `(DWORD)-10` sentinel `GetStdHandle` maps to CONIN$.
+    pub const STD_INPUT_HANDLE: u32 = -10i32 as u32;
+    /// `STD_OUTPUT_HANDLE` — the `(DWORD)-11` sentinel `GetStdHandle` maps to CONOUT$.
+    pub const STD_OUTPUT_HANDLE: u32 = -11i32 as u32;
+
+    unsafe extern "system" {
+        fn GetStdHandle(nStdHandle: u32) -> *mut c_void;
+        fn GetConsoleMode(hConsoleHandle: *mut c_void, lpMode: *mut u32) -> i32;
+        fn SetConsoleMode(hConsoleHandle: *mut c_void, dwMode: u32) -> i32;
+    }
+
+    /// The current console mode for a std handle, or `None` when the handle is not a console (e.g.
+    /// redirected to a pipe/file) — then there is nothing to restore.
+    pub fn get_mode(std_handle: u32) -> Option<u32> {
+        // SAFETY: GetStdHandle returns a process-owned pseudo-handle we never close; GetConsoleMode
+        // only writes through the provided `&mut u32`. A non-console handle yields 0 → None.
+        unsafe {
+            let handle = GetStdHandle(std_handle);
+            let mut mode: u32 = 0;
+            if GetConsoleMode(handle, &mut mode) != 0 {
+                Some(mode)
+            } else {
+                None
+            }
+        }
+    }
+
+    /// Best-effort restore of a std handle's console mode; a failure is ignored because this is
+    /// already the recovery path.
+    pub fn set_mode(std_handle: u32, mode: u32) {
+        // SAFETY: as `get_mode`; SetConsoleMode only reads `mode` and touches no Rust memory.
+        unsafe {
+            let handle = GetStdHandle(std_handle);
+            let _ = SetConsoleMode(handle, mode);
+        }
+    }
 }
 
 /// Draw (only when something changed), read one input (or time out), drain renders; repeat


### PR DESCRIPTION
## What this addresses

Issue #73 — on Windows, after the file viewer has been invoked during a herdr session, `prefix+q`
detach can leave the shell unresponsive (raw-mode-stuck). Reported on Windows 11 / Windows Terminal /
PowerShell 5.1 / herdr `0.7.1-preview`.

## ⚠️ Reproduction status — read before merging

**I could not reproduce #73 on a matched-environment Windows box, and this fix is therefore NOT yet
validated against the actual bug. It needs @sanirudh17 (the reporter) to confirm.**

On a Windows 11 box with the **same** herdr `0.7.1-preview.2026-07-06` build and Windows PowerShell
5.1, using the **shipped v1.9.0** binary, detach stayed responsive across every launch path:

| Launch path | Detach result (shipped v1.9.0) |
| --- | --- |
| `plugin action invoke` (separate split pane) | ✅ shell responsive |
| viewer run directly in the shell's own console | ✅ shell responsive |
| `prefix+f` keybinding → temp pane via `cmd.exe /d /c` (reporter's method) | ✅ shell responsive |

So on that box the shipped binary already restores the console correctly, which is consistent with
crossterm's Windows `disable_raw_mode` unconditionally OR-ing the cooked input bits back on a clean
exit. The real trigger appears to be **environment-specific to the reporter** (exact Windows
Terminal / ConPTY version, or an intermittent condition) **or herdr-side** (its detach console
restoration).

## What the change does (defensive hardening)

Regardless of where the root cause ultimately sits, this makes the viewer's terminal teardown
strictly more robust and *transparent to the console*:

- A `Drop`-based `TerminalGuard` makes raw-mode / alternate-screen / mouse / focus restoration
  **unconditional on every exit path** — a clean close, a `?` error, or a panic unwinding through
  `run` — closing early-return leak paths on all platforms.
- On Windows it **snapshots both console modes (`CONIN$`/`CONOUT$`) before any TUI setup and restores
  them verbatim** on exit. crossterm's Windows mouse-capture path hard-overwrites the input console
  mode and restores it from a process-global cache captured *mid-setup*, so the modes it hands back
  are not guaranteed to equal what herdr had before the viewer ran. Restoring the verbatim snapshot
  means a leaked bit on the shared console cannot survive into the parent shell / herdr's detach.
- The Windows console access is **three hand-declared kernel32 FFI symbols** (`GetStdHandle`,
  `GetConsoleMode`, `SetConsoleMode`) — no new dependency, honouring the crate's minimal-deps house
  style. No effect on Linux/macOS beyond making restore unconditional.

Read-only, no behavior change to the viewer itself.

## Validation performed

- Builds + links on **real Windows** (Rust 1.96.1 GNU + MinGW): the `cfg(windows)` FFI compiles
  clean.
- Windows test suite: **543/544 pass** (the one failure is a pre-existing unix-only test stub that
  pipes through the `tr` command, absent on Windows — unrelated to this change).
- Linux: `cargo fmt --check`, `clippy -D warnings`, full suite green, plus
  `cargo check --target x86_64-pc-windows-gnu`.

## What still needs to happen before this closes #73

@sanirudh17 — could you build this branch (`fix/windows-detach-terminal-restore`) on your machine, or
try a preview build, and confirm whether `prefix+f` → `q` → `prefix+q` detach now leaves a usable
shell? If it still wedges, the root cause is likely herdr-side and we'll route it there. It would
also help to know: is the freeze **every time** or intermittent, what exact **Windows Terminal /
ConPTY version** are you on, and does a specific viewer action (editor hand-off, search) precede it?

Deliberately **not** using `Closes #73` — this is a candidate fix pending that confirmation.
