### PR TITLE
Mouse text selection: content copy in line-select mode, plus ambient drag-select

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -43,7 +43,7 @@ is unit-testable with stubs.
 | `text_layout` | A pure text-wrapping helper: how many display rows a line occupies at a given width — shared by the content pane, the finder, and the help overlay. No I/O. |
 | `prompt` | A reusable single-line text-input buffer (push / backspace / clear) backing the finder query — and future keyboard prompts. |
 | `infile` | In-file-navigation modal state: which bottom prompt is open (go-to-line or in-file search), its `prompt` input buffer, the live `SearchState` (query, matches, current match), and the content-scroll snapshot for cancel-restore. |
-| `lineselect` | Line-select modal state (copy-line-reference): anchor + marker source-line indices, the focus-gated `L` entry that auto-switches to the source view, key/mouse handling, and formatting the `path:line` / `path:start-end` reference for the clipboard. Read-only. |
+| `lineselect` | Line-select modal state (copy-line-content): anchor + marker source-line indices, the focus-gated `L` entry that auto-switches to the source view, key/mouse handling, and extracting the selected lines' text (joined by newlines, residual control bytes stripped) for the clipboard. Read-only. |
 | `help` | Help overlay state: the embedded changelog source and About text, plus the section and vertical scroll position for the `?` overlay. Pure; no I/O — the changelog is compiled in at build time. |
 | `input` | Map crossterm key events → intents. |
 | `intent` | The closed set of user intents (one exhaustive enum). |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -43,7 +43,7 @@ is unit-testable with stubs.
 | `text_layout` | A pure text-wrapping helper: how many display rows a line occupies at a given width — shared by the content pane, the finder, and the help overlay. No I/O. |
 | `prompt` | A reusable single-line text-input buffer (push / backspace / clear) backing the finder query — and future keyboard prompts. |
 | `infile` | In-file-navigation modal state: which bottom prompt is open (go-to-line or in-file search), its `prompt` input buffer, the live `SearchState` (query, matches, current match), and the content-scroll snapshot for cancel-restore. |
-| `lineselect` | Line-select modal state (copy-line-content): anchor + marker source-line indices, the focus-gated `L` entry that auto-switches to the source view, key/mouse handling, and extracting the selected lines' text (joined by newlines, residual control bytes stripped) for the clipboard. Read-only. |
+| `lineselect` | Line-select modal state: anchor + marker source-line indices (plus mouse char carets), the focus-gated `L` entry that auto-switches to the source view, key/mouse handling, and the two confirms — formatting the `path:line` / `path:start-end` reference (`Enter`) and extracting the selected text (`y`/`Y`, joined by newlines, gutter stripped, residual control bytes removed) for the clipboard. Read-only. |
 | `help` | Help overlay state: the embedded changelog source and About text, plus the section and vertical scroll position for the `?` overlay. Pure; no I/O — the changelog is compiled in at build time. |
 | `input` | Map crossterm key events → intents. |
 | `intent` | The closed set of user intents (one exhaustive enum). |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,10 @@ All notable changes to this project are documented here. The format is based on
 - **Line-select mode copies content with `y`/`Y`.** One selection, two products: `Enter` keeps
   copying the `path:line` / `path:start-end` **reference** (unchanged since 1.9.0), while the new
   `y`/`Y` copy the selected **content** — for a keyboard selection, the line(s) joined by
-  newlines; for a mouse selection, the exact character span. The syntax view's line-number gutter
-  (`bat --style=numbers`) is stripped from the content copy, indentation is preserved, and
-  residual control bytes are removed before it reaches the clipboard (tabs kept). The confirmation
+  newlines; for a mouse selection, the exact character span. Whole-line copies come from the
+  file's own retained text, byte-faithful (real tabs, no renderer decoration); the syntax view's
+  line-number gutter (`bat --style=numbers`) never reaches the copy, indentation is preserved,
+  and residual control bytes are removed before it reaches the clipboard (tabs kept). The confirmation
   notice names what was copied (e.g. "Copied lines 42-58" / "Copied selection").
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,21 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+### Added
+- **Mouse text selection in line-select mode.** Click-drag in the content pane to select text
+  character-by-character (press at the start, drag to the end — the pane auto-scrolls past an
+  edge — release), with the selected characters highlighted as you drag; `Enter`/`y`/`Y` copies
+  exactly the dragged characters. `Shift`+mouse is left untouched so the terminal's own native
+  selection still works.
+
 ### Changed
-- **Line-select mode now copies the selected lines' content, not a `path:line` reference.** `Enter`,
-  `y`/`Y`, or a double-click copies the actual text of the selected line (or, for a range, every
-  line joined by newlines, indentation preserved) — so it pastes as real code rather than a
-  location string. The syntax view's line-number gutter (`bat --style=numbers`) is stripped from
-  the copy, and residual control bytes are removed before it reaches the clipboard (tabs kept).
-  The confirmation notice names the copied line range (e.g. "Copied lines 42-58"). Marker
-  movement, extend, mouse handling, and the source-view auto-switch are unchanged.
+- **Line-select mode now copies the selected content, not a `path:line` reference.** `Enter`,
+  `y`/`Y` copies the actual text: for a keyboard selection, the line(s) joined by newlines; for a
+  mouse selection, the exact character span. The syntax view's line-number gutter
+  (`bat --style=numbers`) is stripped from the copy, indentation is preserved, and residual control
+  bytes are removed before it reaches the clipboard (tabs kept). The confirmation notice names what
+  was copied (e.g. "Copied lines 42-58" / "Copied selection"). A mouse press now places the
+  selection caret (previously a click placed the line marker; a double-click no longer copies).
 
 ## [1.10.0] - 2026-07-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,18 +16,19 @@ All notable changes to this project are documented here. The format is based on
   selection still works, and dragging over placeholder text (a directory / empty pane) copies nothing.
 - **Mouse text selection in line-select mode.** Click-drag in the content pane to select text
   character-by-character (press at the start, drag to the end — the pane auto-scrolls past an
-  edge — release), with the selected characters highlighted as you drag; `Enter`/`y`/`Y` copies
-  exactly the dragged characters. `Shift`+mouse is left untouched so the terminal's own native
-  selection still works.
+  edge — release), with the selected characters highlighted as you drag. `Shift`+mouse is left
+  untouched so the terminal's own native selection still works.
+- **Line-select mode copies content with `y`/`Y`.** One selection, two products: `Enter` keeps
+  copying the `path:line` / `path:start-end` **reference** (unchanged since 1.9.0), while the new
+  `y`/`Y` copy the selected **content** — for a keyboard selection, the line(s) joined by
+  newlines; for a mouse selection, the exact character span. The syntax view's line-number gutter
+  (`bat --style=numbers`) is stripped from the content copy, indentation is preserved, and
+  residual control bytes are removed before it reaches the clipboard (tabs kept). The confirmation
+  notice names what was copied (e.g. "Copied lines 42-58" / "Copied selection").
 
 ### Changed
-- **Line-select mode now copies the selected content, not a `path:line` reference.** `Enter`,
-  `y`/`Y` copies the actual text: for a keyboard selection, the line(s) joined by newlines; for a
-  mouse selection, the exact character span. The syntax view's line-number gutter
-  (`bat --style=numbers`) is stripped from the copy, indentation is preserved, and residual control
-  bytes are removed before it reaches the clipboard (tabs kept). The confirmation notice names what
-  was copied (e.g. "Copied lines 42-58" / "Copied selection"). A mouse press now places the
-  selection caret (previously a click placed the line marker; a double-click no longer copies).
+- **In line-select mode, a mouse press now places the selection caret** (previously a click placed
+  the line marker, and a double-click copied — copying is now always an explicit `Enter`/`y`).
 
 ## [1.10.0] - 2026-07-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ All notable changes to this project are documented here. The format is based on
 ## [Unreleased]
 
 ### Added
+- **Ambient mouse text selection in the content pane.** Click-drag over the content pane during
+  normal navigation — no mode to enter — to select text character-by-character (press at the start,
+  drag to the end while the pane auto-scrolls past an edge, release). Releasing the drag copies the
+  selected text to the clipboard automatically ("Copied selection"), and the highlight stays for
+  feedback; `Esc`, a click elsewhere, or switching files clears it. Line-select mode (`L`) remains a
+  separate keyboard-driven mode. `Shift`+drag is left untouched so the terminal's own native
+  selection still works, and dragging over placeholder text (a directory / empty pane) copies nothing.
 - **Mouse text selection in line-select mode.** Click-drag in the content pane to select text
   character-by-character (press at the start, drag to the end — the pane auto-scrolls past an
   edge — release), with the selected characters highlighted as you drag; `Enter`/`y`/`Y` copies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- **Line-select mode now copies the selected lines' content, not a `path:line` reference.** `Enter`,
+  `y`/`Y`, or a double-click copies the actual text of the selected line (or, for a range, every
+  line joined by newlines, indentation preserved) — so it pastes as real code rather than a
+  location string. The syntax view's line-number gutter (`bat --style=numbers`) is stripped from
+  the copy, and residual control bytes are removed before it reaches the clipboard (tabs kept).
+  The confirmation notice names the copied line range (e.g. "Copied lines 42-58"). Marker
+  movement, extend, mouse handling, and the source-view auto-switch are unchanged.
+
 ## [1.10.0] - 2026-07-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,10 @@ All notable changes to this project are documented here. The format is based on
   drag to the end while the pane auto-scrolls past an edge, release). Releasing the drag copies the
   selected text to the clipboard automatically ("Copied selection"), and the highlight stays for
   feedback; `Esc`, a click elsewhere, or switching files clears it. Line-select mode (`L`) remains a
-  separate keyboard-driven mode. `Shift`+drag is left untouched so the terminal's own native
-  selection still works, and dragging over placeholder text (a directory / empty pane) copies nothing.
+  separate keyboard-driven mode. Works in **wrapped** views (prose/markdown by default, or the
+  `w` toggle) too — the click maps through the same wrapping the pane draws with. `Shift`+drag is
+  left untouched so the terminal's own native selection still works, and dragging over placeholder
+  text (a directory / empty pane) copies nothing.
 - **Mouse text selection in line-select mode.** Click-drag in the content pane to select text
   character-by-character (press at the start, drag to the end — the pane auto-scrolls past an
   edge — release), with the selected characters highlighted as you drag. `Shift`+mouse is left

--- a/README.md
+++ b/README.md
@@ -154,8 +154,8 @@ PowerShell launcher scripts.
 | `→` / `l` | Expand the selected directory — or **scroll the content pane right** when it is focused |
 | `←` / `h` | Collapse the selected directory — or **scroll the content pane left** when it is focused |
 | `H` (Shift+`h`) | Scroll the **tree** pane left (long / deeply-nested rows) — inert unless the tree is focused |
-| `L` (Shift+`l`) | Focus-gated: with the **tree** focused, scroll it right (long / deeply-nested rows); with the **content pane** focused (or zoomed), enter **line-select mode** to select and copy content — whole lines by keyboard or text by mouse click-drag (see below) |
-| _line-select mode_ | `j`/`k` (or `↑`/`↓`) move the marker, `Shift`+move (`J`/`K`, Shift+`↑`/`↓`) extends a line selection; **click-drag** with the mouse selects **text** (character-granular); `Enter` / `y` / `Y` copies the selected content, `Esc` exits |
+| `L` (Shift+`l`) | Focus-gated: with the **tree** focused, scroll it right (long / deeply-nested rows); with the **content pane** focused (or zoomed), enter **line-select mode** to select lines and copy either a `file:line` reference or the content itself (see below) |
+| _line-select mode_ | `j`/`k` (or `↑`/`↓`) move the marker, `Shift`+move (`J`/`K`, Shift+`↑`/`↓`) extends a line selection; **click-drag** with the mouse selects **text** (character-granular); `Enter` copies the `path:line` / `path:start-end` **reference**, `y`/`Y` copies the selected **content**, `Esc` exits |
 | `Enter` | Activate the selection — expand/collapse a directory, or open a file in **zoom mode** (content full-screen) |
 | `i` | Toggle gitignored files |
 | `.` | Toggle hidden (dot-prefixed) files and folders |
@@ -203,17 +203,22 @@ clipboard with no extra tooling. A confirmation appears in the notices strip. If
 on your clipboard, your terminal likely needs OSC 52 / clipboard-write enabled (e.g. in tmux,
 `set -g set-clipboard on`).
 
-**Copy line content (`L`).** With the content pane focused (or zoomed), `L` enters
-**line-select mode**: a marker lands on the top visible line, `j`/`k` (or `↑`/`↓`) move it, and
-holding `Shift` (`J`/`K`, or Shift+`↑`/`↓`) extends a whole-line selection. Or **click-drag with
-the mouse** to select **text** character-by-character — press where the selection starts, drag to
-where it ends (the pane scrolls if you drag past an edge), release; the selected characters are
-highlighted as you go. `Enter` or `y`/`Y` copies the selection to the clipboard: for a line
-selection, the lines joined by newlines; for a mouse text selection, exactly the characters you
-dragged over. Either way the syntax view's line-number
-gutter is stripped and indentation is preserved, so it pastes as real code. A confirmation notice
-names what was copied. The copy uses the same **OSC 52** path as `y`/`Y`, so it's ready to paste
-straight into an agent chat, an editor, or an issue. `Esc` leaves the mode.
+**Copy a line reference or line content (`L`).** With the content pane focused (or zoomed), `L`
+enters **line-select mode**: a marker lands on the top visible line, `j`/`k` (or `↑`/`↓`) move it,
+and holding `Shift` (`J`/`K`, or Shift+`↑`/`↓`) extends a whole-line selection. Or **click-drag
+with the mouse** to select **text** character-by-character — press where the selection starts,
+drag to where it ends (the pane scrolls if you drag past an edge), release; the selected
+characters are highlighted as you go. One selection, two products:
+
+- **`Enter` copies a repo-relative reference** — `src/app.rs:42` for a single line,
+  `src/app.rs:42-58` for a range (a mouse selection references the lines it spans) — ready to
+  paste into an agent chat or an issue to point at exact lines.
+- **`y` / `Y` copy the content itself** — for a line selection, the lines joined by newlines; for
+  a mouse text selection, exactly the characters you dragged over. The syntax view's line-number
+  gutter is stripped and indentation is preserved, so it pastes as real code.
+
+A confirmation notice names what was copied. Both copies use the same **OSC 52** path as the
+tree's `y`/`Y`. `Esc` leaves the mode.
 
 `Shift`+mouse is deliberately left alone so your terminal's own native selection/copy still works
 — most terminals reserve `Shift`+drag for exactly that. Because selection only maps onto the

--- a/README.md
+++ b/README.md
@@ -221,9 +221,10 @@ A confirmation notice names what was copied. Both copies use the same **OSC 52**
 tree's `y`/`Y`. `Esc` leaves the mode.
 
 `Shift`+mouse is deliberately left alone so your terminal's own native selection/copy still works
-— most terminals reserve `Shift`+drag for exactly that. Because selection only maps onto the
-source, entering line-select from a rendered-markdown or diff view first switches that file to the
-line-numbered content view. With the **tree** focused, `L` keeps its tree horizontal-scroll
+— most terminals reserve `Shift`+drag for exactly that. Selection works in wrapped views too (the
+`w` toggle): the click maps through the same wrapping the pane draws with, so the caret lands on
+the character under the cursor. Because selection only maps onto the source, entering line-select
+from a rendered-markdown or diff view first switches that file to the line-numbered content view. With the **tree** focused, `L` keeps its tree horizontal-scroll
 behavior instead — the mode is gated on which pane has focus.
 
 ### Mouse
@@ -239,6 +240,7 @@ The viewer is keyboard-first; the mouse is additive and on by default:
 | **Horizontal wheel / swipe** | Scroll the content — or the tree — sideways (terminal-dependent — see below) |
 | **Drag** a scrollbar | Scroll that pane — drag ↕ on a vertical bar, ↔ on a horizontal bar; pressing the track jumps there |
 | **Drag** the divider | Resize the tree / content split |
+| **Drag** over the content text | **Select and copy text** — the selection highlights character-by-character as you drag (auto-scrolling past an edge) and is copied to the clipboard on release; no mode needed. Works in wrapped views (prose/markdown) too. `Esc`, a click elsewhere, or switching files clears the highlight |
 
 **`Shift`+drag is left to your terminal**, so its native select-and-copy still works while the
 viewer owns ordinary clicks — herdr reserves `Shift`+mouse for exactly this. (herdr forwards

--- a/README.md
+++ b/README.md
@@ -154,8 +154,8 @@ PowerShell launcher scripts.
 | `→` / `l` | Expand the selected directory — or **scroll the content pane right** when it is focused |
 | `←` / `h` | Collapse the selected directory — or **scroll the content pane left** when it is focused |
 | `H` (Shift+`h`) | Scroll the **tree** pane left (long / deeply-nested rows) — inert unless the tree is focused |
-| `L` (Shift+`l`) | Focus-gated: with the **tree** focused, scroll it right (long / deeply-nested rows); with the **content pane** focused (or zoomed), enter **line-select mode** to copy the selected lines' content (see below) |
-| _line-select mode_ | `j`/`k` (or `↑`/`↓`) move the marker, `Shift`+move (`J`/`K`, Shift+`↑`/`↓`) extends the selection, `Enter` / `y` / `Y` (or double-click) copies the selected lines' **content**, `Esc` exits |
+| `L` (Shift+`l`) | Focus-gated: with the **tree** focused, scroll it right (long / deeply-nested rows); with the **content pane** focused (or zoomed), enter **line-select mode** to select and copy content — whole lines by keyboard or text by mouse click-drag (see below) |
+| _line-select mode_ | `j`/`k` (or `↑`/`↓`) move the marker, `Shift`+move (`J`/`K`, Shift+`↑`/`↓`) extends a line selection; **click-drag** with the mouse selects **text** (character-granular); `Enter` / `y` / `Y` copies the selected content, `Esc` exits |
 | `Enter` | Activate the selection — expand/collapse a directory, or open a file in **zoom mode** (content full-screen) |
 | `i` | Toggle gitignored files |
 | `.` | Toggle hidden (dot-prefixed) files and folders |
@@ -205,17 +205,21 @@ on your clipboard, your terminal likely needs OSC 52 / clipboard-write enabled (
 
 **Copy line content (`L`).** With the content pane focused (or zoomed), `L` enters
 **line-select mode**: a marker lands on the top visible line, `j`/`k` (or `↑`/`↓`) move it, and
-holding `Shift` (`J`/`K`, or Shift+`↑`/`↓`) extends the selection over a range. `Enter`, `y`/`Y`
-— or a double-click — copies the **selected lines' text** to the clipboard: a single line copies
-that line, a range copies every line joined by newlines, so it pastes as real code (indentation
-preserved). A confirmation notice names the copied line range. A mouse **click** places the marker
-and a **double-click** copies; `Esc` leaves the mode. (Mouse shift-click extend isn't supported —
-most terminals reserve `Shift`+mouse for their own selection — so use keyboard `Shift`+`j`/`k` to
-extend from the mouse.) The copy uses the same **OSC 52** path as `y`/`Y`, so the lines are ready
-to paste straight into an agent chat, an editor, or an issue. Because line selection only maps
-onto the source, entering line-select from a rendered-markdown or diff view first switches that
-file to the line-numbered content view. With the **tree** focused, `L` keeps its tree
-horizontal-scroll behavior instead — the mode is gated on which pane has focus.
+holding `Shift` (`J`/`K`, or Shift+`↑`/`↓`) extends a whole-line selection. Or **click-drag with
+the mouse** to select **text** character-by-character — press where the selection starts, drag to
+where it ends (the pane scrolls if you drag past an edge), release; the selected characters are
+highlighted as you go. `Enter` or `y`/`Y` copies the selection to the clipboard: for a line
+selection, the lines joined by newlines; for a mouse text selection, exactly the characters you
+dragged over. Either way the syntax view's line-number
+gutter is stripped and indentation is preserved, so it pastes as real code. A confirmation notice
+names what was copied. The copy uses the same **OSC 52** path as `y`/`Y`, so it's ready to paste
+straight into an agent chat, an editor, or an issue. `Esc` leaves the mode.
+
+`Shift`+mouse is deliberately left alone so your terminal's own native selection/copy still works
+— most terminals reserve `Shift`+drag for exactly that. Because selection only maps onto the
+source, entering line-select from a rendered-markdown or diff view first switches that file to the
+line-numbered content view. With the **tree** focused, `L` keeps its tree horizontal-scroll
+behavior instead — the mode is gated on which pane has focus.
 
 ### Mouse
 

--- a/README.md
+++ b/README.md
@@ -154,8 +154,8 @@ PowerShell launcher scripts.
 | `→` / `l` | Expand the selected directory — or **scroll the content pane right** when it is focused |
 | `←` / `h` | Collapse the selected directory — or **scroll the content pane left** when it is focused |
 | `H` (Shift+`h`) | Scroll the **tree** pane left (long / deeply-nested rows) — inert unless the tree is focused |
-| `L` (Shift+`l`) | Focus-gated: with the **tree** focused, scroll it right (long / deeply-nested rows); with the **content pane** focused (or zoomed), enter **line-select mode** to copy a `file:line` reference (see below) |
-| _line-select mode_ | `j`/`k` (or `↑`/`↓`) move the marker, `Shift`+move (`J`/`K`, Shift+`↑`/`↓`) extends the selection, `Enter` (or double-click) copies the `path:line` / `path:start-end` reference, `Esc` exits |
+| `L` (Shift+`l`) | Focus-gated: with the **tree** focused, scroll it right (long / deeply-nested rows); with the **content pane** focused (or zoomed), enter **line-select mode** to copy the selected lines' content (see below) |
+| _line-select mode_ | `j`/`k` (or `↑`/`↓`) move the marker, `Shift`+move (`J`/`K`, Shift+`↑`/`↓`) extends the selection, `Enter` / `y` / `Y` (or double-click) copies the selected lines' **content**, `Esc` exits |
 | `Enter` | Activate the selection — expand/collapse a directory, or open a file in **zoom mode** (content full-screen) |
 | `i` | Toggle gitignored files |
 | `.` | Toggle hidden (dot-prefixed) files and folders |
@@ -203,19 +203,19 @@ clipboard with no extra tooling. A confirmation appears in the notices strip. If
 on your clipboard, your terminal likely needs OSC 52 / clipboard-write enabled (e.g. in tmux,
 `set -g set-clipboard on`).
 
-**Copy a line reference (`L`).** With the content pane focused (or zoomed), `L` enters
+**Copy line content (`L`).** With the content pane focused (or zoomed), `L` enters
 **line-select mode**: a marker lands on the top visible line, `j`/`k` (or `↑`/`↓`) move it, and
-holding `Shift` (`J`/`K`, or Shift+`↑`/`↓`) extends the selection over a range. `Enter` — or a
-double-click — copies a repo-relative reference to the clipboard: `src/app.rs:42` for a single
-line, `src/app.rs:42-58` for a range. A mouse **click** places the marker and a **double-click**
-copies; `Esc` leaves the mode. (Mouse shift-click extend isn't supported — most terminals reserve
-`Shift`+mouse for their own selection — so use keyboard `Shift`+`j`/`k` to extend from the mouse.)
-The copy uses the same **OSC 52**
-path as `y`/`Y`, so the reference is ready to paste straight into an agent chat or an issue to
-point at exact lines. Because line numbers only map onto the source, entering line-select from a
-rendered-markdown or diff view first switches that file to the line-numbered content view. With
-the **tree** focused, `L` keeps its tree horizontal-scroll behavior instead — the mode is gated on
-which pane has focus.
+holding `Shift` (`J`/`K`, or Shift+`↑`/`↓`) extends the selection over a range. `Enter`, `y`/`Y`
+— or a double-click — copies the **selected lines' text** to the clipboard: a single line copies
+that line, a range copies every line joined by newlines, so it pastes as real code (indentation
+preserved). A confirmation notice names the copied line range. A mouse **click** places the marker
+and a **double-click** copies; `Esc` leaves the mode. (Mouse shift-click extend isn't supported —
+most terminals reserve `Shift`+mouse for their own selection — so use keyboard `Shift`+`j`/`k` to
+extend from the mouse.) The copy uses the same **OSC 52** path as `y`/`Y`, so the lines are ready
+to paste straight into an agent chat, an editor, or an issue. Because line selection only maps
+onto the source, entering line-select from a rendered-markdown or diff view first switches that
+file to the line-numbered content view. With the **tree** focused, `L` keeps its tree
+horizontal-scroll behavior instead — the mode is gated on which pane has focus.
 
 ### Mouse
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -307,10 +307,22 @@ impl ContentProvider for LiveContent {
             render::classify(&self.root, path)
         };
         let name = path.file_name().and_then(OsStr::to_str);
+        // Retain the raw source lines behind a source-mapped render: `SyntaxContent` displays one
+        // rendered line per source line, so the copy paths can hand back the file's own text
+        // (byte-faithful — real tabs, no `bat` gutter/tab-expansion) and anchor the gutter width
+        // exactly. Transformed views (markdown / diffs) have no per-display-line source → `None`.
+        let source = match (&mode, &prepared) {
+            (ViewMode::SyntaxContent, Prepared::Full { text })
+            | (ViewMode::SyntaxContent, Prepared::Truncated { text, .. }) => {
+                Some(text.lines().map(str::to_owned).collect())
+            }
+            _ => None,
+        };
         let (content, notice) = render::render(&self.renderers, &prepared, mode, raw_diff, name);
         RenderResult {
             content,
             notices: notice.into_iter().collect(),
+            source,
         }
     }
 }

--- a/src/controller/lineselect.rs
+++ b/src/controller/lineselect.rs
@@ -168,6 +168,14 @@ impl Controller {
         // the deferred (T-6 auto-switch) path are covered — the clear happens when entry begins,
         // not when the (possibly-deferred) modal actually opens.
         self.last_click = None;
+        // Entering L mode drops any ambient content-pane selection so the two overlays never
+        // coexist — L mode gets a fresh line marker rather than inheriting the mouse char span.
+        self.content_selection = None;
+        // Also drop any in-flight drag: a still-held ambient press left `drag = Some(ContentSelect)`,
+        // and both mouse paths key their drag arm off that variant — without this reset the next
+        // mouse-move would extend the freshly-opened L-mode selection from a press the user never
+        // made in L mode. Clearing it keeps the first L-mode drag inert until a genuine L-mode press.
+        self.drag = None;
         let source_mapped = self.selected_view_mode() == Some(ViewMode::SyntaxContent);
         if source_mapped && self.applied_seq == self.latest_seq {
             // Source-mapped AND the displayed content is the latest render → the line→row mapping is
@@ -237,11 +245,13 @@ impl Controller {
             .collect()
     }
 
-    /// Map a screen `(col, row)` to a `(source line, char caret)` for mouse selection. The row maps
-    /// to a source line exactly as [`handle_line_select_mouse`](Self::handle_line_select_mouse)
-    /// does; the column subtracts the pane origin and the one-column selection glyph the overlay
-    /// prepends, adds any horizontal scroll, then resolves to a char caret in the displayed line.
-    /// Clamped to `[1, line_count]` for the line and `[0, line_len]` for the caret.
+    /// Map a screen `(col, row)` to a `(source line, char caret)` for mouse selection — used by both
+    /// the L-mode drag and the ambient content-pane drag. The row maps to a source line exactly as
+    /// [`handle_line_select_mouse`](Self::handle_line_select_mouse) does; the column subtracts the
+    /// pane origin and whatever leading glyph columns the ACTIVE overlay prepends
+    /// ([`content_overlay_glyph_cols`](Self::content_overlay_glyph_cols) — 1 in L mode, 0 ambient),
+    /// adds any horizontal scroll, then resolves to a char caret in the displayed line. Clamped to
+    /// `[1, line_count]` for the line and `[0, line_len]` for the caret.
     ///
     /// The char caret is an index into the *displayed* line (gutter included); the copy path strips
     /// the gutter afterward. Column accounting assumes the unwrapped view (the common case for a
@@ -255,30 +265,83 @@ impl Controller {
         let x = self.geom.content_inner.map_or(0, |c| c.x);
         let display_row = self.content_scroll as usize + row.saturating_sub(top) as usize;
         let line = self.line_at_content_row(display_row).clamp(1, last);
-        // The overlay prepends a 1-col glyph, so real content begins one column right of the pane
-        // origin; add horizontal scroll, then drop that glyph column to index the displayed line.
+        // The active overlay may prepend leading glyph column(s), so real content begins that many
+        // columns right of the pane origin; add horizontal scroll, then drop those glyph columns to
+        // index the displayed line. L mode prepends a 1-col ▶/│ gutter glyph; the ambient overlay
+        // prepends none (see `content_overlay_glyph_cols`).
         let within = (col.saturating_sub(x)) as usize + self.content_hscroll as usize;
-        let disp_col = within.saturating_sub(1);
+        let disp_col = within.saturating_sub(self.content_overlay_glyph_cols());
         let caret = char_index_at_col(&self.filtered_display_line(line), disp_col);
         (line, caret)
     }
 
-    /// The number of leading chars the syntax renderer's line-number gutter occupies — constant
-    /// across the source-mapped view, so it's measured off the marker line. `0` when there is no
-    /// gutter (plain-text fallback / test stubs), no line-select, or empty content. The Presenter
-    /// uses it so a character selection's highlight never paints the gutter on continuation lines.
-    pub(crate) fn selection_gutter_len(&self) -> usize {
-        let Some(s) = self.modal.line_select() else {
-            return 0;
+    /// How many leading display columns the ACTIVE content overlay prepends before the real text, so
+    /// a mouse column can be mapped back to a character caret in [`char_at_content_col`]. L
+    /// line-select mode draws a 1-column gutter glyph (▶ marker / │ bar) ahead of every line, so its
+    /// caret math subtracts 1; the ambient selection overlay draws no glyph, so it subtracts 0. The
+    /// L-mode overlay is the only one that prepends a glyph, so this is exactly `line_select_active()`.
+    fn content_overlay_glyph_cols(&self) -> usize {
+        if self.line_select_active() { 1 } else { 0 }
+    }
+
+    /// Auto-copy an ambient content-pane selection to the clipboard on the drag's release, leaving
+    /// the highlight standing for feedback (unlike the L-mode confirm, which closes the mode). Reads
+    /// the char span from [`content_selection`](Controller::content_selection) and builds the text
+    /// with [`char_selection_text`](Self::char_selection_text) — the same per-line gutter strip +
+    /// control-byte scrub (tabs kept) the L-mode copy uses, so code copies clean. Guards the
+    /// no-real-file case like [`copy_line_content`](Self::copy_line_content): a directory / empty
+    /// tree shows first-party guidance ("Directory —" / "No files") with no file node selected, so
+    /// copy nothing then; a collapsed/empty span also copies nothing. (The other placeholder,
+    /// "Rendering…", is shown while a file IS selected, so the file-node guard does NOT catch it —
+    /// the press-time `content_rendering` check in `handle_column_mouse` prevents a selection ever
+    /// being seeded over it.) Read-only: touches only the clipboard and the transient action notice.
+    pub(super) fn copy_content_selection(&mut self) -> Effects {
+        let Some((lo, hi)) = self.content_selection.as_ref().map(|s| s.char_span()) else {
+            return Effects::redraw();
         };
+        let is_file = self
+            .tree
+            .selected()
+            .is_some_and(|node| node.kind == NodeKind::File);
+        if !is_file {
+            return Effects::redraw();
+        }
+        let text = self.char_selection_text(lo, hi);
+        if text.is_empty() {
+            return Effects::redraw();
+        }
+        self.action_notice = Some(match self.clipboard.copy(&text) {
+            Ok(()) => "Copied selection".to_string(),
+            Err(e) => format!("Could not copy selection: {e}"),
+        });
+        Effects::redraw()
+    }
+
+    /// The number of leading chars the syntax renderer's line-number gutter occupies on 1-based
+    /// source `line` — constant across the source-mapped view, so any line in it measures the same.
+    /// `0` when there is no gutter (plain-text fallback / test stubs) or empty content. Both content
+    /// overlays use it so a character selection's highlight never paints the gutter on continuation
+    /// lines: the L-mode overlay measures it off the marker line, the ambient overlay off its start
+    /// line. `line` is clamped into `[1, line_count]`.
+    pub(crate) fn content_gutter_len(&self, line: usize) -> usize {
         let total = self.content.lines.len();
         if total == 0 {
             return 0;
         }
-        let n = s.marker().clamp(1, total);
+        let n = line.clamp(1, total);
         let displayed = self.filtered_display_line(n);
         let code = strip_line_gutter(&displayed, n);
         displayed.chars().count() - code.chars().count()
+    }
+
+    /// The gutter width on the L-mode marker line — [`content_gutter_len`](Self::content_gutter_len)
+    /// measured off the active line-select marker. `0` when line-select is inactive or content is
+    /// empty. The Presenter uses it for the L-mode character-selection highlight.
+    pub(crate) fn selection_gutter_len(&self) -> usize {
+        let Some(s) = self.modal.line_select() else {
+            return 0;
+        };
+        self.content_gutter_len(s.marker())
     }
 
     /// The text of a character-granular selection from `(lo_line, lo_col)` to `(hi_line, hi_col)`

--- a/src/controller/lineselect.rs
+++ b/src/controller/lineselect.rs
@@ -1,24 +1,35 @@
-//! Line-reference formatting for the copy-line-reference feature — turns a selected line or
-//! line range on a file into the `path:line` / `path:start-end` string the Copy adapter (T-7)
-//! puts on the clipboard, plus the line-select modal state and its enter/exit on the Controller.
+//! The line-select modal: its in-progress selection state, the enter/exit transitions on the
+//! Controller, and the confirm path that copies the selected lines' CONTENT (the actual file
+//! text, not a `path:line` reference) to the clipboard.
 
 use super::*;
 
-/// Format `rel_path` plus a 1-based line selection as `"<rel>:<n>"` for a single line
-/// (`start == end`) or `"<rel>:<lo>-<hi>"` for a range, normalizing `start`/`end` to ascending
-/// order first so a selection dragged either direction reads the same. Pure formatting only —
-/// no sanitization of `rel_path` (the Copy adapter, T-7, handles that before this is called).
-pub(crate) fn format_line_reference(rel_path: &str, start: usize, end: usize) -> String {
-    let (lo, hi) = if start <= end {
-        (start, end)
-    } else {
-        (end, start)
+/// Strip a leading line-number gutter (as the syntax renderer adds — `bat --style=numbers` prints
+/// a right-aligned number then a separator before each source line) from one rendered line's plain
+/// text, given the 1-based source line number `n` that line displays.
+///
+/// Self-validating: it only strips when the digits immediately after the right-align padding EQUAL
+/// `n` **and** are followed by a real separator (a space, and/or a box-drawing `│`/`|` with its
+/// spaces). So a renderer that adds no gutter (the plain-text fallback, or the test stubs), or a
+/// code line that merely happens to start with some other digits, is returned unchanged — and the
+/// code's OWN leading indentation, which sits after the single separator, is preserved intact.
+fn strip_line_gutter(plain: &str, n: usize) -> &str {
+    let after_pad = plain.trim_start_matches(' ');
+    let Some(rest) = after_pad.strip_prefix(&n.to_string()) else {
+        return plain;
     };
-    if lo == hi {
-        format!("{rel_path}:{lo}")
-    } else {
-        format!("{rel_path}:{lo}-{hi}")
+    // The gutter number must be followed by a separator; otherwise this isn't a gutter.
+    let mut rest = rest;
+    let mut saw_sep = false;
+    if let Some(r) = rest.strip_prefix(' ') {
+        rest = r;
+        saw_sep = true;
     }
+    if let Some(r) = rest.strip_prefix('│').or_else(|| rest.strip_prefix('|')) {
+        rest = r.strip_prefix(' ').unwrap_or(r);
+        saw_sep = true;
+    }
+    if saw_sep { rest } else { plain }
 }
 
 /// In-progress line selection on the content pane: `anchor` is where the selection started,
@@ -93,7 +104,7 @@ impl Controller {
         // Reset double-click state (mirrors open_finder/open_help): a tree click made just before
         // entry must not pair with the FIRST content click inside the mode as a double-click —
         // `is_double_click` only compares the row, not the column/pane, so a stale prior-context
-        // click could otherwise fire `copy_line_reference` (copy + close) before the marker is
+        // click could otherwise fire `copy_line_content` (copy + close) before the marker is
         // ever placed. Cleared here, at the top of entry, so BOTH the synchronous path below and
         // the deferred (T-6 auto-switch) path are covered — the clear happens when entry begins,
         // not when the (possibly-deferred) modal actually opens.
@@ -128,49 +139,75 @@ impl Controller {
         }
     }
 
-    /// Copy the current line reference for the selected file to the clipboard and close the mode
-    /// (the `Enter` / double-click confirm, T-7). Mirrors [`copy_path`](Controller::copy_path):
-    /// build the `path:line` / `path:start-end` reference, run it through
-    /// [`sanitize_control`](crate::text_layout::sanitize_control) **before** it reaches the
-    /// clipboard *or* the notice (AC-16 — a crafted file name may carry ESC/newline), then surface
-    /// the outcome as a transient notice ("Copied …" on `Ok` / a failure message on `Err`,
-    /// AC-10/AC-11).
+    /// Join the plain text of the currently-selected 1-based source lines `[start, end]` with `\n`.
+    ///
+    /// Line-select forces the source-mapped content view (`SyntaxContent`), so each entry in
+    /// `content.lines` is exactly one source line — the selection therefore indexes straight into
+    /// it (`line - 1`). For each selected line we (1) join its spans' text, (2) drop any residual
+    /// control char **while keeping `\t`** so indentation survives, and (3) strip the syntax
+    /// renderer's line-number gutter via [`strip_line_gutter`] so the copy is the source text
+    /// alone — not `bat`'s `   1 …` decoration. The `\n` joins are added only *after* that
+    /// per-line work so line structure survives (a whole-string `sanitize_control` would eat the
+    /// newlines/tabs — hence the per-line approach). Bounds are clamped into `[1, line_count]`; an
+    /// empty body yields an empty string.
+    fn selected_lines_text(&self, start: usize, end: usize) -> String {
+        let total = self.content.lines.len();
+        if total == 0 {
+            return String::new();
+        }
+        let lo = start.max(1).min(total);
+        let hi = end.max(1).min(total);
+        (lo..=hi)
+            .map(|n| {
+                let plain: String = self.content.lines[n - 1]
+                    .spans
+                    .iter()
+                    .flat_map(|s| s.content.chars())
+                    .filter(|c| !c.is_control() || *c == '\t')
+                    .collect();
+                strip_line_gutter(&plain, n).to_string()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    /// Copy the CONTENT of the selected lines to the clipboard and close the mode (the `Enter` /
+    /// `y` / `Y` / double-click confirm). Builds the joined line text via
+    /// [`selected_lines_text`](Self::selected_lines_text), copies it, then surfaces a concise
+    /// outcome notice naming the line range — NOT the content itself, which may be many lines
+    /// ("Copied line 5" / "Copied lines 5-8" on `Ok`, a failure message on `Err`, AC-10/AC-11).
     ///
     /// Guards the no-real-file case: the mode can be open without a selected *file* node (the T-4
     /// guidance screen is non-empty), so if there is no active selection or the selected node is
-    /// not a file, copy nothing and return [`Effects::noop`] rather than fabricate a reference.
+    /// not a file, copy nothing and return [`Effects::noop`] rather than copy the guidance text.
     /// Read-only (AC-17): touches only the clipboard and in-memory notice / modal state.
     ///
     /// The mode closes on **both** `Ok` and `Err` (via [`exit_line_select`](Self::exit_line_select))
-    /// so `Enter` is a completed action that returns to normal navigation — consistent with the
+    /// so the confirm is a completed action that returns to normal navigation — consistent with the
     /// finder/picker/prompt confirm paths; the notice conveys the outcome.
-    pub fn copy_line_reference(&mut self) -> Effects {
+    pub fn copy_line_content(&mut self) -> Effects {
         // Both an active selection AND a selected file node are required; otherwise there is no
-        // reference to copy — do not fabricate one.
+        // file content to copy — do not copy the non-file guidance screen (T-4).
         let Some((start, end)) = self.line_selection() else {
             return Effects::noop();
         };
-        let Some(rel_path) = self
+        let is_file = self
             .tree
             .selected()
-            .filter(|node| node.kind == NodeKind::File)
-            .map(|node| {
-                self.rel(&node.path)
-                    .unwrap_or_else(|| node.path.clone())
-                    .to_string_lossy()
-                    .into_owned()
-            })
-        else {
+            .is_some_and(|node| node.kind == NodeKind::File);
+        if !is_file {
             return Effects::noop();
-        };
+        }
 
-        let raw = format_line_reference(&rel_path, start, end);
-        // Sanitize the WHOLE reference before it reaches the clipboard OR the notice (AC-16) — the
-        // path segment is untrusted, exactly as in `copy_path`.
-        let text = crate::text_layout::sanitize_control(&raw);
+        let text = self.selected_lines_text(start, end);
+        let label = if start == end {
+            format!("line {start}")
+        } else {
+            format!("lines {start}-{end}")
+        };
         self.action_notice = Some(match self.clipboard.copy(&text) {
-            Ok(()) => format!("Copied {text}"),
-            Err(e) => format!("Could not copy line reference: {e}"),
+            Ok(()) => format!("Copied {label}"),
+            Err(e) => format!("Could not copy {label}: {e}"),
         });
         self.exit_line_select();
         Effects::redraw()
@@ -205,8 +242,9 @@ impl Controller {
     /// reports Shift+letter as the **uppercase char** (`J`/`K`) and Shift+arrow as the arrow key
     /// plus `KeyModifiers::SHIFT`, so both spellings are accepted. `move_to`/`extend_to` clamp
     /// the target to `[1, last]` (AC-6). After any move the content pane scrolls so the marker
-    /// stays visible (AC-7). `Esc` exits without copying (AC-4); `Enter` copies the reference and
-    /// closes the mode ([`copy_line_reference`](Self::copy_line_reference), AC-9). Any other key
+    /// stays visible (AC-7). `Esc` exits without copying (AC-4); `Enter` copies the selected lines'
+    /// content and closes the mode; `y`/`Y` do the same (the familiar copy keys)
+    /// ([`copy_line_content`](Self::copy_line_content), AC-9). Any other key
     /// is inert. Ctrl/Alt chords are rejected up
     /// front so a reserved combo never moves the marker; Shift is meaningful (extend / shifted
     /// arrows) and is allowed.
@@ -223,8 +261,13 @@ impl Controller {
                 self.exit_line_select(); // AC-4: close, copy nothing, scroll unchanged
                 return Effects::redraw();
             }
-            KeyCode::Enter => {
-                return self.copy_line_reference(); // AC-9: copy the reference, then close the mode
+            // Enter / y / Y all confirm: copy the selected lines' content, then close the mode.
+            // `y`/`Y` reach here because line-select routes every key through this handler, so the
+            // normal copy-path bindings would otherwise be inert; wiring them here matches the
+            // muscle memory of "y copies". `Y` arrives as the uppercase char + SHIFT, which the
+            // modifier guard above permits.
+            KeyCode::Enter | KeyCode::Char('y') | KeyCode::Char('Y') => {
+                return self.copy_line_content(); // AC-9
             }
             _ => {}
         }
@@ -284,23 +327,39 @@ mod tests {
     use super::*;
 
     #[test]
-    fn single_line_has_no_range_suffix() {
-        assert_eq!(
-            format_line_reference("src/editor.rs", 50, 50),
-            "src/editor.rs:50"
-        );
+    fn strip_gutter_removes_number_and_space_keeps_code() {
+        // `bat --style=numbers`-style: right-aligned number + one space, then the source line.
+        assert_eq!(strip_line_gutter("   1 # Architecture", 1), "# Architecture");
+        assert_eq!(strip_line_gutter("  42 fn main() {", 42), "fn main() {");
     }
 
     #[test]
-    fn range_normalizes_ascending() {
-        assert_eq!(
-            format_line_reference("src/editor.rs", 50, 58),
-            "src/editor.rs:50-58"
-        );
-        assert_eq!(
-            format_line_reference("src/editor.rs", 58, 50),
-            "src/editor.rs:50-58"
-        );
+    fn strip_gutter_preserves_code_indentation() {
+        // Only the single separator space is consumed; the code's own leading indentation stays.
+        assert_eq!(strip_line_gutter("  2     let x = 5;", 2), "    let x = 5;");
+    }
+
+    #[test]
+    fn strip_gutter_handles_box_drawing_separator() {
+        // Some `bat` styles put a `│` between the number and the code.
+        assert_eq!(strip_line_gutter("  1 │ code", 1), "code");
+        assert_eq!(strip_line_gutter("  1 | code", 1), "code");
+    }
+
+    #[test]
+    fn strip_gutter_blank_line_becomes_empty() {
+        assert_eq!(strip_line_gutter("   2 ", 2), "");
+    }
+
+    #[test]
+    fn strip_gutter_leaves_ungutter_content_untouched() {
+        // No matching leading number (the test stubs render "line4" etc.) → unchanged.
+        assert_eq!(strip_line_gutter("line4", 5), "line4");
+        // Digits present but NOT equal to the line number → not a gutter, unchanged.
+        assert_eq!(strip_line_gutter("42 is the answer", 7), "42 is the answer");
+        // Leading digits equal to `n` but with no separator (code that just starts with them) →
+        // unchanged, so we never eat real content.
+        assert_eq!(strip_line_gutter("5000 loops", 5), "5000 loops");
     }
 
     #[test]

--- a/src/controller/lineselect.rs
+++ b/src/controller/lineselect.rs
@@ -429,7 +429,10 @@ impl Controller {
                 let text = self.char_selection_text(lo, hi);
                 if text.is_empty() {
                     let marker = self.line_selection().map_or(start, |(_, e)| e);
-                    (self.selected_lines_text(marker, marker), format!("line {marker}"))
+                    (
+                        self.selected_lines_text(marker, marker),
+                        format!("line {marker}"),
+                    )
                 } else {
                     (text, "selection".to_string())
                 }
@@ -568,7 +571,10 @@ mod tests {
     #[test]
     fn strip_gutter_removes_number_and_space_keeps_code() {
         // `bat --style=numbers`-style: right-aligned number + one space, then the source line.
-        assert_eq!(strip_line_gutter("   1 # Architecture", 1), "# Architecture");
+        assert_eq!(
+            strip_line_gutter("   1 # Architecture", 1),
+            "# Architecture"
+        );
         assert_eq!(strip_line_gutter("  42 fn main() {", 42), "fn main() {");
     }
 
@@ -632,7 +638,10 @@ mod tests {
         s.begin_char(1, 4, 10);
         assert!(s.is_char_mode(), "a mouse press is character-granular");
         s.move_to(3, 10);
-        assert!(!s.is_char_mode(), "a keyboard move reverts to line granularity");
+        assert!(
+            !s.is_char_mode(),
+            "a keyboard move reverts to line granularity"
+        );
     }
 
     #[test]

--- a/src/controller/lineselect.rs
+++ b/src/controller/lineselect.rs
@@ -1,8 +1,27 @@
 //! The line-select modal: its in-progress selection state, the enter/exit transitions on the
-//! Controller, and the confirm path that copies the selected lines' CONTENT (the actual file
-//! text, not a `path:line` reference) to the clipboard.
+//! Controller, and the two confirm paths — `Enter` copies the selection's `path:line` /
+//! `path:start-end` REFERENCE (the v1.9.0 copy-line-reference contract, unchanged), while
+//! `y`/`Y` copy the selected lines' CONTENT (the actual file text). One selection, two
+//! products, one keystroke apart.
 
 use super::*;
+
+/// Format `rel_path` plus a 1-based line selection as `"<rel>:<n>"` for a single line
+/// (`start == end`) or `"<rel>:<lo>-<hi>"` for a range, normalizing `start`/`end` to ascending
+/// order first so a selection dragged either direction reads the same. Pure formatting only —
+/// no sanitization of `rel_path` (the Copy adapter, T-7, handles that before this is called).
+pub(crate) fn format_line_reference(rel_path: &str, start: usize, end: usize) -> String {
+    let (lo, hi) = if start <= end {
+        (start, end)
+    } else {
+        (end, start)
+    };
+    if lo == hi {
+        format!("{rel_path}:{lo}")
+    } else {
+        format!("{rel_path}:{lo}-{hi}")
+    }
+}
 
 /// Strip a leading line-number gutter (as the syntax renderer adds — `bat --style=numbers` prints
 /// a right-aligned number then a separator before each source line) from one rendered line's plain
@@ -372,8 +391,57 @@ impl Controller {
             .join("\n")
     }
 
-    /// Copy the selected content to the clipboard and close the mode (the `Enter` / `y` / `Y`
-    /// confirm). Whole lines for a keyboard (line-granular) selection via
+    /// Copy the current line reference for the selected file to the clipboard and close the mode
+    /// (the `Enter` confirm — the v1.9.0 copy-line-reference contract, unchanged by the
+    /// copy-content addition; `y`/`Y` copy the CONTENT instead, see
+    /// [`copy_line_content`](Self::copy_line_content)). Mirrors [`copy_path`](Controller::copy_path):
+    /// build the `path:line` / `path:start-end` reference, run it through
+    /// [`sanitize_control`](crate::text_layout::sanitize_control) **before** it reaches the
+    /// clipboard *or* the notice (AC-16 — a crafted file name may carry ESC/newline), then surface
+    /// the outcome as a transient notice ("Copied …" on `Ok` / a failure message on `Err`,
+    /// AC-10/AC-11). A character-granular (mouse) selection references the lines its span covers —
+    /// the drag's line range is exactly [`line_selection`](Self::line_selection).
+    ///
+    /// Guards the no-real-file case exactly as [`copy_line_content`](Self::copy_line_content)
+    /// does: no active selection or a non-file node ⇒ copy nothing, [`Effects::noop`] — never
+    /// fabricate a reference. Read-only (AC-17): touches only the clipboard and in-memory
+    /// notice / modal state. The mode closes on **both** `Ok` and `Err` (via
+    /// [`exit_line_select`](Self::exit_line_select)) so `Enter` is a completed action.
+    pub fn copy_line_reference(&mut self) -> Effects {
+        // Both an active selection AND a selected file node are required; otherwise there is no
+        // reference to copy — do not fabricate one.
+        let Some((start, end)) = self.line_selection() else {
+            return Effects::noop();
+        };
+        let Some(rel_path) = self
+            .tree
+            .selected()
+            .filter(|node| node.kind == NodeKind::File)
+            .map(|node| {
+                self.rel(&node.path)
+                    .unwrap_or_else(|| node.path.clone())
+                    .to_string_lossy()
+                    .into_owned()
+            })
+        else {
+            return Effects::noop();
+        };
+
+        let raw = format_line_reference(&rel_path, start, end);
+        // Sanitize the WHOLE reference before it reaches the clipboard OR the notice (AC-16) — the
+        // path segment is untrusted, exactly as in `copy_path`.
+        let text = crate::text_layout::sanitize_control(&raw);
+        self.action_notice = Some(match self.clipboard.copy(&text) {
+            Ok(()) => format!("Copied {text}"),
+            Err(e) => format!("Could not copy line reference: {e}"),
+        });
+        self.exit_line_select();
+        Effects::redraw()
+    }
+
+    /// Copy the selected content to the clipboard and close the mode (the `y` / `Y`
+    /// confirm — `Enter` copies the REFERENCE instead, see
+    /// [`copy_line_reference`](Self::copy_line_reference)). Whole lines for a keyboard (line-granular) selection via
     /// [`selected_lines_text`](Self::selected_lines_text), or the exact character span for a mouse
     /// drag via [`char_selection_text`](Self::char_selection_text). Surfaces a concise outcome
     /// notice — the line range or "selection", NOT the content itself, which may be many lines
@@ -470,9 +538,10 @@ impl Controller {
     /// reports Shift+letter as the **uppercase char** (`J`/`K`) and Shift+arrow as the arrow key
     /// plus `KeyModifiers::SHIFT`, so both spellings are accepted. `move_to`/`extend_to` clamp
     /// the target to `[1, last]` (AC-6). After any move the content pane scrolls so the marker
-    /// stays visible (AC-7). `Esc` exits without copying (AC-4); `Enter` copies the selected
-    /// content and closes the mode; `y`/`Y` do the same (the familiar copy keys)
-    /// ([`copy_line_content`](Self::copy_line_content), AC-9). Any other key
+    /// stays visible (AC-7). `Esc` exits without copying (AC-4); `Enter` copies the `path:line`
+    /// REFERENCE and closes the mode ([`copy_line_reference`](Self::copy_line_reference), AC-9 —
+    /// the shipped v1.9.0 behavior, unchanged); `y`/`Y` copy the selected CONTENT instead
+    /// ([`copy_line_content`](Self::copy_line_content)) — one selection, two products. Any other key
     /// is inert. Ctrl/Alt chords are rejected up
     /// front so a reserved combo never moves the marker; Shift is meaningful (extend / shifted
     /// arrows) and is allowed.
@@ -489,13 +558,17 @@ impl Controller {
                 self.exit_line_select(); // AC-4: close, copy nothing, scroll unchanged
                 return Effects::redraw();
             }
-            // Enter / y / Y all confirm: copy the selection, then close the mode. `y`/`Y` reach here
-            // because line-select routes every key through this handler, so the normal copy-path
-            // bindings would otherwise be inert; wiring them matches the app's `y`/`Y`=copy idiom
-            // (and vim's yank). `Y` arrives as the uppercase char + SHIFT, which the modifier guard
-            // above permits — accepted so holding Shift never makes copy silently fail.
-            KeyCode::Enter | KeyCode::Char('y') | KeyCode::Char('Y') => {
-                return self.copy_line_content(); // AC-9
+            // Two confirms, one selection: `Enter` copies the `path:line` REFERENCE (the shipped
+            // v1.9.0 contract — ready to paste into an agent chat or an issue), while `y`/`Y` copy
+            // the selected CONTENT (the actual text — vim's yank, and the app's `y`=copy idiom;
+            // they reach here because line-select routes every key through this handler). `Y`
+            // arrives as the uppercase char + SHIFT, which the modifier guard above permits —
+            // accepted so holding Shift never makes copy silently fail. Both close the mode.
+            KeyCode::Enter => {
+                return self.copy_line_reference(); // AC-9: the reference, as shipped
+            }
+            KeyCode::Char('y') | KeyCode::Char('Y') => {
+                return self.copy_line_content(); // the content — the PR #78 addition
             }
             _ => {}
         }
@@ -553,6 +626,26 @@ impl Controller {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn single_line_has_no_range_suffix() {
+        assert_eq!(
+            format_line_reference("src/editor.rs", 50, 50),
+            "src/editor.rs:50"
+        );
+    }
+
+    #[test]
+    fn range_normalizes_ascending() {
+        assert_eq!(
+            format_line_reference("src/editor.rs", 50, 58),
+            "src/editor.rs:50-58"
+        );
+        assert_eq!(
+            format_line_reference("src/editor.rs", 58, 50),
+            "src/editor.rs:50-58"
+        );
+    }
 
     #[test]
     fn strip_gutter_removes_number_and_space_keeps_code() {

--- a/src/controller/lineselect.rs
+++ b/src/controller/lineselect.rs
@@ -168,13 +168,10 @@ impl Controller {
         // the deferred (T-6 auto-switch) path are covered — the clear happens when entry begins,
         // not when the (possibly-deferred) modal actually opens.
         self.last_click = None;
-        // Entering L mode drops any ambient content-pane selection so the two overlays never
-        // coexist — L mode gets a fresh line marker rather than inheriting the mouse char span.
+        // Drop any ambient selection AND in-flight drag so L mode starts clean: a still-held ambient
+        // press left `drag = Some(ContentSelect)`, which the mouse drag arm would otherwise honor and
+        // use to extend this freshly-opened L-mode selection from a press never made in L mode.
         self.content_selection = None;
-        // Also drop any in-flight drag: a still-held ambient press left `drag = Some(ContentSelect)`,
-        // and both mouse paths key their drag arm off that variant — without this reset the next
-        // mouse-move would extend the freshly-opened L-mode selection from a press the user never
-        // made in L mode. Clearing it keeps the first L-mode drag inert until a genuine L-mode press.
         self.drag = None;
         let source_mapped = self.selected_view_mode() == Some(ViewMode::SyntaxContent);
         if source_mapped && self.applied_seq == self.latest_seq {
@@ -265,36 +262,28 @@ impl Controller {
         let x = self.geom.content_inner.map_or(0, |c| c.x);
         let display_row = self.content_scroll as usize + row.saturating_sub(top) as usize;
         let line = self.line_at_content_row(display_row).clamp(1, last);
-        // The active overlay may prepend leading glyph column(s), so real content begins that many
-        // columns right of the pane origin; add horizontal scroll, then drop those glyph columns to
-        // index the displayed line. L mode prepends a 1-col ▶/│ gutter glyph; the ambient overlay
-        // prepends none (see `content_overlay_glyph_cols`).
+        // Subtract the active overlay's leading glyph column(s) (see `content_overlay_glyph_cols`)
+        // and the pane origin, add horizontal scroll, to index the displayed line.
         let within = (col.saturating_sub(x)) as usize + self.content_hscroll as usize;
         let disp_col = within.saturating_sub(self.content_overlay_glyph_cols());
         let caret = char_index_at_col(&self.filtered_display_line(line), disp_col);
         (line, caret)
     }
 
-    /// How many leading display columns the ACTIVE content overlay prepends before the real text, so
-    /// a mouse column can be mapped back to a character caret in [`char_at_content_col`]. L
-    /// line-select mode draws a 1-column gutter glyph (▶ marker / │ bar) ahead of every line, so its
-    /// caret math subtracts 1; the ambient selection overlay draws no glyph, so it subtracts 0. The
-    /// L-mode overlay is the only one that prepends a glyph, so this is exactly `line_select_active()`.
+    /// Leading columns the active content overlay prepends before the text, so a mouse column maps
+    /// back to a caret: L mode draws a 1-col ▶/│ gutter glyph, the ambient overlay none — which is
+    /// exactly `line_select_active()`.
     fn content_overlay_glyph_cols(&self) -> usize {
         if self.line_select_active() { 1 } else { 0 }
     }
 
-    /// Auto-copy an ambient content-pane selection to the clipboard on the drag's release, leaving
-    /// the highlight standing for feedback (unlike the L-mode confirm, which closes the mode). Reads
-    /// the char span from [`content_selection`](Controller::content_selection) and builds the text
-    /// with [`char_selection_text`](Self::char_selection_text) — the same per-line gutter strip +
-    /// control-byte scrub (tabs kept) the L-mode copy uses, so code copies clean. Guards the
-    /// no-real-file case like [`copy_line_content`](Self::copy_line_content): a directory / empty
-    /// tree shows first-party guidance ("Directory —" / "No files") with no file node selected, so
-    /// copy nothing then; a collapsed/empty span also copies nothing. (The other placeholder,
-    /// "Rendering…", is shown while a file IS selected, so the file-node guard does NOT catch it —
-    /// the press-time `content_rendering` check in `handle_column_mouse` prevents a selection ever
-    /// being seeded over it.) Read-only: touches only the clipboard and the transient action notice.
+    /// Auto-copy an ambient selection on the drag's release, leaving the highlight standing for
+    /// feedback (the L-mode confirm instead closes the mode). Reuses
+    /// [`char_selection_text`](Self::char_selection_text), so the gutter strip / control-byte scrub
+    /// match the L-mode copy. Copies nothing for a non-file selection (a directory / empty tree shows
+    /// guidance with no file node) or an empty span. NB the `is_file` guard does NOT cover the
+    /// "Rendering…" placeholder (a file *is* selected mid-render) — `handle_column_mouse` blocks
+    /// seeding a selection while a render is in flight instead.
     pub(super) fn copy_content_selection(&mut self) -> Effects {
         let Some((lo, hi)) = self.content_selection.as_ref().map(|s| s.char_span()) else {
             return Effects::redraw();
@@ -317,12 +306,9 @@ impl Controller {
         Effects::redraw()
     }
 
-    /// The number of leading chars the syntax renderer's line-number gutter occupies on 1-based
-    /// source `line` — constant across the source-mapped view, so any line in it measures the same.
-    /// `0` when there is no gutter (plain-text fallback / test stubs) or empty content. Both content
-    /// overlays use it so a character selection's highlight never paints the gutter on continuation
-    /// lines: the L-mode overlay measures it off the marker line, the ambient overlay off its start
-    /// line. `line` is clamped into `[1, line_count]`.
+    /// Width of the syntax renderer's line-number gutter on 1-based source `line` (0 with no gutter —
+    /// plain-text fallback / test stubs — or empty content). Both char-selection overlays subtract it
+    /// so a highlight never paints the gutter. `line` is clamped into `[1, line_count]`.
     pub(crate) fn content_gutter_len(&self, line: usize) -> usize {
         let total = self.content.lines.len();
         if total == 0 {

--- a/src/controller/lineselect.rs
+++ b/src/controller/lineselect.rs
@@ -51,6 +51,16 @@ fn strip_line_gutter(plain: &str, n: usize) -> &str {
     if saw_sep { rest } else { plain }
 }
 
+/// Drop control characters from one line of untrusted file text while keeping `\t`, so
+/// indentation survives the AC-16 scrub. The per-line counterpart of
+/// [`crate::text_layout::sanitize_control`] (which would also eat tabs and newlines); callers
+/// join lines with `\n` AFTER filtering so line structure survives.
+fn filter_control_keep_tabs(s: &str) -> String {
+    s.chars()
+        .filter(|c| !c.is_control() || *c == '\t')
+        .collect()
+}
+
 /// The char index within `s` displayed at 0-based display column `col` — i.e. how many chars sit
 /// to the left of a caret dropped at that column. Used to turn a mouse column into a character
 /// position for click-drag selection. Clamps to the char count when `col` is at/past the end (a
@@ -242,16 +252,54 @@ impl Controller {
         let hi = end.max(1).min(total);
         (lo..=hi)
             .map(|n| {
+                // Prefer the retained SOURCE line (byte-faithful: real tabs, no renderer
+                // decoration, no gutter to strip) — the control filter still applies, since file
+                // bytes are untrusted (AC-16). Fall back to display extraction + gutter strip
+                // when no source is retained (transformed views / providers without it).
+                if let Some(src) = self.source_line(n) {
+                    return filter_control_keep_tabs(src);
+                }
                 let plain = self.filtered_display_line(n);
-                strip_line_gutter(&plain, n).to_string()
+                let gutter = self.gutter_len_of(&plain, n);
+                plain.chars().skip(gutter).collect()
             })
             .collect::<Vec<_>>()
             .join("\n")
     }
 
+    /// The retained raw source text of 1-based displayed line `n`, when the current content is
+    /// source-mapped (see [`RenderResult::source`]); `None` otherwise. `content_source` is applied
+    /// in lockstep with `content`, so `Some` guarantees index `n-1` IS displayed line `n`'s source.
+    fn source_line(&self, n: usize) -> Option<&str> {
+        self.content_source
+            .as_ref()
+            .and_then(|src| src.get(n - 1))
+            .map(String::as_str)
+    }
+
+    /// Width (in chars) of the renderer's line-number gutter on displayed line `n`, given that
+    /// line's already-extracted plain text. **Source-anchored when possible**: the syntax renderer
+    /// emits the source line verbatim after its gutter, so if the displayed line ends with the
+    /// (control-filtered) source text, the gutter is exactly the length difference — no guessing,
+    /// and immune to the heuristic's one false positive (a gutter-less line that happens to start
+    /// with its own line number). When the anchor can't apply — no retained source, or the
+    /// renderer transformed the text (e.g. `bat` expands tabs, so a tab-bearing line won't match)
+    /// — fall back to the self-validating [`strip_line_gutter`] heuristic.
+    fn gutter_len_of(&self, displayed: &str, n: usize) -> usize {
+        if let Some(src) = self.source_line(n) {
+            let src = filter_control_keep_tabs(src);
+            if displayed.ends_with(src.as_str()) {
+                return displayed.chars().count() - src.chars().count();
+            }
+        }
+        let code = strip_line_gutter(displayed, n);
+        displayed.chars().count() - code.chars().count()
+    }
+
     /// The plain text of 1-based source line `n` (its spans joined), with residual control chars
-    /// dropped but `\t` kept. Includes the syntax renderer's gutter — callers strip it with
-    /// [`strip_line_gutter`]. Caller guarantees `n` is in `[1, content.lines.len()]`.
+    /// dropped but `\t` kept. Includes the syntax renderer's gutter — callers strip it via
+    /// [`gutter_len_of`](Self::gutter_len_of). Caller guarantees `n` is in
+    /// `[1, content.lines.len()]`.
     fn filtered_display_line(&self, n: usize) -> String {
         self.content.lines[n - 1]
             .spans
@@ -335,8 +383,7 @@ impl Controller {
         }
         let n = line.clamp(1, total);
         let displayed = self.filtered_display_line(n);
-        let code = strip_line_gutter(&displayed, n);
-        displayed.chars().count() - code.chars().count()
+        self.gutter_len_of(&displayed, n)
     }
 
     /// The gutter width on the L-mode marker line — [`content_gutter_len`](Self::content_gutter_len)
@@ -354,6 +401,12 @@ impl Controller {
     /// line and the carets are re-based into the ungutter'd code, so the copy is source text alone:
     /// the tail of the first line, whole middle lines, and the head of the last, joined by `\n`.
     /// A collapsed selection (same line and caret) yields the empty string.
+    ///
+    /// Deliberately extracts from the DISPLAYED text (what-you-see-is-what-you-copy — the carets
+    /// are display positions, so the copy is exactly the glyphs the user swept), with the gutter
+    /// width source-anchored via [`gutter_len_of`](Self::gutter_len_of). Whole-line copies
+    /// ([`selected_lines_text`](Self::selected_lines_text)) are the byte-faithful, source-backed
+    /// path.
     fn char_selection_text(
         &self,
         (lo_line, lo_col): (usize, usize),
@@ -368,11 +421,8 @@ impl Controller {
         (lo_line..=hi_line)
             .map(|n| {
                 let displayed = self.filtered_display_line(n);
-                let code = strip_line_gutter(&displayed, n);
-                // Chars the gutter occupies (constant across the view, but derive it per line so a
-                // gutter-less renderer yields 0), so a display-char caret maps into the code.
-                let gutter = displayed.chars().count() - code.chars().count();
-                let chars: Vec<char> = code.chars().collect();
+                let gutter = self.gutter_len_of(&displayed, n);
+                let chars: Vec<char> = displayed.chars().skip(gutter).collect();
                 let start = if n == lo_line {
                     lo_col.saturating_sub(gutter)
                 } else {

--- a/src/controller/lineselect.rs
+++ b/src/controller/lineselect.rs
@@ -301,12 +301,12 @@ impl Controller {
     /// [`gutter_len_of`](Self::gutter_len_of). Caller guarantees `n` is in
     /// `[1, content.lines.len()]`.
     fn filtered_display_line(&self, n: usize) -> String {
-        self.content.lines[n - 1]
+        let joined: String = self.content.lines[n - 1]
             .spans
             .iter()
-            .flat_map(|s| s.content.chars())
-            .filter(|c| !c.is_control() || *c == '\t')
-            .collect()
+            .map(|s| s.content.as_ref())
+            .collect();
+        filter_control_keep_tabs(&joined)
     }
 
     /// Map a screen `(col, row)` to a `(source line, char caret)` for mouse selection — used by both
@@ -318,8 +318,10 @@ impl Controller {
     /// `[1, line_count]` for the line and `[0, line_len]` for the caret.
     ///
     /// The char caret is an index into the *displayed* line (gutter included); the copy path strips
-    /// the gutter afterward. Column accounting assumes the unwrapped view (the common case for a
-    /// mouse drag); precise mapping under the `w` wrap override is a follow-up.
+    /// the gutter afterward. Wrap-correct: unwrapped, the column indexes the line directly; under
+    /// wrap, the clicked display row is located within the line via
+    /// [`crate::text_layout::wrap_row_starts`] — the same break-position port the wrapped scroll
+    /// math counts rows with — so the caret lands on the character actually under the cursor.
     pub(crate) fn char_at_content_col(&self, col: u16, row: u16) -> (usize, usize) {
         if self.content.lines.is_empty() {
             return (1, 0); // no content to index (line-select can't open on an empty pane anyway)
@@ -333,8 +335,24 @@ impl Controller {
         // and the pane origin, add horizontal scroll, to index the displayed line.
         let within = (col.saturating_sub(x)) as usize + self.content_hscroll as usize;
         let disp_col = within.saturating_sub(self.content_overlay_glyph_cols());
-        let caret = char_index_at_col(&self.filtered_display_line(line), disp_col);
-        (line, caret)
+        let text = self.filtered_display_line(line);
+        if !self.effective_wrap() {
+            return (line, char_index_at_col(&text, disp_col));
+        }
+        // Under wrap a source line spans several display rows; the caret is the clicked row's
+        // START char (from the same break-position simulation the wrapped scroll math runs on —
+        // `wrap_row_starts` and `wrapped_rows` are one source of truth) plus the column, clamped
+        // into that row's span so a click past a row's end lands at its end, not on the next row.
+        let starts = crate::text_layout::wrap_row_starts(&text, self.content_width.max(1) as usize);
+        let row_within = display_row
+            .saturating_sub(self.content_row_of_line(line))
+            .min(starts.len() - 1); // the wide-glyph floor can inflate the row count past the port's
+        let base = starts[row_within];
+        let seg_end = starts
+            .get(row_within + 1)
+            .copied()
+            .unwrap_or_else(|| text.chars().count());
+        (line, (base + disp_col).min(seg_end))
     }
 
     /// Leading columns the active content overlay prepends before the text, so a mouse column maps
@@ -346,11 +364,11 @@ impl Controller {
 
     /// Auto-copy an ambient selection on the drag's release, leaving the highlight standing for
     /// feedback (the L-mode confirm instead closes the mode). Reuses
-    /// [`char_selection_text`](Self::char_selection_text), so the gutter strip / control-byte scrub
-    /// match the L-mode copy. Copies nothing for a non-file selection (a directory / empty tree shows
-    /// guidance with no file node) or an empty span. NB the `is_file` guard does NOT cover the
-    /// "Rendering…" placeholder (a file *is* selected mid-render) — `handle_column_mouse` blocks
-    /// seeding a selection while a render is in flight instead.
+    /// [`char_selection_text`](Self::char_selection_text), so the gutter handling / control-byte
+    /// scrub match the L-mode copy. Copies nothing for a non-file selection (a directory / empty
+    /// tree shows guidance with no file node) or an empty span. NB the `is_file` guard does NOT
+    /// cover the "Rendering…" placeholder (a file *is* selected mid-render) —
+    /// `handle_column_mouse` blocks seeding a selection while a render is in flight instead.
     pub(super) fn copy_content_selection(&mut self) -> Effects {
         let Some((lo, hi)) = self.content_selection.as_ref().map(|s| s.char_span()) else {
             return Effects::redraw();

--- a/src/controller/lineselect.rs
+++ b/src/controller/lineselect.rs
@@ -32,36 +32,95 @@ fn strip_line_gutter(plain: &str, n: usize) -> &str {
     if saw_sep { rest } else { plain }
 }
 
-/// In-progress line selection on the content pane: `anchor` is where the selection started,
-/// `marker` is the current cursor line. Both are 1-based source-line indices. A plain move
-/// collapses the selection (anchor follows marker); an extend move holds the anchor so the
-/// selection grows/shrinks toward the new marker.
+/// The char index within `s` displayed at 0-based display column `col` — i.e. how many chars sit
+/// to the left of a caret dropped at that column. Used to turn a mouse column into a character
+/// position for click-drag selection. Clamps to the char count when `col` is at/past the end (a
+/// caret at end-of-line).
+///
+/// v1 assumes one display column per char: `bat` expands tabs to spaces before we ever see the
+/// text, and code is overwhelmingly single-width, so `col` maps straight to a char index. Precise
+/// wide-glyph (CJK / emoji) column accounting is a follow-up; it would replace this body with a
+/// width-summing walk without changing the signature.
+fn char_index_at_col(s: &str, col: usize) -> usize {
+    col.min(s.chars().count())
+}
+
+/// In-progress selection on the content pane. `anchor` is where the selection started, `marker`
+/// the current cursor; both are 1-based source-line indices. Two granularities share this state:
+///
+/// - **Line** (keyboard `j`/`k`, Shift-extend): whole source lines. `char_mode` is `false` and the
+///   `*_col` carets are ignored — copy takes full lines.
+/// - **Character** (mouse click-drag): `anchor_col`/`marker_col` are char carets (0-based char
+///   indices into the *displayed* line, gutter included) pairing with `anchor`/`marker`. Set while
+///   `char_mode` is `true` — copy takes the exact `anchor..marker` character span.
+///
+/// A keyboard move reverts to line granularity (`char_mode = false`), so the two never tangle.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct LineSelectState {
     anchor: usize,
     marker: usize,
+    anchor_col: usize,
+    marker_col: usize,
+    char_mode: bool,
 }
 
 impl LineSelectState {
-    /// Start a new selection collapsed onto a single `line`.
+    /// Start a new selection collapsed onto a single `line` (line granularity).
     pub(crate) fn new(line: usize) -> Self {
         Self {
             anchor: line,
             marker: line,
+            anchor_col: 0,
+            marker_col: 0,
+            char_mode: false,
         }
     }
 
+    /// Begin a character-granular selection collapsed at `(line, col)` — a mouse press. `col` is a
+    /// char caret into the displayed line; `line` is clamped to `[1, last]`.
+    pub(crate) fn begin_char(&mut self, line: usize, col: usize, last: usize) {
+        let l = Self::clamp(line, last);
+        self.anchor = l;
+        self.marker = l;
+        self.anchor_col = col;
+        self.marker_col = col;
+        self.char_mode = true;
+    }
+
+    /// Extend a character-granular selection: move the marker to `(line, col)` while holding the
+    /// anchor — a mouse drag. `line` is clamped to `[1, last]`.
+    pub(crate) fn drag_char(&mut self, line: usize, col: usize, last: usize) {
+        self.marker = Self::clamp(line, last);
+        self.marker_col = col;
+        self.char_mode = true;
+    }
+
+    /// Whether the selection is character-granular (a mouse drag), vs. whole-line (keyboard).
+    pub(crate) fn is_char_mode(&self) -> bool {
+        self.char_mode
+    }
+
+    /// The character selection as an ordered `((lo_line, lo_col), (hi_line, hi_col))` pair —
+    /// ascending by line then column, so a drag in either direction reads the same.
+    pub(crate) fn char_span(&self) -> ((usize, usize), (usize, usize)) {
+        let a = (self.anchor, self.anchor_col);
+        let m = (self.marker, self.marker_col);
+        if a <= m { (a, m) } else { (m, a) }
+    }
+
     /// Move the marker to `line` (clamped to `[1, last]`) and collapse the selection onto it —
-    /// the anchor follows the marker.
+    /// the anchor follows the marker. A keyboard move, so it reverts to line granularity.
     pub(crate) fn move_to(&mut self, line: usize, last: usize) {
         self.marker = Self::clamp(line, last);
         self.anchor = self.marker;
+        self.char_mode = false;
     }
 
     /// Move the marker to `line` (clamped to `[1, last]`) while holding the anchor fixed,
-    /// extending (or shrinking) the selection.
+    /// extending (or shrinking) the selection. A keyboard extend, so it reverts to line granularity.
     pub(crate) fn extend_to(&mut self, line: usize, last: usize) {
         self.marker = Self::clamp(line, last);
+        self.char_mode = false;
     }
 
     /// The marker (cursor) line — 1-based. Exposed for the Presenter's line-select overlay (T-9),
@@ -159,23 +218,118 @@ impl Controller {
         let hi = end.max(1).min(total);
         (lo..=hi)
             .map(|n| {
-                let plain: String = self.content.lines[n - 1]
-                    .spans
-                    .iter()
-                    .flat_map(|s| s.content.chars())
-                    .filter(|c| !c.is_control() || *c == '\t')
-                    .collect();
+                let plain = self.filtered_display_line(n);
                 strip_line_gutter(&plain, n).to_string()
             })
             .collect::<Vec<_>>()
             .join("\n")
     }
 
-    /// Copy the CONTENT of the selected lines to the clipboard and close the mode (the `Enter` /
-    /// `y` / `Y` / double-click confirm). Builds the joined line text via
-    /// [`selected_lines_text`](Self::selected_lines_text), copies it, then surfaces a concise
-    /// outcome notice naming the line range — NOT the content itself, which may be many lines
-    /// ("Copied line 5" / "Copied lines 5-8" on `Ok`, a failure message on `Err`, AC-10/AC-11).
+    /// The plain text of 1-based source line `n` (its spans joined), with residual control chars
+    /// dropped but `\t` kept. Includes the syntax renderer's gutter — callers strip it with
+    /// [`strip_line_gutter`]. Caller guarantees `n` is in `[1, content.lines.len()]`.
+    fn filtered_display_line(&self, n: usize) -> String {
+        self.content.lines[n - 1]
+            .spans
+            .iter()
+            .flat_map(|s| s.content.chars())
+            .filter(|c| !c.is_control() || *c == '\t')
+            .collect()
+    }
+
+    /// Map a screen `(col, row)` to a `(source line, char caret)` for mouse selection. The row maps
+    /// to a source line exactly as [`handle_line_select_mouse`](Self::handle_line_select_mouse)
+    /// does; the column subtracts the pane origin and the one-column selection glyph the overlay
+    /// prepends, adds any horizontal scroll, then resolves to a char caret in the displayed line.
+    /// Clamped to `[1, line_count]` for the line and `[0, line_len]` for the caret.
+    ///
+    /// The char caret is an index into the *displayed* line (gutter included); the copy path strips
+    /// the gutter afterward. Column accounting assumes the unwrapped view (the common case for a
+    /// mouse drag); precise mapping under the `w` wrap override is a follow-up.
+    pub(crate) fn char_at_content_col(&self, col: u16, row: u16) -> (usize, usize) {
+        if self.content.lines.is_empty() {
+            return (1, 0); // no content to index (line-select can't open on an empty pane anyway)
+        }
+        let last = self.content.lines.len();
+        let top = self.geom.content_inner.map_or(row, |c| c.y);
+        let x = self.geom.content_inner.map_or(0, |c| c.x);
+        let display_row = self.content_scroll as usize + row.saturating_sub(top) as usize;
+        let line = self.line_at_content_row(display_row).clamp(1, last);
+        // The overlay prepends a 1-col glyph, so real content begins one column right of the pane
+        // origin; add horizontal scroll, then drop that glyph column to index the displayed line.
+        let within = (col.saturating_sub(x)) as usize + self.content_hscroll as usize;
+        let disp_col = within.saturating_sub(1);
+        let caret = char_index_at_col(&self.filtered_display_line(line), disp_col);
+        (line, caret)
+    }
+
+    /// The number of leading chars the syntax renderer's line-number gutter occupies — constant
+    /// across the source-mapped view, so it's measured off the marker line. `0` when there is no
+    /// gutter (plain-text fallback / test stubs), no line-select, or empty content. The Presenter
+    /// uses it so a character selection's highlight never paints the gutter on continuation lines.
+    pub(crate) fn selection_gutter_len(&self) -> usize {
+        let Some(s) = self.modal.line_select() else {
+            return 0;
+        };
+        let total = self.content.lines.len();
+        if total == 0 {
+            return 0;
+        }
+        let n = s.marker().clamp(1, total);
+        let displayed = self.filtered_display_line(n);
+        let code = strip_line_gutter(&displayed, n);
+        displayed.chars().count() - code.chars().count()
+    }
+
+    /// The text of a character-granular selection from `(lo_line, lo_col)` to `(hi_line, hi_col)`
+    /// (both ordered ascending, char carets into the displayed line). The gutter is stripped per
+    /// line and the carets are re-based into the ungutter'd code, so the copy is source text alone:
+    /// the tail of the first line, whole middle lines, and the head of the last, joined by `\n`.
+    /// A collapsed selection (same line and caret) yields the empty string.
+    fn char_selection_text(
+        &self,
+        (lo_line, lo_col): (usize, usize),
+        (hi_line, hi_col): (usize, usize),
+    ) -> String {
+        let total = self.content.lines.len();
+        if total == 0 {
+            return String::new();
+        }
+        let lo_line = lo_line.clamp(1, total);
+        let hi_line = hi_line.clamp(1, total);
+        (lo_line..=hi_line)
+            .map(|n| {
+                let displayed = self.filtered_display_line(n);
+                let code = strip_line_gutter(&displayed, n);
+                // Chars the gutter occupies (constant across the view, but derive it per line so a
+                // gutter-less renderer yields 0), so a display-char caret maps into the code.
+                let gutter = displayed.chars().count() - code.chars().count();
+                let chars: Vec<char> = code.chars().collect();
+                let start = if n == lo_line {
+                    lo_col.saturating_sub(gutter)
+                } else {
+                    0
+                };
+                let end = if n == hi_line {
+                    hi_col.saturating_sub(gutter)
+                } else {
+                    chars.len()
+                };
+                let start = start.min(chars.len());
+                let end = end.min(chars.len()).max(start);
+                chars[start..end].iter().collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    /// Copy the selected content to the clipboard and close the mode (the `Enter` / `y` / `Y`
+    /// confirm). Whole lines for a keyboard (line-granular) selection via
+    /// [`selected_lines_text`](Self::selected_lines_text), or the exact character span for a mouse
+    /// drag via [`char_selection_text`](Self::char_selection_text). Surfaces a concise outcome
+    /// notice — the line range or "selection", NOT the content itself, which may be many lines
+    /// ("Copied line 5" / "Copied lines 5-8" / "Copied selection" on `Ok`; a failure message on
+    /// `Err`, AC-10/AC-11).
     ///
     /// Guards the no-real-file case: the mode can be open without a selected *file* node (the T-4
     /// guidance screen is non-empty), so if there is no active selection or the selected node is
@@ -199,11 +353,33 @@ impl Controller {
             return Effects::noop();
         }
 
-        let text = self.selected_lines_text(start, end);
-        let label = if start == end {
-            format!("line {start}")
-        } else {
-            format!("lines {start}-{end}")
+        // Character granularity (a mouse drag) copies the exact selected span; line granularity
+        // (keyboard) copies whole lines. A collapsed character selection (a plain click, nothing
+        // dragged) falls back to copying the clicked line, so click-then-Enter still yields a line.
+        let char_span = self
+            .modal
+            .line_select()
+            .filter(|s| s.is_char_mode())
+            .map(|s| s.char_span());
+        let (text, label) = match char_span {
+            Some((lo, hi)) => {
+                let text = self.char_selection_text(lo, hi);
+                if text.is_empty() {
+                    let marker = self.line_selection().map_or(start, |(_, e)| e);
+                    (self.selected_lines_text(marker, marker), format!("line {marker}"))
+                } else {
+                    (text, "selection".to_string())
+                }
+            }
+            None => {
+                let text = self.selected_lines_text(start, end);
+                let label = if start == end {
+                    format!("line {start}")
+                } else {
+                    format!("lines {start}-{end}")
+                };
+                (text, label)
+            }
         };
         self.action_notice = Some(match self.clipboard.copy(&text) {
             Ok(()) => format!("Copied {label}"),
@@ -242,7 +418,7 @@ impl Controller {
     /// reports Shift+letter as the **uppercase char** (`J`/`K`) and Shift+arrow as the arrow key
     /// plus `KeyModifiers::SHIFT`, so both spellings are accepted. `move_to`/`extend_to` clamp
     /// the target to `[1, last]` (AC-6). After any move the content pane scrolls so the marker
-    /// stays visible (AC-7). `Esc` exits without copying (AC-4); `Enter` copies the selected lines'
+    /// stays visible (AC-7). `Esc` exits without copying (AC-4); `Enter` copies the selected
     /// content and closes the mode; `y`/`Y` do the same (the familiar copy keys)
     /// ([`copy_line_content`](Self::copy_line_content), AC-9). Any other key
     /// is inert. Ctrl/Alt chords are rejected up
@@ -261,11 +437,11 @@ impl Controller {
                 self.exit_line_select(); // AC-4: close, copy nothing, scroll unchanged
                 return Effects::redraw();
             }
-            // Enter / y / Y all confirm: copy the selected lines' content, then close the mode.
-            // `y`/`Y` reach here because line-select routes every key through this handler, so the
-            // normal copy-path bindings would otherwise be inert; wiring them here matches the
-            // muscle memory of "y copies". `Y` arrives as the uppercase char + SHIFT, which the
-            // modifier guard above permits.
+            // Enter / y / Y all confirm: copy the selection, then close the mode. `y`/`Y` reach here
+            // because line-select routes every key through this handler, so the normal copy-path
+            // bindings would otherwise be inert; wiring them matches the app's `y`/`Y`=copy idiom
+            // (and vim's yank). `Y` arrives as the uppercase char + SHIFT, which the modifier guard
+            // above permits — accepted so holding Shift never makes copy silently fail.
             KeyCode::Enter | KeyCode::Char('y') | KeyCode::Char('Y') => {
                 return self.copy_line_content(); // AC-9
             }
@@ -360,6 +536,40 @@ mod tests {
         // Leading digits equal to `n` but with no separator (code that just starts with them) →
         // unchanged, so we never eat real content.
         assert_eq!(strip_line_gutter("5000 loops", 5), "5000 loops");
+    }
+
+    #[test]
+    fn char_index_at_col_maps_column_to_char_and_clamps() {
+        assert_eq!(char_index_at_col("hello", 0), 0);
+        assert_eq!(char_index_at_col("hello", 3), 3);
+        // Past the end clamps to a caret at end-of-line.
+        assert_eq!(char_index_at_col("hello", 99), 5);
+        assert_eq!(char_index_at_col("", 4), 0);
+    }
+
+    #[test]
+    fn char_span_orders_by_line_then_column() {
+        // Anchor after marker on the same line → ordered ascending by column.
+        let mut s = LineSelectState::new(3);
+        s.begin_char(3, 7, 10);
+        s.drag_char(3, 2, 10);
+        assert_eq!(s.char_span(), ((3, 2), (3, 7)));
+        assert!(s.is_char_mode());
+
+        // Anchor on a later line than the marker → ordered ascending by line.
+        let mut s = LineSelectState::new(5);
+        s.begin_char(5, 1, 10);
+        s.drag_char(2, 9, 10);
+        assert_eq!(s.char_span(), ((2, 9), (5, 1)));
+    }
+
+    #[test]
+    fn keyboard_move_reverts_to_line_mode() {
+        let mut s = LineSelectState::new(1);
+        s.begin_char(1, 4, 10);
+        assert!(s.is_char_mode(), "a mouse press is character-granular");
+        s.move_to(3, 10);
+        assert!(!s.is_char_mode(), "a keyboard move reverts to line granularity");
     }
 
     #[test]

--- a/src/controller/lineselect.rs
+++ b/src/controller/lineselect.rs
@@ -286,12 +286,22 @@ impl Controller {
     /// renderer transformed the text (e.g. `bat` expands tabs, so a tab-bearing line won't match)
     /// — fall back to the self-validating [`strip_line_gutter`] heuristic.
     fn gutter_len_of(&self, displayed: &str, n: usize) -> usize {
-        if let Some(src) = self.source_line(n) {
-            let src = filter_control_keep_tabs(src);
-            if displayed.ends_with(src.as_str()) {
-                return displayed.chars().count() - src.chars().count();
-            }
+        // A line-number gutter exists ONLY behind a `SyntaxContent` render (`bat --style=numbers`),
+        // which is exactly when the raw source is retained (see `RenderResult::source`). Every
+        // other view (rendered markdown, diff, plain-text fallback, binary) has NO gutter and no
+        // source, so there is nothing to strip: return 0 rather than run the digit heuristic, which
+        // would otherwise drop a legitimate leading "N " from a copied line that happens to begin
+        // with its own display-line number.
+        let Some(src) = self.source_line(n) else {
+            return 0;
+        };
+        let src = filter_control_keep_tabs(src);
+        if displayed.ends_with(src.as_str()) {
+            return displayed.chars().count() - src.chars().count();
         }
+        // Source retained but the renderer transformed the line (e.g. `bat` expanded tabs, so it no
+        // longer ends with the raw source): the gutter is real but unanchorable, so fall back to
+        // the self-validating digit heuristic.
         let code = strip_line_gutter(displayed, n);
         displayed.chars().count() - code.chars().count()
     }
@@ -331,19 +341,32 @@ impl Controller {
         let x = self.geom.content_inner.map_or(0, |c| c.x);
         let display_row = self.content_scroll as usize + row.saturating_sub(top) as usize;
         let line = self.line_at_content_row(display_row).clamp(1, last);
-        // Subtract the active overlay's leading glyph column(s) (see `content_overlay_glyph_cols`)
-        // and the pane origin, add horizontal scroll, to index the displayed line.
+        // The pane-relative column, plus any horizontal scroll. The active overlay's leading glyph
+        // column(s) (see `content_overlay_glyph_cols`) are subtracted per display row below — they
+        // sit on the FIRST row only.
         let within = (col.saturating_sub(x)) as usize + self.content_hscroll as usize;
-        let disp_col = within.saturating_sub(self.content_overlay_glyph_cols());
+        let overlay = self.content_overlay_glyph_cols();
         let text = self.filtered_display_line(line);
         if !self.effective_wrap() {
-            return (line, char_index_at_col(&text, disp_col));
+            // The whole line is display row 0, so the overlay glyph precedes it.
+            return (
+                line,
+                char_index_at_col(&text, within.saturating_sub(overlay)),
+            );
         }
         // Under wrap a source line spans several display rows; the caret is the clicked row's
-        // START char (from the same break-position simulation the wrapped scroll math runs on —
-        // `wrap_row_starts` and `wrapped_rows` are one source of truth) plus the column, clamped
-        // into that row's span so a click past a row's end lands at its end, not on the next row.
-        let starts = crate::text_layout::wrap_row_starts(&text, self.content_width.max(1) as usize);
+        // START char (from `wrap_row_starts_prefixed` — the SAME glyph-aware break simulation the
+        // wrapped scroll/row-count math runs on, one source of truth) plus the column, clamped into
+        // that row's span so a click past a row's end lands at its end, not on the next row. The
+        // overlay glyph occupies a column on the FIRST display row only (ratatui renders it glued
+        // to the text, continuation rows carry none), so it is subtracted from the column on row 0
+        // and NOT on continuation rows — its effect on where later rows break is already baked into
+        // the prefixed break positions.
+        let starts = crate::text_layout::wrap_row_starts_prefixed(
+            &text,
+            self.content_width.max(1) as usize,
+            overlay,
+        );
         let row_within = display_row
             .saturating_sub(self.content_row_of_line(line))
             .min(starts.len() - 1); // the wide-glyph floor can inflate the row count past the port's
@@ -352,13 +375,19 @@ impl Controller {
             .get(row_within + 1)
             .copied()
             .unwrap_or_else(|| text.chars().count());
-        (line, (base + disp_col).min(seg_end))
+        let col_in_row = if row_within == 0 {
+            within.saturating_sub(overlay)
+        } else {
+            within
+        };
+        (line, (base + col_in_row).min(seg_end))
     }
 
     /// Leading columns the active content overlay prepends before the text, so a mouse column maps
     /// back to a caret: L mode draws a 1-col ▶/│ gutter glyph, the ambient overlay none — which is
-    /// exactly `line_select_active()`.
-    fn content_overlay_glyph_cols(&self) -> usize {
+    /// exactly `line_select_active()`. `pub(super)` so the shared wrapped-row math in the parent
+    /// module ([`wrapped_rows_before`]/[`line_at_content_row`]) counts the L-mode glyph too.
+    pub(super) fn content_overlay_glyph_cols(&self) -> usize {
         if self.line_select_active() { 1 } else { 0 }
     }
 

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -411,6 +411,16 @@ pub struct Controller {
     /// What the held left button is dragging (divider resize or a scrollbar), so the release is
     /// treated as the end of the drag, not a click. `None` ⇒ no drag in progress.
     drag: Option<Drag>,
+    /// An ambient character-granular text selection dragged out in the content pane during normal
+    /// navigation — held OUTSIDE [`Modal`] so `Modal::None` stays in force and every keyboard
+    /// binding keeps its normal meaning (that is what makes it ambient, not a mode). Reuses the
+    /// [`LineSelectState`] char primitives (`begin_char`/`drag_char`/`char_span`), always in
+    /// char-mode. Mutually exclusive with L line-select mode by construction: this is created only
+    /// in `handle_column_mouse` (which runs only for `Modal::None`), and entering L mode clears it.
+    /// Copied automatically on the drag's release; drawn by a gutter-less presenter overlay. `None`
+    /// ⇒ no ambient selection. Cleared on any content change (`dispatch_render`/`poll`), Esc, a
+    /// click-away, a plain collapsed click, or entering L mode.
+    content_selection: Option<LineSelectState>,
     /// The newer version to advertise, if any (set from the cached value at startup and
     /// refreshed by the background check). `None` ⇒ up-to-date / unknown.
     update_available: Option<Version>,
@@ -558,6 +568,7 @@ impl Controller {
             geom: PaneGeometry::default(),
             last_click: None,
             drag: None,
+            content_selection: None,
             update_available: None,
             update_dismissed: false,
             update_rx: None,
@@ -1030,6 +1041,28 @@ impl Controller {
                     char_sel,
                 }
             }),
+            // The ambient content-pane selection (a mouse drag with no modal open). Snapshotted
+            // only when non-collapsed (a real drag, not a bare click) so a click never paints a
+            // zero-width highlight. It is mutually exclusive with `line_select` by construction, but
+            // `draw_content` still gives `line_select` precedence, so at most one overlay draws. The
+            // gutter is measured off the selection's start line via `content_gutter_len`.
+            content_selection: self
+                .content_selection
+                .as_ref()
+                .filter(|s| {
+                    let (a, b) = s.char_span();
+                    a != b
+                })
+                .map(|s| {
+                    let ((sl, sc), (el, ec)) = s.char_span();
+                    CharSelView {
+                        start_line: sl,
+                        start_col: sc,
+                        end_line: el,
+                        end_col: ec,
+                        gutter: self.content_gutter_len(sl),
+                    }
+                }),
             help: self.help_view(),
         }
     }
@@ -1636,6 +1669,15 @@ impl Controller {
     /// then un-zoom if zoomed, then quit. So from a committed search the sequence is:
     /// Esc → clears the search; Esc again → un-zooms (if zoomed) or quits. (AC-20, owner UX.)
     fn close_or_unzoom(&mut self) -> Effects {
+        // An ambient content-pane selection is dismissed FIRST: Esc "drops the highlight" before it
+        // comes out of a search, unzooms, or quits (the outermost layer of the same Esc stack).
+        // `take()` clears it in one step; a standing selection swallows this Esc and nothing else
+        // changes. The only other state this can catch is a collapsed selection held between a
+        // press and its first drag (mouse physically down while Esc is pressed) — swallowing that
+        // Esc is harmless, and the subsequent release then finds `None` and falls through to a click.
+        if self.content_selection.take().is_some() {
+            return Effects::redraw();
+        }
         // A committed search (prompt closed, highlights persisting) is dismissed first — Esc/q
         // "come out of the search" before they unzoom or close (layered like unzoom). (owner UX)
         if self.search.is_some() && !self.prompt_open() {
@@ -1825,6 +1867,13 @@ impl Controller {
         // `self.search` directly — it does NOT call `dispatch_render` — so live typing is NOT
         // wiped by this clear.
         self.search = None;
+        // Any displayed-content change also drops an ambient content-pane selection: its
+        // source-line/char coordinates are only meaningful against the content they were dragged
+        // over, so a stale highlight must not map onto the new body (a later copy would read the
+        // wrong text). This one hook covers file-select, view-cycle, baseline-toggle, refresh,
+        // re-root, and the editor-return path (all funnel through here). Content SCROLLING keeps
+        // the selection — it does not call `dispatch_render`, and the coordinates stay valid.
+        self.content_selection = None;
 
         let Some(node) = self.tree.selected() else {
             // No visible node: an empty tree or a filter (changed-only, gitignore, etc.)
@@ -1890,6 +1939,11 @@ impl Controller {
         while let Ok((seq, result)) = self.result_rx.try_recv() {
             if seq == self.latest_seq {
                 self.content = result.content;
+                // A selection dragged over the "Rendering…" placeholder must not survive onto the
+                // freshly-landed body (its coordinates were relative to the placeholder text).
+                // `dispatch_render` cleared it at dispatch time; this covers the placeholder→land
+                // window, where a drag could have started after the dispatch cleared it.
+                self.content_selection = None;
                 self.content_notices = result.notices;
                 self.applied_seq = seq; // the displayed content is now this render (go-to-line guard)
                 // the body has landed — now switch the title to match it. The latest

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -426,8 +426,9 @@ pub struct Controller {
     /// An ambient character selection dragged out in the content pane during normal navigation, held
     /// OUTSIDE [`Modal`] so `Modal::None` stays in force and every keyboard binding keeps its normal
     /// meaning — that is what makes it ambient, not a mode. Reuses the [`LineSelectState`] char
-    /// primitives (always char-mode). Mutually exclusive with L line-select mode by construction:
-    /// created only in `handle_column_mouse`, which runs only for `Modal::None`. Auto-copied on release.
+    /// primitives (always char-mode; `char_at_content_col` maps wrapped views too). Mutually
+    /// exclusive with L line-select mode by construction: created only in `handle_column_mouse`,
+    /// which runs only for `Modal::None`. Auto-copied on release.
     content_selection: Option<LineSelectState>,
     /// The newer version to advertise, if any (set from the cached value at startup and
     /// refreshed by the background check). `None` ⇒ up-to-date / unknown.
@@ -2102,8 +2103,9 @@ enum Drag {
     TreeH,
     /// Dragging the finder overlay's vertical scrollbar (handled in `handle_finder_mouse`).
     FinderV,
-    /// Dragging out a character-granular text selection in the content pane while line-select mode
-    /// is active (handled in `handle_line_select_mouse`).
+    /// Dragging out a character-granular text selection in the content pane — in L mode (handled
+    /// in `handle_line_select_mouse`, on the modal's state) or ambient (handled in
+    /// `handle_column_mouse`, on `content_selection`; the release auto-copies).
     ContentSelect,
 }
 

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -1310,11 +1310,12 @@ impl Controller {
     /// computed by the SAME wrapping logic and therefore always agree (AC-3/AC-4).
     fn wrapped_rows_before(&self, n: usize) -> usize {
         let w = self.content_width as usize;
+        let overlay = self.content_overlay_glyph_cols();
         self.content
             .lines
             .iter()
             .take(n)
-            .map(|l| crate::text_layout::line_wrapped_rows(l, w))
+            .map(|l| crate::text_layout::line_wrapped_rows_prefixed(l, w, overlay))
             .sum::<usize>()
     }
 
@@ -1344,9 +1345,10 @@ impl Controller {
             return row + 1;
         }
         let w = self.content_width as usize;
+        let overlay = self.content_overlay_glyph_cols();
         let mut acc = 0usize;
         for (i, line) in self.content.lines.iter().enumerate() {
-            acc += crate::text_layout::line_wrapped_rows(line, w);
+            acc += crate::text_layout::line_wrapped_rows_prefixed(line, w, overlay);
             if row < acc {
                 return i + 1;
             }

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -98,6 +98,13 @@ pub trait GitService: Send + Sync {
 pub struct RenderResult {
     pub content: Text<'static>,
     pub notices: Vec<String>,
+    /// The raw SOURCE lines behind a source-mapped (`SyntaxContent`) render — the file text the
+    /// renderer was fed, split into lines, 1:1 with `content.lines` — so the copy paths can
+    /// produce byte-faithful text (real tabs, no renderer decoration) and anchor the gutter
+    /// width exactly instead of heuristically. `None` for transformed views (markdown / diffs,
+    /// where no per-display-line source exists) and for providers that don't supply it; the
+    /// copy paths then fall back to display-text extraction.
+    pub source: Option<Vec<String>>,
 }
 
 /// Produce the content-pane text for `(file, mode)`. `Send` so a later task can run it on a
@@ -372,6 +379,11 @@ pub struct Controller {
     /// The content pane's current text and its notices (truncation/fallback).
     content: Text<'static>,
     content_notices: Vec<String>,
+    /// The raw source lines behind the displayed content when it is source-mapped
+    /// (`SyntaxContent`), 1:1 with `content.lines` — see [`RenderResult::source`]. Applied and
+    /// cleared in lockstep with `content` (`poll` / `clear_content`), so the copy paths can trust
+    /// that when it is `Some`, index `n-1` IS displayed line `n`'s source.
+    content_source: Option<Vec<String>>,
     /// The path of the file whose content is currently displayed in the pane — the title's
     /// source of truth, so the border label switches in lockstep with the body. `None`
     /// while no file's content has landed yet (launch, a re-root, or a directory/empty tree
@@ -550,6 +562,7 @@ impl Controller {
             overrides: HashMap::new(),
             content: Text::raw(""),
             content_notices: Vec::new(),
+            content_source: None,
             content_path: None,
             content_rendering: false,
             action_notice: None,
@@ -626,6 +639,7 @@ impl Controller {
                 .unwrap_or_else(|_| RenderResult {
                     content: Text::raw("[content unavailable — renderer error]"),
                     notices: vec!["the renderer failed unexpectedly; showing a placeholder".into()],
+                    source: None,
                 });
                 if result_tx.send((job.seq, result)).is_err() {
                     break; // controller gone
@@ -1899,6 +1913,7 @@ impl Controller {
         {
             self.content = Text::raw("Rendering\u{2026}");
             self.content_notices.clear();
+            self.content_source = None; // the placeholder has no source; the landing render brings its own
             self.content_rendering = true;
         }
     }
@@ -1910,6 +1925,7 @@ impl Controller {
     fn clear_content(&mut self, reason: EmptyReason) {
         self.content = Text::raw(reason.label());
         self.content_notices.clear();
+        self.content_source = None; // guidance text has no source behind it
         // No file content is displayed for a directory/empty tree, and no render is in flight
         // (this path sends no `RenderJob`), so the title falls back to the selected node's name
         //.
@@ -1929,6 +1945,7 @@ impl Controller {
                 // dispatch_render's clear must not carry its stale coordinates onto the new body.
                 self.content_selection = None;
                 self.content_notices = result.notices;
+                self.content_source = result.source; // in lockstep with `content` (copy fidelity)
                 self.applied_seq = seq; // the displayed content is now this render (go-to-line guard)
                 // the body has landed — now switch the title to match it. The latest
                 // dispatched render always corresponds to the current tree selection (every

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -411,15 +411,11 @@ pub struct Controller {
     /// What the held left button is dragging (divider resize or a scrollbar), so the release is
     /// treated as the end of the drag, not a click. `None` ⇒ no drag in progress.
     drag: Option<Drag>,
-    /// An ambient character-granular text selection dragged out in the content pane during normal
-    /// navigation — held OUTSIDE [`Modal`] so `Modal::None` stays in force and every keyboard
-    /// binding keeps its normal meaning (that is what makes it ambient, not a mode). Reuses the
-    /// [`LineSelectState`] char primitives (`begin_char`/`drag_char`/`char_span`), always in
-    /// char-mode. Mutually exclusive with L line-select mode by construction: this is created only
-    /// in `handle_column_mouse` (which runs only for `Modal::None`), and entering L mode clears it.
-    /// Copied automatically on the drag's release; drawn by a gutter-less presenter overlay. `None`
-    /// ⇒ no ambient selection. Cleared on any content change (`dispatch_render`/`poll`), Esc, a
-    /// click-away, a plain collapsed click, or entering L mode.
+    /// An ambient character selection dragged out in the content pane during normal navigation, held
+    /// OUTSIDE [`Modal`] so `Modal::None` stays in force and every keyboard binding keeps its normal
+    /// meaning — that is what makes it ambient, not a mode. Reuses the [`LineSelectState`] char
+    /// primitives (always char-mode). Mutually exclusive with L line-select mode by construction:
+    /// created only in `handle_column_mouse`, which runs only for `Modal::None`. Auto-copied on release.
     content_selection: Option<LineSelectState>,
     /// The newer version to advertise, if any (set from the cached value at startup and
     /// refreshed by the background check). `None` ⇒ up-to-date / unknown.
@@ -1041,11 +1037,8 @@ impl Controller {
                     char_sel,
                 }
             }),
-            // The ambient content-pane selection (a mouse drag with no modal open). Snapshotted
-            // only when non-collapsed (a real drag, not a bare click) so a click never paints a
-            // zero-width highlight. It is mutually exclusive with `line_select` by construction, but
-            // `draw_content` still gives `line_select` precedence, so at most one overlay draws. The
-            // gutter is measured off the selection's start line via `content_gutter_len`.
+            // Snapshot the ambient selection only when non-collapsed, so a bare click never paints a
+            // zero-width highlight (`draw_content` gives `line_select` precedence if both were set).
             content_selection: self
                 .content_selection
                 .as_ref()
@@ -1669,12 +1662,8 @@ impl Controller {
     /// then un-zoom if zoomed, then quit. So from a committed search the sequence is:
     /// Esc → clears the search; Esc again → un-zooms (if zoomed) or quits. (AC-20, owner UX.)
     fn close_or_unzoom(&mut self) -> Effects {
-        // An ambient content-pane selection is dismissed FIRST: Esc "drops the highlight" before it
-        // comes out of a search, unzooms, or quits (the outermost layer of the same Esc stack).
-        // `take()` clears it in one step; a standing selection swallows this Esc and nothing else
-        // changes. The only other state this can catch is a collapsed selection held between a
-        // press and its first drag (mouse physically down while Esc is pressed) — swallowing that
-        // Esc is harmless, and the subsequent release then finds `None` and falls through to a click.
+        // Esc drops an ambient selection first — the outermost layer of the Esc stack, ahead of
+        // search / unzoom / quit. (A collapsed selection held mid-press is swallowed too; harmless.)
         if self.content_selection.take().is_some() {
             return Effects::redraw();
         }
@@ -1867,12 +1856,9 @@ impl Controller {
         // `self.search` directly — it does NOT call `dispatch_render` — so live typing is NOT
         // wiped by this clear.
         self.search = None;
-        // Any displayed-content change also drops an ambient content-pane selection: its
-        // source-line/char coordinates are only meaningful against the content they were dragged
-        // over, so a stale highlight must not map onto the new body (a later copy would read the
-        // wrong text). This one hook covers file-select, view-cycle, baseline-toggle, refresh,
-        // re-root, and the editor-return path (all funnel through here). Content SCROLLING keeps
-        // the selection — it does not call `dispatch_render`, and the coordinates stay valid.
+        // Drop an ambient selection on any content change: its line/char coordinates only mean
+        // something against the body it was dragged over, so a stale highlight (and copy) must not
+        // carry onto new content. Scrolling keeps it — it doesn't dispatch, and the coords stay valid.
         self.content_selection = None;
 
         let Some(node) = self.tree.selected() else {
@@ -1939,10 +1925,8 @@ impl Controller {
         while let Ok((seq, result)) = self.result_rx.try_recv() {
             if seq == self.latest_seq {
                 self.content = result.content;
-                // A selection dragged over the "Rendering…" placeholder must not survive onto the
-                // freshly-landed body (its coordinates were relative to the placeholder text).
-                // `dispatch_render` cleared it at dispatch time; this covers the placeholder→land
-                // window, where a drag could have started after the dispatch cleared it.
+                // Covers the placeholder→land window: a selection dragged over "Rendering…" after
+                // dispatch_render's clear must not carry its stale coordinates onto the new body.
                 self.content_selection = None;
                 self.content_notices = result.notices;
                 self.applied_seq = seq; // the displayed content is now this render (go-to-line guard)

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -37,8 +37,8 @@ use crate::infile::{PromptMode, PromptState, SearchState};
 use crate::intent::Intent;
 use crate::picker::PickerState;
 use crate::presenter::{
-    ContentSearch, FinderView, Focus, HelpView, LineSelectView, PaneGeometry, PickerRowView,
-    PickerView, ViewState,
+    CharSelView, ContentSearch, FinderView, Focus, HelpView, LineSelectView, PaneGeometry,
+    PickerRowView, PickerView, ViewState,
 };
 use crate::render::{Prepared, Renderers};
 use crate::root::Resolved;
@@ -950,6 +950,9 @@ impl Controller {
         // mis-sizing the thumb / hiding the bar). Computed with the wrap we already have — no extra
         // tree walk.
         let content_rows = self.rendered_line_count_for(wrap);
+        // Gutter width for a character selection's highlight (0 when not applicable); computed once
+        // here so the line-select snapshot below stays a pure read.
+        let sel_gutter = self.selection_gutter_len();
         ViewState {
             nodes,
             selected,
@@ -1006,10 +1009,25 @@ impl Controller {
             // content path is byte-identical to the prior render (no other snapshot moves).
             line_select: self.modal.line_select().map(|s| {
                 let (start, end) = s.selection();
+                // A mouse drag carries character carets → the overlay highlights just those chars;
+                // a keyboard selection has none → the whole-line highlight.
+                let char_sel = if s.is_char_mode() {
+                    let ((sl, sc), (el, ec)) = s.char_span();
+                    Some(CharSelView {
+                        start_line: sl,
+                        start_col: sc,
+                        end_line: el,
+                        end_col: ec,
+                        gutter: sel_gutter,
+                    })
+                } else {
+                    None
+                };
                 LineSelectView {
                     marker: s.marker(),
                     start,
                     end,
+                    char_sel,
                 }
             }),
             help: self.help_view(),
@@ -2029,6 +2047,9 @@ enum Drag {
     TreeH,
     /// Dragging the finder overlay's vertical scrollbar (handled in `handle_finder_mouse`).
     FinderV,
+    /// Dragging out a character-granular text selection in the content pane while line-select mode
+    /// is active (handled in `handle_line_select_mouse`).
+    ContentSelect,
 }
 
 /// Whether a path names a markdown file (by extension, case-insensitive).

--- a/src/controller/mouse.rs
+++ b/src/controller/mouse.rs
@@ -30,57 +30,76 @@ impl Controller {
         }
     }
 
-    /// Mouse handling while line-select mode owns the pointer (copy-line-reference). The mode is
-    /// keyboard-first, but a click is a natural way to place the marker: a left **release** in the
-    /// content pane ALWAYS moves the marker to the clicked source line (AC-8), regardless of the
-    /// Shift modifier — herdr and most terminals reserve Shift+mouse for native text selection, so
-    /// a shift-click extend can never be relied on to reach the plugin (keyboard `Shift`+`j`/`k`
-    /// is the supported way to extend). A double-click copies the reference and closes the mode
-    /// (AC-9) — mirroring the keyboard move / Enter. Every other event kind (press / drag / wheel)
-    /// is inert, so a click can't start a divider or scrollbar drag while the mode holds the
-    /// mouse. A click outside the content region is inert too and clears any pending double-click,
-    /// so a stray click can't pair a later one across regions.
+    /// Mouse handling while line-select mode owns the pointer. A left **press** in the content pane
+    /// drops the selection caret on the character under the cursor; **dragging** extends a
+    /// character-granular selection (scrolling the pane when the drag runs past an edge); the
+    /// **release** finalizes it, leaving the selection standing for `Enter`/`y` to copy. A press
+    /// with no drag collapses the selection to that character — click-then-`Enter` still copies the
+    /// clicked line (the copy path's collapsed-selection fallback).
+    ///
+    /// `Shift`+mouse is deliberately left untouched (returned inert) so the terminal's OWN native
+    /// selection/copy still works — herdr reserves `Shift`+drag for exactly that, and we don't want
+    /// to swallow it. Every non-left event (wheel, other buttons) is inert so nothing leaks to the
+    /// columns beneath while the mode holds the mouse.
     fn handle_line_select_mouse(&mut self, ev: MouseEvent) -> Effects {
-        // Act only on a completed left-click (consistent with `handle_click`); swallow the rest so
-        // the mode keeps the mouse and no divider/scrollbar drag starts underneath.
-        if ev.kind != MouseEventKind::Up(MouseButton::Left) {
+        // Leave Shift+mouse for the terminal's native selection — never swallow it.
+        if ev.modifiers.contains(KeyModifiers::SHIFT) {
             return Effects::noop();
         }
         let (col, row) = (ev.column, ev.row);
-        if self.hit_test(col, row) != MouseRegion::Content {
-            self.last_click = None; // outside content → inert, and break any pending double-click
-            return Effects::noop();
-        }
-        // Map the clicked screen row to a 1-based source line. The content area's top row is the
-        // content rect's `y`, so the clicked line's display-row offset is `content_scroll + (row -
-        // content_top)`; `line_at_content_row` maps that offset back to a source line, correctly even
-        // when the `w` wrap override is on (a source line then spans several display rows, so the
-        // mapping is NOT 1:1). Clamp into `[1, line_count]`. `hit_test == Content` guarantees
-        // `content_inner` is `Some` and `row >= content_inner.y`, so the subtraction never underflows.
-        let content_top = self.geom.content_inner.map_or(row, |c| c.y);
         let last = self.content.lines.len().max(1);
-        let display_row = self.content_scroll as usize + row.saturating_sub(content_top) as usize;
-        let line = self.line_at_content_row(display_row).clamp(1, last);
-
-        // Reuse the exact click-detection the columns use: same-row within the window is a
-        // double-click, and every non-content click above cleared `last_click`.
-        let now = Instant::now();
-        let double = is_double_click(self.last_click, (col, row), now);
-        self.last_click = Some((col, row, now));
-
-        if double {
-            return self.copy_line_content(); // AC-9: copy the lines' content + close, same as Enter
+        match ev.kind {
+            MouseEventKind::Down(MouseButton::Left) => {
+                // A press outside the content region is inert and drops any in-flight drag.
+                if self.hit_test(col, row) != MouseRegion::Content {
+                    self.drag = None;
+                    return Effects::noop();
+                }
+                let (line, caret) = self.char_at_content_col(col, row);
+                if let Some(state) = self.modal.line_select_mut() {
+                    state.begin_char(line, caret, last);
+                }
+                self.drag = Some(Drag::ContentSelect); // subsequent drags extend the selection
+                Effects::redraw()
+            }
+            MouseEventKind::Drag(MouseButton::Left) => {
+                // Only extend when this drag began as a text selection (a press inside content);
+                // otherwise it's a stray drag we don't own.
+                if !matches!(self.drag, Some(Drag::ContentSelect)) {
+                    return Effects::noop();
+                }
+                let (line, caret) = self.char_at_content_col(col, row);
+                if let Some(state) = self.modal.line_select_mut() {
+                    state.drag_char(line, caret, last);
+                }
+                self.autoscroll_selection(row); // follow the cursor past a viewport edge
+                Effects::redraw()
+            }
+            MouseEventKind::Up(MouseButton::Left) => {
+                // Finalize only a selection drag; a stray release is inert (so it can't be mistaken
+                // for a click that changes state).
+                if matches!(self.drag, Some(Drag::ContentSelect)) {
+                    self.drag = None;
+                    return Effects::redraw();
+                }
+                Effects::noop()
+            }
+            _ => Effects::noop(),
         }
-        if let Some(state) = self.modal.line_select_mut() {
-            // A single click ALWAYS places the marker (collapsing the anchor to the clicked
-            // line), regardless of the Shift modifier: herdr and most terminals reserve
-            // Shift+mouse for their own native text selection, so a shift-click never reliably
-            // reaches the plugin. If one does get through anyway, it harmlessly places the
-            // marker rather than claiming an extend we can't guarantee. Keyboard `Shift`+`j`/`k`
-            // (and Shift+arrows) is the supported way to extend a multi-line selection.
-            state.move_to(line, last); // AC-8: click places the marker
+    }
+
+    /// While dragging out a selection, nudge the content pane one line when the cursor is above the
+    /// top or below the bottom of the text viewport, so the selection can extend past what's on
+    /// screen. Only fires at the edges; a drag inside the viewport leaves the scroll alone.
+    fn autoscroll_selection(&mut self, row: u16) {
+        let Some(c) = self.geom.content_inner else {
+            return;
+        };
+        if row < c.y {
+            self.scroll_content(-1);
+        } else if row >= c.y + c.height {
+            self.scroll_content(1);
         }
-        Effects::redraw()
     }
 
     /// Handle a mouse event over the two columns, with no modal open (the [`handle_mouse`] gate
@@ -129,6 +148,9 @@ impl Controller {
                 // The finder is modal: its scrollbar drag is handled in handle_finder_mouse and
                 // never reaches this (non-finder) path. Covered here only for exhaustiveness.
                 Some(Drag::FinderV) => Effects::noop(),
+                // Text-selection drags belong to line-select mode (handle_line_select_mouse); the
+                // Modal::None gate means this path never sees one. Here only for exhaustiveness.
+                Some(Drag::ContentSelect) => Effects::noop(),
                 None => Effects::noop(),
             },
             MouseEventKind::Up(MouseButton::Left) => {

--- a/src/controller/mouse.rs
+++ b/src/controller/mouse.rs
@@ -118,11 +118,39 @@ impl Controller {
             MouseEventKind::ScrollRight => self.hscroll_at(col, row, HSCROLL_STEP as i32),
             MouseEventKind::ScrollLeft => self.hscroll_at(col, row, -(HSCROLL_STEP as i32)),
             MouseEventKind::Down(MouseButton::Left) => {
-                // A press on the divider begins a resize drag; on a scrollbar it begins a scroll
-                // drag AND jumps to the pressed position (click-to-scroll). Anything else waits for
-                // the release (a click). Always (re)set `drag` from the press — so a stale drag from
-                // a release we never saw (e.g. swallowed by a modal) can't keep acting on later moves.
+                // A press in the content pane begins an ambient character selection (a drag extends
+                // it, the release copies it); on the divider a resize drag; on a scrollbar a scroll
+                // drag AND a jump to the pressed position (click-to-scroll). Anything else waits for
+                // the release (a click) and drops a standing selection (click-away deselect). Always
+                // (re)set `drag` from the press — so a stale drag from a release we never saw (e.g.
+                // swallowed by a modal) can't keep acting on later moves.
                 let region = self.hit_test(col, row);
+                if region == MouseRegion::Content {
+                    // Focus follows the press (like a plain content click), then seed a fresh
+                    // collapsed char selection at the pressed caret. `char_at_content_col` subtracts
+                    // 0 glyph columns here (no modal → no gutter glyph). The Drag arm extends it and
+                    // Up finalizes (collapsed ⇒ it was a click; non-collapsed ⇒ copy).
+                    self.last_click = None;
+                    self.focus = Focus::Content;
+                    self.drag = None;
+                    // While a render is in flight the pane shows the "Rendering…" placeholder, not
+                    // real file text — pressing over it must not seed a selection (a drag would
+                    // otherwise copy the placeholder, which the file-node guard in
+                    // `copy_content_selection` does NOT catch: a file IS selected while it renders).
+                    // The press still focuses the pane; a fresh press after the render lands selects.
+                    if self.content_rendering {
+                        return Effects::redraw();
+                    }
+                    let (line, caret) = self.char_at_content_col(col, row);
+                    let last = self.content.lines.len().max(1);
+                    let mut sel = LineSelectState::new(line);
+                    sel.begin_char(line, caret, last);
+                    self.content_selection = Some(sel);
+                    self.drag = Some(Drag::ContentSelect);
+                    return Effects::redraw();
+                }
+                // A press anywhere outside the content region drops a standing ambient selection.
+                let had_selection = self.content_selection.take().is_some();
                 self.drag = match region {
                     MouseRegion::Divider => Some(Drag::Divider),
                     MouseRegion::ContentVBar => Some(Drag::ContentV),
@@ -131,13 +159,15 @@ impl Controller {
                     MouseRegion::TreeHBar => Some(Drag::TreeH),
                     _ => None,
                 };
-                match region {
+                let fx = match region {
                     MouseRegion::ContentVBar => self.scroll_content_to_row(row),
                     MouseRegion::ContentHBar => self.scroll_content_h_to_col(col),
                     MouseRegion::TreeVBar => self.scroll_tree_to_row(row),
                     MouseRegion::TreeHBar => self.scroll_tree_h_to_col(col),
                     _ => Effects::noop(),
-                }
+                };
+                // A cleared selection needs a repaint even when the press itself was inert.
+                if had_selection { Effects::redraw() } else { fx }
             }
             MouseEventKind::Drag(MouseButton::Left) => match self.drag {
                 Some(Drag::Divider) => self.resize_split_to_col(col),
@@ -148,21 +178,54 @@ impl Controller {
                 // The finder is modal: its scrollbar drag is handled in handle_finder_mouse and
                 // never reaches this (non-finder) path. Covered here only for exhaustiveness.
                 Some(Drag::FinderV) => Effects::noop(),
-                // Text-selection drags belong to line-select mode (handle_line_select_mouse); the
-                // Modal::None gate means this path never sees one. Here only for exhaustiveness.
-                Some(Drag::ContentSelect) => Effects::noop(),
+                // Extend the ambient content-pane selection to the dragged caret, scrolling the pane
+                // when the cursor runs past a viewport edge (mirrors the L-mode drag in
+                // handle_line_select_mouse, but writes the Modal-independent `content_selection`).
+                // The `as_mut` guard makes a stray ContentSelect drag inert.
+                Some(Drag::ContentSelect) => {
+                    let (line, caret) = self.char_at_content_col(col, row);
+                    let last = self.content.lines.len().max(1);
+                    if let Some(sel) = self.content_selection.as_mut() {
+                        sel.drag_char(line, caret, last);
+                    }
+                    self.autoscroll_selection(row);
+                    Effects::redraw()
+                }
                 None => Effects::noop(),
             },
-            MouseEventKind::Up(MouseButton::Left) => {
-                if self.drag.take().is_some() {
-                    // End of a drag, not a click. Clear the pending-click so a tree-row click made
-                    // before the drag can't pair with a later one as a double-click — the drag may
-                    // have scrolled the viewport, so the same screen row now maps to a different node.
+            MouseEventKind::Up(MouseButton::Left) => match self.drag.take() {
+                // End of an ambient content-pane selection drag. A selection still collapsed at
+                // release was a plain click (the press emitted no Drag events): drop it and just
+                // focus the pane, exactly as a bare content click did before. A real (non-collapsed)
+                // selection auto-copies and stays highlighted for feedback.
+                Some(Drag::ContentSelect) => {
+                    let collapsed = self
+                        .content_selection
+                        .as_ref()
+                        .map(|s| {
+                            let (a, b) = s.char_span();
+                            a == b
+                        })
+                        .unwrap_or(true);
                     self.last_click = None;
-                    return Effects::noop();
+                    if collapsed {
+                        self.content_selection = None;
+                        self.focus = Focus::Content;
+                        Effects::redraw()
+                    } else {
+                        self.copy_content_selection()
+                    }
                 }
-                self.handle_click(col, row)
-            }
+                // End of a divider/scrollbar drag, not a click. Clear the pending-click so a
+                // tree-row click made before the drag can't pair with a later one as a double-click
+                // — the drag may have scrolled the viewport, so the same screen row now maps to a
+                // different node.
+                Some(_) => {
+                    self.last_click = None;
+                    Effects::noop()
+                }
+                None => self.handle_click(col, row),
+            },
             _ => Effects::noop(),
         }
     }

--- a/src/controller/mouse.rs
+++ b/src/controller/mouse.rs
@@ -69,7 +69,7 @@ impl Controller {
         self.last_click = Some((col, row, now));
 
         if double {
-            return self.copy_line_reference(); // AC-9: copy + close, same as Enter
+            return self.copy_line_content(); // AC-9: copy the lines' content + close, same as Enter
         }
         if let Some(state) = self.modal.line_select_mut() {
             // A single click ALWAYS places the marker (collapsing the anchor to the clicked

--- a/src/controller/mouse.rs
+++ b/src/controller/mouse.rs
@@ -118,26 +118,21 @@ impl Controller {
             MouseEventKind::ScrollRight => self.hscroll_at(col, row, HSCROLL_STEP as i32),
             MouseEventKind::ScrollLeft => self.hscroll_at(col, row, -(HSCROLL_STEP as i32)),
             MouseEventKind::Down(MouseButton::Left) => {
-                // A press in the content pane begins an ambient character selection (a drag extends
-                // it, the release copies it); on the divider a resize drag; on a scrollbar a scroll
-                // drag AND a jump to the pressed position (click-to-scroll). Anything else waits for
-                // the release (a click) and drops a standing selection (click-away deselect). Always
-                // (re)set `drag` from the press — so a stale drag from a release we never saw (e.g.
-                // swallowed by a modal) can't keep acting on later moves.
+                // A press in the content pane begins an ambient character selection; on the divider a
+                // resize drag; on a scrollbar a scroll drag AND a jump to the pressed position
+                // (click-to-scroll). Anything else waits for the release (a click) and drops a standing
+                // selection (click-away deselect). Always (re)set `drag` from the press — so a stale
+                // drag from a release we never saw (e.g. swallowed by a modal) can't act on later moves.
                 let region = self.hit_test(col, row);
                 if region == MouseRegion::Content {
-                    // Focus follows the press (like a plain content click), then seed a fresh
-                    // collapsed char selection at the pressed caret. `char_at_content_col` subtracts
-                    // 0 glyph columns here (no modal → no gutter glyph). The Drag arm extends it and
-                    // Up finalizes (collapsed ⇒ it was a click; non-collapsed ⇒ copy).
+                    // Seed a fresh collapsed char selection at the pressed caret; the Drag arm
+                    // extends it and Up finalizes (collapsed ⇒ a click; non-collapsed ⇒ copy).
                     self.last_click = None;
                     self.focus = Focus::Content;
                     self.drag = None;
-                    // While a render is in flight the pane shows the "Rendering…" placeholder, not
-                    // real file text — pressing over it must not seed a selection (a drag would
-                    // otherwise copy the placeholder, which the file-node guard in
-                    // `copy_content_selection` does NOT catch: a file IS selected while it renders).
-                    // The press still focuses the pane; a fresh press after the render lands selects.
+                    // But not over the "Rendering…" placeholder: a file *is* selected mid-render, so
+                    // the is-file guard in `copy_content_selection` wouldn't stop a drag from copying
+                    // the placeholder text. (The press still focuses the pane.)
                     if self.content_rendering {
                         return Effects::redraw();
                     }
@@ -178,10 +173,8 @@ impl Controller {
                 // The finder is modal: its scrollbar drag is handled in handle_finder_mouse and
                 // never reaches this (non-finder) path. Covered here only for exhaustiveness.
                 Some(Drag::FinderV) => Effects::noop(),
-                // Extend the ambient content-pane selection to the dragged caret, scrolling the pane
-                // when the cursor runs past a viewport edge (mirrors the L-mode drag in
-                // handle_line_select_mouse, but writes the Modal-independent `content_selection`).
-                // The `as_mut` guard makes a stray ContentSelect drag inert.
+                // Extend the ambient selection to the dragged caret + autoscroll past a viewport edge
+                // — the L-mode drag, but on the Modal-independent `content_selection`.
                 Some(Drag::ContentSelect) => {
                     let (line, caret) = self.char_at_content_col(col, row);
                     let last = self.content.lines.len().max(1);
@@ -194,10 +187,9 @@ impl Controller {
                 None => Effects::noop(),
             },
             MouseEventKind::Up(MouseButton::Left) => match self.drag.take() {
-                // End of an ambient content-pane selection drag. A selection still collapsed at
-                // release was a plain click (the press emitted no Drag events): drop it and just
-                // focus the pane, exactly as a bare content click did before. A real (non-collapsed)
-                // selection auto-copies and stays highlighted for feedback.
+                // End of an ambient drag. Still collapsed ⇒ it was a plain click (no Drag events):
+                // drop it and just focus, as a bare content click did. Non-collapsed ⇒ auto-copy,
+                // keeping the highlight.
                 Some(Drag::ContentSelect) => {
                     let collapsed = self
                         .content_selection

--- a/src/controller/mouse.rs
+++ b/src/controller/mouse.rs
@@ -33,9 +33,12 @@ impl Controller {
     /// Mouse handling while line-select mode owns the pointer. A left **press** in the content pane
     /// drops the selection caret on the character under the cursor; **dragging** extends a
     /// character-granular selection (scrolling the pane when the drag runs past an edge); the
-    /// **release** finalizes it, leaving the selection standing for `Enter`/`y` to copy. A press
-    /// with no drag collapses the selection to that character — click-then-`Enter` still copies the
-    /// clicked line (the copy path's collapsed-selection fallback).
+    /// **release** finalizes it, leaving the selection standing for `Enter` (the `path:line`
+    /// reference) or `y` (the content) to confirm. A press with no drag collapses the selection to
+    /// that character — click-then-`y` still copies the clicked line (the content path's
+    /// collapsed-selection fallback) and click-then-`Enter` its reference. Works under wrap too:
+    /// `char_at_content_col` maps the clicked row through the same break-position simulation the
+    /// wrapped scroll math uses, so the caret lands on the character actually under the cursor.
     ///
     /// `Shift`+mouse is deliberately left untouched (returned inert) so the terminal's OWN native
     /// selection/copy still works — herdr reserves `Shift`+drag for exactly that, and we don't want
@@ -127,6 +130,7 @@ impl Controller {
                 if region == MouseRegion::Content {
                     // Seed a fresh collapsed char selection at the pressed caret; the Drag arm
                     // extends it and Up finalizes (collapsed ⇒ a click; non-collapsed ⇒ copy).
+                    // `char_at_content_col` is wrap-aware, so this works on wrapped prose too.
                     self.last_click = None;
                     self.focus = Focus::Content;
                     self.drag = None;

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -2036,8 +2036,16 @@ mod tests {
         // Two spans "fn " + "main" → chars 0..7; highlight [3, 7) == "main".
         let spans = vec![Span::raw("fn "), Span::raw("main")];
         let out = patch_char_range(&spans, 3, 7, hl);
-        assert_eq!(plain(&out), "fn main", "no characters are lost or reordered");
-        assert_eq!(selected_text(&out, hl), "main", "exactly [3,7) is highlighted");
+        assert_eq!(
+            plain(&out),
+            "fn main",
+            "no characters are lost or reordered"
+        );
+        assert_eq!(
+            selected_text(&out, hl),
+            "main",
+            "exactly [3,7) is highlighted"
+        );
     }
 
     #[test]
@@ -2045,7 +2053,10 @@ mod tests {
         let hl = crate::highlight::HIGHLIGHT;
         let spans = vec![Span::raw("hello")];
         // Open-ended (usize::MAX) highlights to end of line.
-        assert_eq!(selected_text(&patch_char_range(&spans, 2, usize::MAX, hl), hl), "llo");
+        assert_eq!(
+            selected_text(&patch_char_range(&spans, 2, usize::MAX, hl), hl),
+            "llo"
+        );
         // Empty range highlights nothing.
         assert_eq!(selected_text(&patch_char_range(&spans, 3, 3, hl), hl), "");
         assert_eq!(plain(&patch_char_range(&spans, 3, 3, hl)), "hello");

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -116,11 +116,9 @@ pub struct ViewState {
     /// overlay. `None` ⇒ draw the content as-is (byte-identical to today — the `None` arm leaves the
     /// content path untouched, so no other snapshot moves).
     pub line_select: Option<LineSelectView>,
-    /// When `Some`, an ambient character selection was dragged out in the content pane during normal
-    /// navigation (no modal open). The Presenter overlays a gutter-less character highlight — no
-    /// ▶/│ glyph and no content shift, so it reads as a plain text selection rather than a mode.
-    /// Mutually exclusive with [`line_select`](Self::line_select) by construction; `draw_content`
-    /// still gives `line_select` precedence. `None` ⇒ no ambient selection (content drawn as-is).
+    /// When `Some`, an ambient character selection (a content-pane drag, no modal). Drawn as a
+    /// gutter-less highlight — no ▶/│ glyph, no content shift — so it reads as a plain text selection,
+    /// not a mode. `draw_content` gives [`line_select`](Self::line_select) precedence if both are set.
     pub content_selection: Option<CharSelView>,
     /// When `Some`, the in-app help overlay is drawn on top of everything else (AC-1, AC-5).
     /// `None` ⇒ no overlay. Drawn last in [`draw`] so it sits above the picker and finder.
@@ -591,15 +589,11 @@ fn apply_line_select(lines: &[Line<'static>], ls: &LineSelectView) -> Vec<Line<'
         .collect()
 }
 
-/// Overlay an ambient character selection onto the content lines — the gutter-less counterpart of
-/// [`apply_line_select`]'s character branch. For each source line (1-based index `i + 1`) inside the
-/// selection, the selected characters are re-styled with [`crate::highlight::HIGHLIGHT`] via
-/// [`patch_char_range`]; every other line is cloned unchanged. Unlike [`apply_line_select`] it
-/// prepends NO gutter glyph and applies no whole-row style, so the content does not shift and reads
-/// as a plain text selection (there is no marker — an ambient selection has no cursor line). The
-/// boundary rows are partial (`start_col`/`end_col`, never left of the gutter); interior rows
-/// highlight from the gutter to end-of-line. The line count is preserved so `content_rows` stays
-/// valid, and the content text itself is never mutated — spans are cloned, only their style patched.
+/// Overlay an ambient character selection — the gutter-less counterpart of [`apply_line_select`]'s
+/// character branch: it re-styles the selected chars with [`crate::highlight::HIGHLIGHT`] but
+/// prepends NO ▶/│ glyph and no whole-row style, so the content does not shift. Boundary rows are
+/// partial (`start_col`..`end_col`, clamped past the gutter); interior rows run to end-of-line.
+/// Preserves the line count so `content_rows` stays valid.
 fn apply_char_selection(lines: &[Line<'static>], cs: &CharSelView) -> Vec<Line<'static>> {
     lines
         .iter()

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -182,6 +182,21 @@ pub struct LineSelectView {
     pub start: usize,
     /// The ascending selection end (inclusive), 1-based.
     pub end: usize,
+    /// The character-granular selection (a mouse drag), or `None` for a whole-line (keyboard)
+    /// selection. When `Some`, the overlay highlights only the selected characters on the boundary
+    /// lines (and the full code of any interior line) instead of the whole `[start, end]` rows.
+    pub char_sel: Option<CharSelView>,
+}
+
+/// A character-granular selection for the line-select overlay. `*_col` are char carets into the
+/// displayed line (gutter included), ordered ascending by `(line, col)`; `gutter` is the leading
+/// gutter width so continuation lines start their highlight at the code, not the line number.
+pub struct CharSelView {
+    pub start_line: usize,
+    pub start_col: usize,
+    pub end_line: usize,
+    pub end_col: usize,
+    pub gutter: usize,
 }
 
 /// The finder overlay's draw model (an owned snapshot of the controller's finder state).
@@ -523,16 +538,43 @@ fn apply_line_select(lines: &[Line<'static>], ls: &LineSelectView) -> Vec<Line<'
             };
             let mut spans = Vec::with_capacity(line.spans.len() + 1);
             spans.push(Span::styled(glyph.to_string(), style));
-            for s in &line.spans {
-                let patched = if is_marker || in_range {
-                    s.style.patch(style)
-                } else {
-                    s.style
-                };
-                spans.push(Span {
-                    content: s.content.clone(),
-                    style: patched,
-                });
+            match &ls.char_sel {
+                // Character selection: highlight only the selected chars on this row (the boundary
+                // lines get a partial range; interior lines get all of their code). The gutter is
+                // never highlighted — continuation lines start at `cs.gutter`.
+                Some(cs) if in_range => {
+                    let lo = if src == cs.start_line {
+                        cs.start_col.max(cs.gutter)
+                    } else {
+                        cs.gutter
+                    };
+                    let hi = if src == cs.end_line {
+                        cs.end_col
+                    } else {
+                        usize::MAX // to end of line for an interior row
+                    };
+                    spans.extend(patch_char_range(
+                        &line.spans,
+                        lo,
+                        hi,
+                        crate::highlight::HIGHLIGHT,
+                    ));
+                }
+                // Whole-line (keyboard) selection, or a row outside the selection: the original
+                // per-line style patch.
+                _ => {
+                    for s in &line.spans {
+                        let patched = if is_marker || in_range {
+                            s.style.patch(style)
+                        } else {
+                            s.style
+                        };
+                        spans.push(Span {
+                            content: s.content.clone(),
+                            style: patched,
+                        });
+                    }
+                }
             }
             Line {
                 spans,
@@ -541,6 +583,51 @@ fn apply_line_select(lines: &[Line<'static>], ls: &LineSelectView) -> Vec<Line<'
             }
         })
         .collect()
+}
+
+/// Rebuild `spans` so the chars at 0-based char indices `[lo, hi)` carry `style` (patched onto
+/// their existing style) and every other char keeps its own. Splits spans at the range boundaries,
+/// grouping consecutive same-selectedness chars so the output stays compact. Char-indexed (not
+/// byte- or column-indexed) to match the caret coordinates the controller produces.
+fn patch_char_range(
+    spans: &[Span<'static>],
+    lo: usize,
+    hi: usize,
+    style: Style,
+) -> Vec<Span<'static>> {
+    let mut out: Vec<Span<'static>> = Vec::new();
+    let mut idx = 0usize;
+    for s in spans {
+        let mut buf = String::new();
+        let mut buf_selected: Option<bool> = None;
+        for ch in s.content.chars() {
+            let selected = idx >= lo && idx < hi;
+            match buf_selected {
+                Some(b) if b == selected => buf.push(ch),
+                Some(b) => {
+                    out.push(styled_run(&buf, s.style, b, style));
+                    buf.clear();
+                    buf.push(ch);
+                    buf_selected = Some(selected);
+                }
+                None => {
+                    buf.push(ch);
+                    buf_selected = Some(selected);
+                }
+            }
+            idx += 1;
+        }
+        if let Some(b) = buf_selected {
+            out.push(styled_run(&buf, s.style, b, style));
+        }
+    }
+    out
+}
+
+/// A span for one run of chars: the base style, patched with `style` when the run is `selected`.
+fn styled_run(text: &str, base: Style, selected: bool, style: Style) -> Span<'static> {
+    let s = if selected { base.patch(style) } else { base };
+    Span::styled(text.to_string(), s)
 }
 
 /// Border style for a column — highlighted when it holds focus.
@@ -1881,6 +1968,43 @@ fn draw_help_overlay(frame: &mut Frame, area: Rect, help: &HelpView) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Flatten a line's spans to plain text (drops styling) so a test can read the result of
+    /// `patch_char_range` back as a string.
+    fn plain(spans: &[Span<'static>]) -> String {
+        spans.iter().map(|s| s.content.as_ref()).collect()
+    }
+
+    /// The chars a `patch_char_range` result marked selected, in order (the run(s) that carry the
+    /// patched style), so a test can assert exactly which characters were highlighted.
+    fn selected_text(spans: &[Span<'static>], style: Style) -> String {
+        spans
+            .iter()
+            .filter(|s| s.style == Style::new().patch(style))
+            .map(|s| s.content.as_ref())
+            .collect()
+    }
+
+    #[test]
+    fn patch_char_range_highlights_only_the_range_across_spans() {
+        let hl = crate::highlight::HIGHLIGHT;
+        // Two spans "fn " + "main" → chars 0..7; highlight [3, 7) == "main".
+        let spans = vec![Span::raw("fn "), Span::raw("main")];
+        let out = patch_char_range(&spans, 3, 7, hl);
+        assert_eq!(plain(&out), "fn main", "no characters are lost or reordered");
+        assert_eq!(selected_text(&out, hl), "main", "exactly [3,7) is highlighted");
+    }
+
+    #[test]
+    fn patch_char_range_clamps_open_end_and_empty_range() {
+        let hl = crate::highlight::HIGHLIGHT;
+        let spans = vec![Span::raw("hello")];
+        // Open-ended (usize::MAX) highlights to end of line.
+        assert_eq!(selected_text(&patch_char_range(&spans, 2, usize::MAX, hl), hl), "llo");
+        // Empty range highlights nothing.
+        assert_eq!(selected_text(&patch_char_range(&spans, 3, 3, hl), hl), "");
+        assert_eq!(plain(&patch_char_range(&spans, 3, 3, hl)), "hello");
+    }
 
     #[test]
     fn help_body_text_width_is_the_interior_minus_the_scrollbar_gutter() {

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -116,6 +116,12 @@ pub struct ViewState {
     /// overlay. `None` ⇒ draw the content as-is (byte-identical to today — the `None` arm leaves the
     /// content path untouched, so no other snapshot moves).
     pub line_select: Option<LineSelectView>,
+    /// When `Some`, an ambient character selection was dragged out in the content pane during normal
+    /// navigation (no modal open). The Presenter overlays a gutter-less character highlight — no
+    /// ▶/│ glyph and no content shift, so it reads as a plain text selection rather than a mode.
+    /// Mutually exclusive with [`line_select`](Self::line_select) by construction; `draw_content`
+    /// still gives `line_select` precedence. `None` ⇒ no ambient selection (content drawn as-is).
+    pub content_selection: Option<CharSelView>,
     /// When `Some`, the in-app help overlay is drawn on top of everything else (AC-1, AC-5).
     /// `None` ⇒ no overlay. Drawn last in [`draw`] so it sits above the picker and finder.
     pub help: Option<HelpView>,
@@ -585,6 +591,43 @@ fn apply_line_select(lines: &[Line<'static>], ls: &LineSelectView) -> Vec<Line<'
         .collect()
 }
 
+/// Overlay an ambient character selection onto the content lines — the gutter-less counterpart of
+/// [`apply_line_select`]'s character branch. For each source line (1-based index `i + 1`) inside the
+/// selection, the selected characters are re-styled with [`crate::highlight::HIGHLIGHT`] via
+/// [`patch_char_range`]; every other line is cloned unchanged. Unlike [`apply_line_select`] it
+/// prepends NO gutter glyph and applies no whole-row style, so the content does not shift and reads
+/// as a plain text selection (there is no marker — an ambient selection has no cursor line). The
+/// boundary rows are partial (`start_col`/`end_col`, never left of the gutter); interior rows
+/// highlight from the gutter to end-of-line. The line count is preserved so `content_rows` stays
+/// valid, and the content text itself is never mutated — spans are cloned, only their style patched.
+fn apply_char_selection(lines: &[Line<'static>], cs: &CharSelView) -> Vec<Line<'static>> {
+    lines
+        .iter()
+        .enumerate()
+        .map(|(i, line)| {
+            let src = i + 1; // 1-based source line
+            if src < cs.start_line || src > cs.end_line {
+                return line.clone();
+            }
+            let lo = if src == cs.start_line {
+                cs.start_col.max(cs.gutter)
+            } else {
+                cs.gutter
+            };
+            let hi = if src == cs.end_line {
+                cs.end_col
+            } else {
+                usize::MAX // to end of line for an interior row
+            };
+            Line {
+                spans: patch_char_range(&line.spans, lo, hi, crate::highlight::HIGHLIGHT),
+                style: line.style,
+                alignment: line.alignment,
+            }
+        })
+        .collect()
+}
+
 /// Rebuild `spans` so the chars at 0-based char indices `[lo, hi)` carry `style` (patched onto
 /// their existing style) and every other char keeps its own. Splits spans at the range boundaries,
 /// grouping consecutive same-selectedness chars so the output stays compact. Char-indexed (not
@@ -766,12 +809,14 @@ fn draw_content(frame: &mut Frame, area: Rect, state: &ViewState) -> (u16, u16) 
     let (text, vbar, hbar) = content_bars(content_area, total_rows, max_width, state.wrap);
 
     // Overlay the line-select marker/selection first (it is a modal — search cannot be committed
-    // while it is open), then a committed search, else the content as-is. Each overlay returns the
-    // same line count, so `content_rows` (computed above from `state.content`) stays valid. When
-    // both are `None`, cloning `state.content` is byte-identical to the prior path, so existing
-    // snapshots are unaffected (AC zero-churn invariant).
+    // while it is open), then an ambient content-pane selection, then a committed search, else the
+    // content as-is. Each overlay returns the same line count, so `content_rows` (computed above
+    // from `state.content`) stays valid. When all are `None`, cloning `state.content` is
+    // byte-identical to the prior path, so existing snapshots are unaffected (AC zero-churn invariant).
     let content_text = if let Some(ls) = &state.line_select {
         ratatui::text::Text::from(apply_line_select(&state.content.lines, ls))
+    } else if let Some(cs) = &state.content_selection {
+        ratatui::text::Text::from(apply_char_selection(&state.content.lines, cs))
     } else if let Some(cs) = &state.search {
         ratatui::text::Text::from(crate::highlight::apply(
             &state.content.lines,

--- a/src/text_layout.rs
+++ b/src/text_layout.rs
@@ -9,47 +9,119 @@
 
 use ratatui::text::Line;
 
-/// How many rows one rendered line occupies under ratatui's word wrapper (`Wrap{trim:false}`)
-/// at `width` columns: greedy word packing — fill the row with space-separated words until the
-/// next one doesn't fit, then wrap; a word wider than the row is broken across rows. A plain
-/// `ceil(width/col)` undercounts this (words rarely pack flush to the column), which is what
-/// would make the bottom of wrapped prose unreachable via the scroll clamp. Char counts stand
-/// in for display width — close enough for the clamp, and the caller floors with the
-/// all-columns char-wrap so it never undershoots.
-pub(crate) fn wrapped_rows(text: &str, width: usize) -> usize {
+/// The 0-based char index at which each wrapped display row of `text` begins under ratatui's
+/// word wrapper (`Wrap{trim:false}`). Row 0 always starts at char 0, so the result is never
+/// empty and its `len()` IS the wrapped row count ([`wrapped_rows`] is defined as exactly that,
+/// so the two can never drift).
+///
+/// This is a faithful char-unit port of ratatui's `WordWrapper::process_input` (the `reflow`
+/// module is private, so it cannot be called directly): whitespace runs are breakable and
+/// OCCUPY row space (`trim: false` — leading/interior spaces pack into the row, which a naive
+/// space-split simulation gets wrong on gutter/indented code lines), whitespace at a break is
+/// dropped only up to the finished row's remaining width (the excess carries to the next row),
+/// and a word wider than a row breaks at full-row boundaries. The
+/// `wrap_row_starts_match_a_real_ratatui_render` test cross-checks this port against an actual
+/// `Paragraph` render, so it cannot silently drift from the widget.
+///
+/// This is what lets a mouse position be mapped to a character under wrap: display row *r* of
+/// the line covers chars `[starts[r], starts[r+1])` (the last row runs to the line's end), so
+/// `caret = starts[r] + column`, clamped into the row's span. Chars stand in for display width
+/// (1 char = 1 column) — the documented wide-glyph caveat every consumer shares.
+pub(crate) fn wrap_row_starts(text: &str, width: usize) -> Vec<usize> {
     if width == 0 {
-        return 1;
+        return vec![0];
     }
-    let mut rows = 1usize;
-    let mut col = 0usize;
-    for (i, word) in text.split(' ').enumerate() {
-        let wl = word.chars().count();
-        let sep = usize::from(i > 0);
-        if col != 0 && col + sep + wl > width {
-            rows += 1; // doesn't fit → start a new row
-            col = 0;
+    let max = width;
+    let mut starts = vec![0usize];
+    // The port tracks char COUNTS where ratatui buffers graphemes; text order is preserved
+    // (pending whitespace precedes the pending word, which precedes the current char), so at
+    // any moment the pending whitespace occupies chars `[pos - word - ws, pos - word)` and the
+    // pending word `[pos - word, pos)` — that is what lets a row start be computed at each break.
+    let mut committed = 0usize; // chars committed to the current (not yet emitted) row
+    let mut word = 0usize; // pending (uncommitted) word chars
+    let mut ws = 0usize; // pending (uncommitted) whitespace chars
+    let mut prev_non_ws = false;
+    for (pos, c) in text.chars().enumerate() {
+        let is_ws = c.is_whitespace();
+        // A finished word (word→whitespace edge), or a first segment that alone overflows the
+        // empty row: commit the pending whitespace + word to the row (trim:false keeps the
+        // whitespace — this is where leading/indent spaces pack into the row).
+        if (prev_non_ws && is_ws) || (committed == 0 && word + ws + 1 > max) {
+            committed += ws + word;
+            ws = 0;
+            word = 0;
         }
-        if col == 0 {
-            // word starts a fresh row; a word wider than the row breaks across full rows
-            let extra = wl.saturating_sub(1) / width;
-            rows += extra;
-            col = wl - extra * width;
+        // The row is full, or the still-growing word would overflow it: emit the row and start
+        // the next one.
+        if committed >= max || committed + ws + word >= max {
+            let remaining = max - committed.min(max);
+            // Whitespace that would have fit on the finished row is dropped; the excess carries.
+            let dropped = ws.min(remaining);
+            ws -= dropped;
+            committed = 0;
+            // Where the next row begins: the first still-pending char — or past the current
+            // char when it is whitespace landing right at the break with nothing pending
+            // (ratatui skips it: "don't count first whitespace toward next word").
+            let skip_current = is_ws && ws == 0;
+            let next_start = if ws + word > 0 {
+                pos - word - ws
+            } else {
+                pos + usize::from(skip_current)
+            };
+            starts.push(next_start);
+            if skip_current {
+                prev_non_ws = false;
+                continue;
+            }
+        }
+        if is_ws {
+            ws += 1;
         } else {
-            col += sep + wl;
+            word += 1;
         }
+        prev_non_ws = !is_ws;
     }
-    rows
+    // Tail: the remaining whitespace + word form the final row (trim:false appends both). If
+    // nothing remains, the last pushed start was for a row ratatui never emits — drop it (but
+    // never row 0: an empty text is still one empty row).
+    if committed + ws + word == 0 && starts.len() > 1 {
+        starts.pop();
+    }
+    starts
 }
 
-/// Wrapped rows a single rendered [`Line`] occupies at `width` columns: flatten its spans to text,
-/// run the word-wrap simulation, and floor by the all-columns char-wrap so the simulation can never
-/// undershoot (a leading/interior over-long word still costs its char-wrapped rows). `width` is
-/// clamped to ≥ 1 so a zero width can't divide-by-zero. The content-pane scroll clamp and the
-/// help-overlay body measurement both call this, so their per-line row counts can never drift.
+/// How many rows one rendered line occupies under ratatui's word wrapper (`Wrap{trim:false}`)
+/// at `width` columns. A plain `ceil(width/col)` undercounts this (words rarely pack flush to
+/// the column), which is what would make the bottom of wrapped prose unreachable via the scroll
+/// clamp. Defined as the row count of [`wrap_row_starts`] — one source of truth, so the scroll
+/// math and the mouse caret mapping can never disagree about where rows break. The caller floors
+/// with the all-columns char-wrap so it never undershoots.
+pub(crate) fn wrapped_rows(text: &str, width: usize) -> usize {
+    wrap_row_starts(text, width).len()
+}
+
+/// Wrapped rows a single rendered [`Line`] occupies at `width` columns: flatten its spans to text
+/// and run the [`wrapped_rows`] port. `width` is clamped to ≥ 1 so a zero width can't
+/// divide-by-zero. The content-pane scroll clamp, the mouse caret mapping, and the help-overlay
+/// body measurement all call this, so their per-line row counts can never drift.
+///
+/// No unconditional char-wrap floor: the port is exact for 1-column text (cross-checked against
+/// a real render), and ratatui DROPS whitespace at row breaks — a real line can occupy FEWER
+/// rows than `ceil(chars/width)` (e.g. two 40-char words joined by one space render as exactly
+/// two rows at width 40), so flooring by the char-wrap would overcount, shifting every line
+/// below it up by a row (mouse selections then landed on the line ABOVE). The floor survives
+/// only for lines whose display width exceeds their char count (wide CJK/emoji glyphs, where the
+/// 1-char=1-col port undercounts): there it keeps the scroll clamp able to reach the bottom, at
+/// the cost of the already-documented wide-glyph mapping caveat.
 pub(crate) fn line_wrapped_rows(line: &Line, width: usize) -> usize {
     let width = width.max(1);
     let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
-    wrapped_rows(&text, width).max(line.width().max(1).div_ceil(width))
+    let rows = wrapped_rows(&text, width);
+    let display_width = line.width();
+    if display_width > text.chars().count() {
+        return rows.max(display_width.div_ceil(width));
+    }
+    rows
 }
 
 /// Neutralize a string for display (a label/title) or for the clipboard: drop control characters
@@ -64,7 +136,7 @@ pub(crate) fn sanitize_control(s: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{sanitize_control, wrapped_rows};
+    use super::{sanitize_control, wrap_row_starts, wrapped_rows};
 
     #[test]
     fn sanitize_control_strips_control_bytes_keeps_printable() {
@@ -84,6 +156,128 @@ mod tests {
                 .chars()
                 .any(|c| c.is_control())
         );
+    }
+
+    #[test]
+    fn wrap_row_starts_marks_word_and_char_breaks() {
+        // Word wrap: four width-6 words in a 10-col pane pack one per row. Each break lands on
+        // the next WORD's first char — the separator space stays behind on the ending row.
+        // "aaaaaa aaaaaa aaaaaa aaaaaa": words start at chars 0, 7, 14, 21.
+        assert_eq!(
+            wrap_row_starts("aaaaaa aaaaaa aaaaaa aaaaaa", 10),
+            vec![0, 7, 14, 21]
+        );
+        // A single over-long word breaks at full-row boundaries, like char wrapping.
+        assert_eq!(wrap_row_starts(&"x".repeat(100), 25), vec![0, 25, 50, 75]);
+        // Words that pack flush share one row; short/empty/zero-width are a single row at 0.
+        assert_eq!(wrap_row_starts("ab cd ef", 8), vec![0]);
+        assert_eq!(wrap_row_starts("hello", 80), vec![0]);
+        assert_eq!(wrap_row_starts("", 80), vec![0]);
+        assert_eq!(wrap_row_starts("anything", 0), vec![0]);
+        // A mixed line: a 50-char word, then a 40-char word at width 80 → the second word
+        // doesn't fit (50+1+40 > 80) and starts row 1 at char 51 (index 50 is the space).
+        let line = format!("{} {}", "a".repeat(50), "b".repeat(40));
+        assert_eq!(wrap_row_starts(&line, 80), vec![0, 51]);
+        // trim:false packs leading whitespace INTO the row: a 4-space indent + a 100-char word
+        // at width 80 fills row 0 with the 4 spaces + 76 word chars, so row 1 begins at char 80
+        // — NOT at 84 as a simulation that discards leading whitespace would claim. This is the
+        // indented-code case that made wrapped selection land on the text below.
+        let line = format!("    {}", "x".repeat(100));
+        assert_eq!(wrap_row_starts(&line, 80), vec![0, 80]);
+    }
+
+    /// The port must agree with the REAL widget: render each corpus line through a ratatui
+    /// `Paragraph` + `Wrap{trim:false}` (the exact configuration the content pane draws with)
+    /// and check row-by-row that the buffer's text equals the slice `[starts[r], starts[r+1])`
+    /// of the source — trailing-whitespace-insensitively, since break-dropped whitespace lives
+    /// between a row's content and the next row's start, and the backend pads rows with spaces.
+    /// This pins `wrap_row_starts` to ratatui's actual behavior, so a silent drift (a ratatui
+    /// upgrade, a port bug) fails here instead of mis-mapping mouse selections.
+    #[test]
+    fn wrap_row_starts_match_a_real_ratatui_render() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+        use ratatui::widgets::{Paragraph, Wrap};
+
+        let corpus: Vec<String> = vec![
+            // bat-style gutter + indented code (the reported mis-selection case)
+            format!("   1     let selected = tree.selected().map(|n| n.path.clone()); {}", "x".repeat(40)),
+            // deep indentation + long tokens
+            format!("        {}", "long_function_name(arg_one, arg_two, arg_three, arg_four);".repeat(3)),
+            // prose with normal word lengths
+            "The quick brown fox jumps over the lazy dog and keeps on running far past the fence line".to_string(),
+            // multi-space interior runs
+            format!("a  b   c    d     e {}", "word ".repeat(30)),
+            // one giant unbroken word
+            "y".repeat(250),
+            // leading whitespace + giant word
+            format!("      {}", "z".repeat(200)),
+            // trailing whitespace
+            format!("{}      ", "tail ".repeat(20)),
+            // exact-fit rows
+            format!("{} {}", "q".repeat(39), "r".repeat(40)),
+            // two exact-width words joined by one space: the break DROPS the space, so the line
+            // renders in 2 rows — fewer than ceil(81/40) = 3. The case that proved the char-wrap
+            // floor wrong (it shifted wrapped code selections onto the line above).
+            format!("{} {}", "x".repeat(40), "y".repeat(40)),
+        ];
+
+        const W: u16 = 40; // a narrow pane exercises many breaks per line
+        for text in &corpus {
+            let starts = wrap_row_starts(text, W as usize);
+            let chars: Vec<char> = text.chars().collect();
+
+            // Render the same text through the real widget at the same width.
+            let rows_needed = starts.len() as u16 + 2;
+            let backend = TestBackend::new(W, rows_needed);
+            let mut term = Terminal::new(backend).unwrap();
+            term.draw(|f| {
+                f.render_widget(
+                    Paragraph::new(text.as_str()).wrap(Wrap { trim: false }),
+                    f.area(),
+                );
+            })
+            .unwrap();
+            let buffer = term.backend().buffer().clone();
+
+            for (r, &start) in starts.iter().enumerate() {
+                let end = starts.get(r + 1).copied().unwrap_or(chars.len());
+                let expected: String = chars[start..end].iter().collect();
+                let rendered: String = (0..W)
+                    .map(|x| {
+                        buffer
+                            .cell(ratatui::layout::Position::new(x, r as u16))
+                            .unwrap()
+                            .symbol()
+                            .chars()
+                            .next()
+                            .unwrap_or(' ')
+                    })
+                    .collect();
+                assert_eq!(
+                    rendered.trim_end(),
+                    expected.trim_end(),
+                    "row {r} of {text:?} at width {W}: port says chars [{start}, {end}), widget drew {rendered:?}"
+                );
+            }
+            // And no extra rendered rows beyond the port's count: the row past the last must be blank.
+            let past: String = (0..W)
+                .map(|x| {
+                    buffer
+                        .cell(ratatui::layout::Position::new(x, starts.len() as u16))
+                        .unwrap()
+                        .symbol()
+                        .chars()
+                        .next()
+                        .unwrap_or(' ')
+                })
+                .collect();
+            assert_eq!(
+                past.trim_end(),
+                "",
+                "the widget drew more rows than the port counted for {text:?}"
+            );
+        }
     }
 
     #[test]

--- a/src/text_layout.rs
+++ b/src/text_layout.rs
@@ -124,6 +124,43 @@ pub(crate) fn line_wrapped_rows(line: &Line, width: usize) -> usize {
     rows
 }
 
+/// [`wrap_row_starts`] for a line the Presenter renders behind a `prefix`-column overlay glyph on
+/// its FIRST display row — the L-mode ▶/│ gutter caret. That glyph is a printable column GLUED to
+/// the text (no separating space), so ratatui wraps it as part of the first word; continuation
+/// rows carry no glyph. We model that faithfully by prepending `prefix` printable placeholder
+/// chars (1 col each, glued), wrapping, then shifting the row starts back into text coordinates.
+/// The returned starts are indices into `text` (glyph excluded); `prefix == 0` is byte-identical
+/// to [`wrap_row_starts`], so every non-overlay caller is unaffected.
+pub(crate) fn wrap_row_starts_prefixed(text: &str, width: usize, prefix: usize) -> Vec<usize> {
+    if prefix == 0 {
+        return wrap_row_starts(text, width);
+    }
+    let padded: String = "|".repeat(prefix) + text;
+    wrap_row_starts(&padded, width)
+        .into_iter()
+        .map(|s| s.saturating_sub(prefix))
+        .collect()
+}
+
+/// [`line_wrapped_rows`] for a line rendered behind a `prefix`-column overlay glyph on its first
+/// row (see [`wrap_row_starts_prefixed`]). The glyph adds `prefix` display columns and chars, so a
+/// line can wrap to more rows in L mode than bare; `prefix == 0` delegates unchanged. Used by the
+/// content scroll/marker math and the mouse caret mapping so they agree with the L-mode render.
+pub(crate) fn line_wrapped_rows_prefixed(line: &Line, width: usize, prefix: usize) -> usize {
+    if prefix == 0 {
+        return line_wrapped_rows(line, width);
+    }
+    let width = width.max(1);
+    let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+    let padded: String = "|".repeat(prefix) + &text;
+    let rows = wrapped_rows(&padded, width);
+    let display_width = line.width() + prefix;
+    if display_width > padded.chars().count() {
+        return rows.max(display_width.div_ceil(width));
+    }
+    rows
+}
+
 /// Neutralize a string for display (a label/title) or for the clipboard: drop control characters
 /// (C0, DEL, and C1 — `char::is_control`), so a repo-controlled file name carrying ESC/CSI bytes
 /// cannot move the cursor, clear the screen, spoof the UI, or paste-inject once copied (AC-27,

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -67,6 +67,7 @@ impl ContentProvider for StubContent {
         RenderResult {
             content: Text::raw("stub-content"),
             notices: Vec::new(),
+            source: None,
         }
     }
 }
@@ -751,6 +752,7 @@ impl ContentProvider for LinesContent {
         RenderResult {
             content: Text::raw(body),
             notices: Vec::new(),
+            source: None,
         }
     }
 }
@@ -765,6 +767,7 @@ impl ContentProvider for WideContent {
         RenderResult {
             content: Text::raw(body),
             notices: Vec::new(),
+            source: None,
         }
     }
 }
@@ -1988,6 +1991,7 @@ impl ContentProvider for PathContent {
         RenderResult {
             content: Text::raw(format!("showing {}", path.display())),
             notices: Vec::new(),
+            source: None,
         }
     }
 }
@@ -5812,6 +5816,7 @@ impl ContentProvider for WrapLines {
         RenderResult {
             content: Text::raw(lines.join("\n")),
             notices: Vec::new(),
+            source: None,
         }
     }
 }
@@ -6121,6 +6126,7 @@ impl ContentProvider for SearchContent {
         RenderResult {
             content: Text::raw(lines.join("\n")),
             notices: Vec::new(),
+            source: None,
         }
     }
 }
@@ -6836,6 +6842,7 @@ impl ContentProvider for SwitchingContent {
         RenderResult {
             content: Text::raw(lines.join("\n")),
             notices: Vec::new(),
+            source: None,
         }
     }
 }
@@ -7089,6 +7096,7 @@ impl ContentProvider for ContentWithoutSentinel {
         RenderResult {
             content: Text::raw(lines),
             notices: Vec::new(),
+            source: None,
         }
     }
 }

--- a/tests/controller_async.rs
+++ b/tests/controller_async.rs
@@ -35,6 +35,7 @@ impl ContentProvider for SlowContent {
         RenderResult {
             content: Text::raw(format!("rendered:{name}")),
             notices: Vec::new(),
+            source: None,
         }
     }
 }
@@ -55,6 +56,7 @@ impl ContentProvider for PanicOnContent {
         RenderResult {
             content: Text::raw(format!("rendered:{name}")),
             notices: Vec::new(),
+            source: None,
         }
     }
 }

--- a/tests/lineselect.rs
+++ b/tests/lineselect.rs
@@ -194,12 +194,35 @@ impl ContentProvider for ControlContent {
 
 /// Content that mimics `bat --style=numbers`: a right-aligned line-number gutter + a one-space
 /// separator, then the source line — with real indentation on line 2 — so a copy test proves the
-/// gutter is stripped while the code's own indentation survives.
+/// gutter is stripped while the code's own indentation survives. Carries the retained source, as
+/// the live `SyntaxContent` renderer always does (a line-number gutter exists ONLY behind that
+/// mode, which is exactly when source is retained — see `RenderResult::source`).
 #[derive(Clone, Copy)]
 struct GutterContent;
 impl ContentProvider for GutterContent {
     fn render(&self, _path: &Path, _mode: ViewMode, _raw_diff: Option<&str>) -> RenderResult {
         let lines = ["  1 fn main() {", "  2     let x = 5;", "  3 }"];
+        RenderResult {
+            content: Text::raw(lines.join("\n")),
+            notices: Vec::new(),
+            source: Some(vec![
+                "fn main() {".to_string(),
+                "    let x = 5;".to_string(),
+                "}".to_string(),
+            ]),
+        }
+    }
+}
+
+/// A genuinely source-less view (rendered markdown / diff — no per-display-line source, no gutter)
+/// whose line 2 happens to start with "2 " — the input that fools the bare digit heuristic. With no
+/// source to anchor, `gutter_len_of` must return 0 (there is no gutter in such a view), so the copy
+/// keeps the leading "2 ". Guards the source-less half of the gutter-strip fix.
+#[derive(Clone, Copy)]
+struct PlainNoSource;
+impl ContentProvider for PlainNoSource {
+    fn render(&self, _path: &Path, _mode: ViewMode, _raw_diff: Option<&str>) -> RenderResult {
+        let lines = ["intro line", "2 spaces of intro", "tail line"];
         RenderResult {
             content: Text::raw(lines.join("\n")),
             notices: Vec::new(),
@@ -1817,6 +1840,90 @@ fn char_drag_gutter_is_source_anchored_not_guessed() {
         copied.lock().unwrap().last().map(String::as_str),
         Some("3 l"),
         "carets are based off the source-anchored gutter (0), not the heuristic's guess"
+    );
+}
+
+#[test]
+fn sourceless_view_ambient_copy_keeps_a_leading_number() {
+    // A source-less view (rendered markdown / diff) is reachable for a copy only via the AMBIENT
+    // drag — entering L mode auto-switches to source. Line 2 reads "2 spaces of intro"; there is no
+    // gutter, so `gutter_len_of` returns 0 with no source to anchor and the leading "2 " survives.
+    // The bare digit heuristic would have wrongly eaten it. Guards the source-less half of the fix.
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("doc.md"), "placeholder\n").unwrap();
+    let (mut ctrl, copied) = controller_with_clipboard(dir.path(), PlainNoSource);
+    await_marker(&mut ctrl, "intro");
+    ctrl.set_content_viewport(80, 20);
+    ctrl.set_pane_geometry(content_geometry());
+    assert!(
+        !ctrl.line_select_active(),
+        "precondition: the ambient path, no modal open"
+    );
+
+    // Drag across all of line 2 (screen row 2 with content_inner.y == 1, scroll 0): cols 41..58
+    // (pane x 41 + the 17 chars of "2 spaces of intro"), no L-mode glyph.
+    ctrl.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 41, 2));
+    ctrl.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 58, 2));
+    ctrl.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 58, 2));
+    assert_eq!(
+        copied.lock().unwrap().last().map(String::as_str),
+        Some("2 spaces of intro"),
+        "no source, no gutter: the leading \"2 \" is real text and survives the copy"
+    );
+}
+
+#[test]
+fn drag_past_the_viewport_edge_autoscrolls_the_content() {
+    // Dragging an ambient selection below the bottom (or above the top) of the content viewport
+    // nudges the scroll one line so the selection can extend past what is on screen; a drag inside
+    // the viewport leaves the scroll alone.
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("code.rs"), "placeholder\n").unwrap();
+    let (mut ctrl, _copied) = controller_with_clipboard(dir.path(), MultiLine);
+    await_marker(&mut ctrl, "line0");
+    // A short viewport (height 5) over the 20-line body, so there is room to scroll (max 15).
+    let geom = PaneGeometry {
+        content_inner: Some(Rect {
+            x: 41,
+            y: 1,
+            width: 58,
+            height: 5,
+        }),
+        divider_x: Some(40),
+        ..PaneGeometry::default()
+    };
+    ctrl.set_content_viewport(80, 5);
+    ctrl.set_pane_geometry(geom);
+    assert_eq!(ctrl.content_scroll(), 0, "precondition: not scrolled");
+
+    // Press inside the pane to start the ambient drag (content_inner bottom edge is row y+h = 6).
+    ctrl.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 41, 1));
+    // Drag below the bottom edge → scroll down one line, twice.
+    ctrl.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 44, 6));
+    assert_eq!(
+        ctrl.content_scroll(),
+        1,
+        "a drag below the bottom scrolls down one"
+    );
+    ctrl.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 44, 6));
+    assert_eq!(
+        ctrl.content_scroll(),
+        2,
+        "another edge drag scrolls one more"
+    );
+    // Drag back inside the viewport → no scroll change.
+    ctrl.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 44, 3));
+    assert_eq!(
+        ctrl.content_scroll(),
+        2,
+        "a drag inside the viewport leaves the scroll alone"
+    );
+    // Drag above the top edge (row < y = 1) → scroll up one line.
+    ctrl.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 44, 0));
+    assert_eq!(
+        ctrl.content_scroll(),
+        1,
+        "a drag above the top scrolls up one"
     );
 }
 

--- a/tests/lineselect.rs
+++ b/tests/lineselect.rs
@@ -800,80 +800,118 @@ fn enter_line_select_top(ctrl: &mut Controller) {
 }
 
 #[test]
-fn click_sets_marker_to_clicked_source_line() {
-    // AC-8: a plain left-click (release) in the content pane moves the marker to the clicked
-    // source line, collapsed. Screen row 3, content top row 1, scroll 0 → source line 3.
+fn mouse_down_places_caret_on_clicked_line() {
+    // A left press in the content pane drops the selection caret on the clicked source line,
+    // collapsed. Screen row 3, content top row 1, scroll 0 → source line 3.
     let dir = TempDir::new();
     std::fs::write(dir.path().join("code.rs"), "placeholder\n").unwrap();
     let (mut ctrl, _copied) = controller_with_clipboard(dir.path(), MultiLine);
     enter_line_select_top(&mut ctrl);
 
-    let fx = ctrl.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 50, 3));
-    assert!(fx.redraw, "a click that moves the marker redraws");
+    let fx = ctrl.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 50, 3));
+    assert!(fx.redraw, "a press that places the caret redraws");
     assert_eq!(
         ctrl.line_selection(),
         Some((3, 3)),
-        "AC-8: a click places the marker on the clicked source line (3)"
+        "a press places the caret on the clicked source line (3), collapsed"
     );
 }
 
 #[test]
-fn shift_click_places_marker_like_a_plain_click() {
-    // Amended T-8: herdr and most terminals reserve Shift+mouse for their own native text
-    // selection, so a shift-click can never reliably reach the plugin — mouse shift-click
-    // extend is removed. A Shift+left-click now behaves exactly like a plain click: it places
-    // the marker on the clicked source line, collapsed (anchor collapses to the clicked line,
-    // NOT extended from a prior anchor). Keyboard `Shift`+`j`/`k` (and Shift+arrows) remains the
-    // supported way to extend a multi-line selection — that path is unchanged.
+fn shift_mouse_is_left_for_the_terminal() {
+    // We must NOT swallow Shift+mouse — herdr and most terminals reserve it for their own native
+    // text selection/copy. A Shift+press is therefore inert in the plugin: it neither starts a
+    // selection nor redraws, so the event passes through to the terminal untouched.
     let dir = TempDir::new();
     std::fs::write(dir.path().join("code.rs"), "placeholder\n").unwrap();
     let (mut ctrl, _copied) = controller_with_clipboard(dir.path(), MultiLine);
     enter_line_select_top(&mut ctrl);
 
-    // Plain click at row 4 → marker at line 4 (this would be the "anchor" under the old
-    // extend behavior, but a subsequent shift-click no longer honors it).
-    ctrl.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 50, 4));
+    let fx = ctrl.handle_mouse(shift_mouse(MouseEventKind::Down(MouseButton::Left), 55, 7));
+    assert!(!fx.redraw, "a Shift+press is inert (left for the terminal)");
     assert_eq!(
         ctrl.line_selection(),
-        Some((4, 4)),
-        "precondition: marker placed at line 4"
-    );
-
-    // Shift-click at row 7 → marker moves to 7, collapsed — NOT (4, 7).
-    let fx = ctrl.handle_mouse(shift_mouse(MouseEventKind::Up(MouseButton::Left), 55, 7));
-    assert!(fx.redraw, "a shift-click that moves the marker redraws");
-    assert_eq!(
-        ctrl.line_selection(),
-        Some((7, 7)),
-        "shift-click places the marker on the clicked line like a plain click, not extending"
+        Some((1, 1)),
+        "Shift+mouse must not move or start a selection in the plugin"
     );
 }
 
 #[test]
-fn double_click_copies_content() {
-    // AC-9: two left-clicks on the same content row within the double-click window copy that
-    // row's CONTENT and close the mode — the same confirm as Enter. Source line 3 == "line2".
+fn drag_selects_characters_across_lines_and_copies() {
+    // Press → drag → release selects a character-granular span; Enter copies exactly that span
+    // (the tail of the first line + the head of the last, joined by '\n'). MultiLine renders
+    // "line0".."line19" with no gutter, so char carets map straight to columns.
     let dir = TempDir::new();
     std::fs::write(dir.path().join("code.rs"), "placeholder\n").unwrap();
     let (mut ctrl, copied) = controller_with_clipboard(dir.path(), MultiLine);
     enter_line_select_top(&mut ctrl);
 
-    // First click moves the marker to line 3; the second (same row, within the window) is the
-    // double-click that copies and closes.
-    ctrl.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 50, 3));
-    let fx = ctrl.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 50, 3));
+    // Press at line 1, char 0 (col 42 = pane x 41 + 1 glyph col + 0).
+    ctrl.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 42, 1));
+    // Drag to line 2, char 3 (col 45 = 41 + 1 glyph + 3).
+    ctrl.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 45, 2));
+    let fx = ctrl.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 45, 2));
+    assert!(fx.redraw, "finalizing the drag redraws");
     assert!(
-        fx.redraw,
-        "the copy redraws to show the confirmation notice"
+        ctrl.line_select_active(),
+        "release finalizes the selection but keeps the mode open for Enter/y"
     );
+
+    ctrl.handle_line_select_key(key(KeyCode::Enter));
+    assert_eq!(
+        copied.lock().unwrap().last().map(String::as_str),
+        Some("line0\nlin"),
+        "Enter copies the character span: all of line 1 + the first 3 chars of line 2"
+    );
+    assert!(
+        ctrl.notices().iter().any(|n| n == "Copied selection"),
+        "the notice confirms a character selection: {:?}",
+        ctrl.notices()
+    );
+    assert!(!ctrl.line_select_active(), "Enter closes the mode after copying");
+}
+
+#[test]
+fn drag_populates_char_selection_in_the_view() {
+    // A mouse drag must feed the presenter a character selection (so the highlight is char-granular,
+    // not whole-line). After dragging line 1 char 0 → line 2 char 3, the view carries those carets.
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("code.rs"), "placeholder\n").unwrap();
+    let (mut ctrl, _copied) = controller_with_clipboard(dir.path(), MultiLine);
+    enter_line_select_top(&mut ctrl);
+
+    ctrl.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 42, 1));
+    ctrl.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 45, 2));
+
+    let vs = ctrl.view_state();
+    let ls = vs.line_select.expect("line-select overlay is present");
+    let cs = ls
+        .char_sel
+        .expect("a mouse drag populates the character selection for the overlay");
+    assert_eq!(
+        (cs.start_line, cs.start_col, cs.end_line, cs.end_col),
+        (1, 0, 2, 3),
+        "the overlay carries the exact drag carets (ordered)"
+    );
+}
+
+#[test]
+fn click_without_drag_collapses_and_enter_copies_the_line() {
+    // A press with no drag collapses the selection onto one character; Enter then falls back to
+    // copying the whole clicked line, so a plain click-then-Enter still yields a line. Row 3 →
+    // source line 3 == "line2".
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("code.rs"), "placeholder\n").unwrap();
+    let (mut ctrl, copied) = controller_with_clipboard(dir.path(), MultiLine);
+    enter_line_select_top(&mut ctrl);
+
+    ctrl.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 50, 3));
+    ctrl.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 50, 3));
+    ctrl.handle_line_select_key(key(KeyCode::Enter));
     assert_eq!(
         copied.lock().unwrap().last().map(String::as_str),
         Some("line2"),
-        "AC-9: double-click copies the content of the clicked line (source line 3 == \"line2\")"
-    );
-    assert!(
-        !ctrl.line_select_active(),
-        "AC-9: the double-click closes the mode (like Enter)"
+        "a collapsed click copies the whole clicked line (source line 3 == \"line2\")"
     );
 }
 
@@ -900,33 +938,38 @@ fn click_outside_content_is_inert() {
 }
 
 #[test]
-fn press_and_drag_do_not_move_the_marker() {
-    // Only a completed left-click (Up) acts; a press (Down) or drag must be inert so the mode keeps
-    // the mouse and no divider/scrollbar drag starts underneath.
+fn drag_within_one_line_selects_chars() {
+    // A press + drag on the same row selects a character range within that single line; Enter
+    // copies just those chars. Line 1 == "line0"; select chars [1, 4) → "ine".
     let dir = TempDir::new();
     std::fs::write(dir.path().join("code.rs"), "placeholder\n").unwrap();
-    let (mut ctrl, _copied) = controller_with_clipboard(dir.path(), MultiLine);
+    let (mut ctrl, copied) = controller_with_clipboard(dir.path(), MultiLine);
     enter_line_select_top(&mut ctrl);
 
-    let fx = ctrl.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 50, 6));
-    assert!(!fx.redraw, "a press is inert in line-select mode");
-    let fx = ctrl.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 50, 6));
-    assert!(!fx.redraw, "a drag is inert in line-select mode");
+    // Press at line 1 char 1 (col 43 = pane x 41 + glyph + 1), drag to char 4 (col 46).
+    ctrl.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 43, 1));
+    let fx = ctrl.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 46, 1));
+    assert!(fx.redraw, "a selection drag redraws");
     assert_eq!(
         ctrl.line_selection(),
         Some((1, 1)),
-        "neither a press nor a drag moves the marker"
+        "the selection stays on line 1 (character-granular within the line)"
+    );
+
+    ctrl.handle_line_select_key(key(KeyCode::Char('y')));
+    assert_eq!(
+        copied.lock().unwrap().last().map(String::as_str),
+        Some("ine"),
+        "y copies the selected characters [1, 4) of \"line0\""
     );
 }
 
 #[test]
-fn stale_tree_click_does_not_misfire_first_content_click_as_double() {
-    // BUG regression: entering line-select mode did not clear `self.last_click`, so a tree-row
-    // click made just before entry could pair with the FIRST content click at the same screen row
-    // as a double-click — `is_double_click` only compares the row (not the column/pane) — firing
-    // `copy_line_content` (copy + close) before the marker was ever placed by a real content
-    // click. Every other modal already guards this (`open_finder`/`open_help` clear `last_click`
-    // on open); line-select's entry point must too.
+fn content_press_after_tree_click_places_caret_without_copying() {
+    // Entering line-select right after a tree-row click, then a first content press at the same
+    // screen row, must place the caret on that source line and copy nothing — a press is a caret
+    // placement, never a copy (copying is Enter/y). Guards that a prior-context click can't cause a
+    // spurious copy on the first content interaction.
     let dir = TempDir::new();
     for name in ["aa.txt", "bb.txt", "code.rs"] {
         std::fs::write(dir.path().join(name), "placeholder\n").unwrap();
@@ -947,8 +990,7 @@ fn stale_tree_click_does_not_misfire_first_content_click_as_double() {
     });
     ctrl.set_pane_geometry(geometry);
 
-    // A tree-row click at screen row 3 selects "code.rs" (idx 2) and sets
-    // `last_click = (_, 3, now)` — the stale prior-context click.
+    // A tree-row click at screen row 3 selects "code.rs" (idx 2) — the prior-context click.
     ctrl.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 6, 3));
     assert_eq!(
         ctrl.tree().cursor(),
@@ -965,25 +1007,25 @@ fn stale_tree_click_does_not_misfire_first_content_click_as_double() {
         "precondition: the mode opened synchronously"
     );
 
-    // The FIRST content click, at the SAME screen row (3) the stale tree click used, must place
-    // the marker on line 3 — not pair with the stale tree click as a double-click.
-    let fx = ctrl.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 50, 3));
+    // The first content press, at the SAME screen row (3) the tree click used, places the caret on
+    // source line 3 — and copies nothing.
+    let fx = ctrl.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 50, 3));
     assert!(
         fx.redraw,
-        "the first content click places the marker and redraws"
+        "the first content press places the caret and redraws"
     );
     assert_eq!(
         ctrl.line_selection(),
         Some((3, 3)),
-        "the first content click must place the marker — not fire a stale cross-context double-click"
+        "the first content press places the caret on the clicked source line"
     );
     assert!(
         ctrl.line_select_active(),
-        "the mode must stay open — a stale pairing must not copy+close it before any real content click"
+        "the mode stays open — a press never copies or closes it"
     );
     assert!(
         copied.lock().unwrap().is_empty(),
-        "nothing should have been copied by a stale-click misfire"
+        "nothing is copied by a press"
     );
 }
 
@@ -1021,8 +1063,8 @@ fn entry_maps_wrapped_scroll_offset_to_source_line() {
 }
 
 #[test]
-fn mouse_click_maps_wrapped_row_to_source_line() {
-    // With wrap ON and scroll at the top, a click on screen row 4 (content top row 1 → display row
+fn mouse_press_maps_wrapped_row_to_source_line() {
+    // With wrap ON and scroll at the top, a press on screen row 4 (content top row 1 → display row
     // 3) must select source line 2 — display row 3 is the first wrapped row of line 2 — NOT the
     // pre-fix `scroll + (row - top) + 1` == 4.
     let dir = TempDir::new();
@@ -1040,12 +1082,12 @@ fn mouse_click_maps_wrapped_row_to_source_line() {
         "precondition: marker on line 1"
     );
 
-    let fx = ctrl.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 50, 4));
-    assert!(fx.redraw, "a click that moves the marker redraws");
+    let fx = ctrl.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 50, 4));
+    assert!(fx.redraw, "a press that places the caret redraws");
     assert_eq!(
         ctrl.line_selection(),
         Some((2, 2)),
-        "click on wrapped display row 3 maps to source line 2, not the buggy row+1 (=4)"
+        "press on wrapped display row 3 maps to source line 2, not the buggy row+1 (=4)"
     );
 }
 

--- a/tests/lineselect.rs
+++ b/tests/lineselect.rs
@@ -173,6 +173,36 @@ impl ContentProvider for EmptyContent {
     }
 }
 
+/// Content whose single source line carries a raw ESC control byte and a leading tab, so a copy
+/// test can prove `copy_line_content` strips the residual control byte while PRESERVING the tab
+/// (indentation). Real renders never leak an ESC into a span (the renderer cleans it first), but
+/// this stub bypasses that path, exercising the copy adapter's own defense-in-depth filter.
+#[derive(Clone, Copy)]
+struct ControlContent;
+impl ContentProvider for ControlContent {
+    fn render(&self, _path: &Path, _mode: ViewMode, _raw_diff: Option<&str>) -> RenderResult {
+        RenderResult {
+            content: Text::raw("\tcode\x1bhere"),
+            notices: Vec::new(),
+        }
+    }
+}
+
+/// Content that mimics `bat --style=numbers`: a right-aligned line-number gutter + a one-space
+/// separator, then the source line — with real indentation on line 2 — so a copy test proves the
+/// gutter is stripped while the code's own indentation survives.
+#[derive(Clone, Copy)]
+struct GutterContent;
+impl ContentProvider for GutterContent {
+    fn render(&self, _path: &Path, _mode: ViewMode, _raw_diff: Option<&str>) -> RenderResult {
+        let lines = ["  1 fn main() {", "  2     let x = 5;", "  3 }"];
+        RenderResult {
+            content: Text::raw(lines.join("\n")),
+            notices: Vec::new(),
+        }
+    }
+}
+
 /// Spin `poll()` until the worker's empty render has landed — i.e. until `content.lines` is
 /// actually empty, past the non-empty "Rendering…" placeholder `dispatch_render` shows while
 /// the job is in flight.
@@ -531,7 +561,7 @@ fn enter_from_source_is_synchronous() {
     );
 }
 
-// ── T-7: Enter copies the reference, sanitizes, notifies, and closes the mode ─────
+// ── T-7: Enter copies the selected lines' CONTENT, sanitizes, notifies, and closes the mode ─────
 
 /// Enter line-select at line 5 on a source-view `.rs` file (synchronous fast path).
 fn enter_at_line_five(ctrl: &mut Controller) {
@@ -547,9 +577,10 @@ fn enter_at_line_five(ctrl: &mut Controller) {
 }
 
 #[test]
-fn enter_copies_single_reference() {
-    // AC-9/AC-10: Enter on a single-line selection copies `path:line` and confirms it in a notice;
-    // AC-4-style close: the mode is a completed action so Enter also closes it.
+fn enter_copies_single_line_content() {
+    // AC-9/AC-10: Enter on a single-line selection copies that line's CONTENT and confirms the
+    // line number in a notice; AC-4-style close: the mode is a completed action so Enter closes it.
+    // MultiLine renders "line0".."line19", so source line 5 is the text "line4".
     let dir = TempDir::new();
     std::fs::write(dir.path().join("a.rs"), "placeholder\n").unwrap();
     let (mut ctrl, copied) = controller_with_clipboard(dir.path(), MultiLine);
@@ -559,12 +590,12 @@ fn enter_copies_single_reference() {
     assert!(fx.redraw, "copying redraws to show the confirmation notice");
     assert_eq!(
         copied.lock().unwrap().last().map(String::as_str),
-        Some("a.rs:5"),
-        "AC-9: Enter copies the single-line reference"
+        Some("line4"),
+        "AC-9: Enter copies the selected line's content (source line 5 == \"line4\")"
     );
     assert!(
-        ctrl.notices().iter().any(|n| n == "Copied a.rs:5"),
-        "AC-10: the copy is confirmed: {:?}",
+        ctrl.notices().iter().any(|n| n == "Copied line 5"),
+        "AC-10: the copy is confirmed by line number: {:?}",
         ctrl.notices()
     );
     assert!(
@@ -574,8 +605,9 @@ fn enter_copies_single_reference() {
 }
 
 #[test]
-fn range_copies_start_end() {
-    // AC-9: Enter on an extended selection copies `path:start-end`.
+fn range_copies_lines_joined_by_newline() {
+    // AC-9: Enter on an extended selection copies every selected line's content, joined with '\n'.
+    // Selection 5-8 over MultiLine → "line4".."line7".
     let dir = TempDir::new();
     std::fs::write(dir.path().join("a.rs"), "placeholder\n").unwrap();
     let (mut ctrl, copied) = controller_with_clipboard(dir.path(), MultiLine);
@@ -594,36 +626,95 @@ fn range_copies_start_end() {
     ctrl.handle_line_select_key(key(KeyCode::Enter));
     assert_eq!(
         copied.lock().unwrap().last().map(String::as_str),
-        Some("a.rs:5-8"),
-        "AC-9: Enter copies the range reference"
+        Some("line4\nline5\nline6\nline7"),
+        "AC-9: Enter copies the range's content joined by newlines"
+    );
+    assert!(
+        ctrl.notices().iter().any(|n| n == "Copied lines 5-8"),
+        "the notice names the copied line range: {:?}",
+        ctrl.notices()
     );
 }
 
-// Unix-only: this repro needs a file whose *name* carries an ESC byte, which Windows forbids —
-// `fs::write` fails there before the copy path runs. The `sanitize_control` defense is
-// platform-agnostic and directly unit-tested in `text_layout.rs` (runs on every platform), so
-// Windows keeps full sanitizer coverage; only the filesystem-level repro is gated.
-#[cfg(unix)]
 #[test]
-fn control_bytes_in_path_are_sanitized() {
-    // AC-16: the path segment is untrusted — a crafted file name can carry an ESC byte. The whole
-    // reference is sanitized before it reaches the clipboard OR the notice, so no raw control byte
-    // is copied.
+fn copy_strips_line_number_gutter_keeps_indentation() {
+    // The syntax view (`bat --style=numbers`) bakes a line-number gutter into the content. Copying
+    // must yield the source text alone — no `  1 ` prefix — while preserving code indentation.
     let dir = TempDir::new();
-    std::fs::write(dir.path().join("a\x1bb.rs"), "placeholder\n").unwrap();
+    std::fs::write(dir.path().join("a.rs"), "placeholder\n").unwrap();
+    let (mut ctrl, copied) = controller_with_clipboard(dir.path(), GutterContent);
+    await_marker(&mut ctrl, "fn main");
+    ctrl.set_content_viewport(80, 10);
+    ctrl.scroll_to_line(1);
+    ctrl.enter_line_select_at_top();
+    assert_eq!(
+        ctrl.line_selection(),
+        Some((1, 1)),
+        "precondition: marker on line 1"
+    );
+
+    // Extend over all three lines (1 → 3) and copy.
+    ctrl.handle_line_select_key(key(KeyCode::Char('J')));
+    ctrl.handle_line_select_key(key(KeyCode::Char('J')));
+    assert_eq!(ctrl.line_selection(), Some((1, 3)), "precondition: 1-3");
+
+    ctrl.handle_line_select_key(key(KeyCode::Enter));
+    assert_eq!(
+        copied.lock().unwrap().last().map(String::as_str),
+        Some("fn main() {\n    let x = 5;\n}"),
+        "the line-number gutter is stripped; the code indentation is preserved"
+    );
+}
+
+#[test]
+fn y_copies_content_like_enter() {
+    // The familiar copy keys `y`/`Y` confirm exactly like Enter (line-select routes every key
+    // through `handle_line_select_key`, so these are wired to the copy path explicitly).
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.rs"), "placeholder\n").unwrap();
     let (mut ctrl, copied) = controller_with_clipboard(dir.path(), MultiLine);
     enter_at_line_five(&mut ctrl);
+
+    let fx = ctrl.handle_line_select_key(key(KeyCode::Char('y')));
+    assert!(fx.redraw, "y copies and redraws");
+    assert_eq!(
+        copied.lock().unwrap().last().map(String::as_str),
+        Some("line4"),
+        "y copies the selected line's content, just like Enter"
+    );
+    assert!(
+        !ctrl.line_select_active(),
+        "y closes the mode after copying"
+    );
+}
+
+#[test]
+fn control_bytes_in_content_are_sanitized_tabs_kept() {
+    // AC-16: content is untrusted too — a crafted line can carry an ESC byte. The copied text is
+    // filtered so no raw control byte reaches the clipboard, while a tab (indentation) survives.
+    // ControlContent renders the single line "\tcode\x1bhere" → copy must yield "\tcodehere".
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.rs"), "placeholder\n").unwrap();
+    let (mut ctrl, copied) = controller_with_clipboard(dir.path(), ControlContent);
+    await_marker(&mut ctrl, "code");
+    ctrl.set_content_viewport(80, 10);
+    ctrl.enter_line_select_at_top();
+    assert_eq!(
+        ctrl.line_selection(),
+        Some((1, 1)),
+        "precondition: marker on the single line"
+    );
 
     ctrl.handle_line_select_key(key(KeyCode::Enter));
     let log = copied.lock().unwrap();
     let got = log.last().map(String::as_str).unwrap();
     assert_eq!(
-        got, "ab.rs:5",
-        "AC-16: the ESC byte in the file name is neutralized before copy"
+        got, "\tcodehere",
+        "AC-16: the ESC byte is dropped from the content while the leading tab is preserved"
     );
     assert!(
-        !got.chars().any(char::is_control),
-        "AC-16: no control byte reaches the clipboard: {got:?}"
+        !got.chars().any(|c| c.is_control() && c != '\t'),
+        "AC-16: no control byte (other than tab) reaches the clipboard: {got:?}"
     );
     assert!(
         ctrl.notices()
@@ -759,9 +850,9 @@ fn shift_click_places_marker_like_a_plain_click() {
 }
 
 #[test]
-fn double_click_copies_reference() {
-    // AC-9: two left-clicks on the same content row within the double-click window copy the
-    // `path:line` reference for that row and close the mode — the same confirm as Enter.
+fn double_click_copies_content() {
+    // AC-9: two left-clicks on the same content row within the double-click window copy that
+    // row's CONTENT and close the mode — the same confirm as Enter. Source line 3 == "line2".
     let dir = TempDir::new();
     std::fs::write(dir.path().join("code.rs"), "placeholder\n").unwrap();
     let (mut ctrl, copied) = controller_with_clipboard(dir.path(), MultiLine);
@@ -777,8 +868,8 @@ fn double_click_copies_reference() {
     );
     assert_eq!(
         copied.lock().unwrap().last().map(String::as_str),
-        Some("code.rs:3"),
-        "AC-9: double-click copies the reference for the clicked line"
+        Some("line2"),
+        "AC-9: double-click copies the content of the clicked line (source line 3 == \"line2\")"
     );
     assert!(
         !ctrl.line_select_active(),
@@ -833,7 +924,7 @@ fn stale_tree_click_does_not_misfire_first_content_click_as_double() {
     // BUG regression: entering line-select mode did not clear `self.last_click`, so a tree-row
     // click made just before entry could pair with the FIRST content click at the same screen row
     // as a double-click — `is_double_click` only compares the row (not the column/pane) — firing
-    // `copy_line_reference` (copy + close) before the marker was ever placed by a real content
+    // `copy_line_content` (copy + close) before the marker was ever placed by a real content
     // click. Every other modal already guards this (`open_finder`/`open_help` clear `last_click`
     // on open); line-select's entry point must too.
     let dir = TempDir::new();

--- a/tests/lineselect.rs
+++ b/tests/lineselect.rs
@@ -868,7 +868,10 @@ fn drag_selects_characters_across_lines_and_copies() {
         "the notice confirms a character selection: {:?}",
         ctrl.notices()
     );
-    assert!(!ctrl.line_select_active(), "Enter closes the mode after copying");
+    assert!(
+        !ctrl.line_select_active(),
+        "Enter closes the mode after copying"
+    );
 }
 
 #[test]

--- a/tests/lineselect.rs
+++ b/tests/lineselect.rs
@@ -1128,3 +1128,332 @@ fn marker_stays_visible_under_wrap_when_moved_past_viewport() {
         "at the last line (display row 12) the bottom pins to the marker: 12 + 1 - 4 = 9"
     );
 }
+
+// ── ambient content-pane selection (mouse drag with NO modal open) ──────────────────────────
+// Click-drag selects text during normal navigation WITHOUT entering L mode; the release
+// auto-copies the span. Because no modal is open the content overlay prepends NO gutter glyph, so
+// a char caret at column C maps to screen column `pane.x + C` (41 + C) — one less than the L-mode
+// drag tests above, which add the glyph column (41 + 1 + C).
+
+/// Await the content render and wire up the content geometry WITHOUT entering line-select, so a
+/// mouse drag in the content pane exercises the ambient (`Modal::None`) path.
+fn setup_ambient(ctrl: &mut Controller) {
+    await_marker(ctrl, "line0");
+    ctrl.set_content_viewport(80, 20); // the full 20-line body fits → content_scroll stays 0
+    ctrl.set_pane_geometry(content_geometry());
+    assert!(
+        !ctrl.line_select_active(),
+        "precondition: no modal is open (the ambient path)"
+    );
+}
+
+/// Drag line 1 char 0 → line 2 char 3 in the ambient path (cols 41/44 = pane x + charcol, no
+/// glyph), leaving a non-collapsed selection standing after the release.
+fn ambient_drag_line1_to_line2(ctrl: &mut Controller) {
+    ctrl.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 41, 1));
+    ctrl.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 44, 2));
+    ctrl.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 44, 2));
+}
+
+#[test]
+fn ambient_drag_auto_copies_on_release() {
+    // A press → drag → release in the content pane with NO modal open selects a character span and
+    // copies it on release (auto-copy), leaving the highlight standing and never entering L mode.
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("code.rs"), "placeholder\n").unwrap();
+    let (mut ctrl, copied) = controller_with_clipboard(dir.path(), MultiLine);
+    setup_ambient(&mut ctrl);
+
+    ctrl.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 41, 1));
+    ctrl.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 44, 2));
+    let fx = ctrl.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 44, 2));
+
+    assert!(fx.redraw, "the release redraws");
+    assert!(
+        !ctrl.line_select_active(),
+        "an ambient selection never enters L mode"
+    );
+    assert_eq!(
+        copied.lock().unwrap().last().map(String::as_str),
+        Some("line0\nlin"),
+        "release auto-copies the span: all of line 1 + the first 3 chars of line 2"
+    );
+    assert!(
+        ctrl.notices().iter().any(|n| n == "Copied selection"),
+        "the notice confirms the copy: {:?}",
+        ctrl.notices()
+    );
+    assert!(
+        ctrl.view_state().content_selection.is_some(),
+        "the selection stays highlighted after the auto-copy (feedback)"
+    );
+}
+
+#[test]
+fn ambient_drag_populates_content_selection_overlay() {
+    // A mouse drag feeds the presenter a gutter-less character selection via view_state, distinct
+    // from the L-mode `line_select` overlay (which stays None — no modal is open).
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("code.rs"), "placeholder\n").unwrap();
+    let (mut ctrl, _copied) = controller_with_clipboard(dir.path(), MultiLine);
+    setup_ambient(&mut ctrl);
+
+    ctrl.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 41, 1));
+    ctrl.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 44, 2));
+
+    let vs = ctrl.view_state();
+    assert!(
+        vs.line_select.is_none(),
+        "the L-mode overlay is not used for an ambient drag"
+    );
+    let cs = vs
+        .content_selection
+        .expect("the ambient selection overlay is populated");
+    assert_eq!(
+        (cs.start_line, cs.start_col, cs.end_line, cs.end_col),
+        (1, 0, 2, 3),
+        "the overlay carries the exact drag carets (ordered), gutter-less"
+    );
+    assert_eq!(cs.gutter, 0, "MultiLine has no bat gutter → gutter width 0");
+}
+
+#[test]
+fn ambient_plain_click_focuses_and_copies_nothing() {
+    // A press with no drag (Down then Up at the same cell) is a plain click: it focuses the content
+    // pane, leaves no standing selection, and copies nothing.
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("code.rs"), "placeholder\n").unwrap();
+    let (mut ctrl, copied) = controller_with_clipboard(dir.path(), MultiLine);
+    setup_ambient(&mut ctrl);
+
+    ctrl.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 50, 3));
+    let fx = ctrl.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 50, 3));
+
+    assert!(fx.redraw, "the click focuses the content pane (redraw)");
+    assert_eq!(
+        ctrl.focus(),
+        Focus::Content,
+        "a content click focuses the content pane"
+    );
+    assert!(
+        ctrl.view_state().content_selection.is_none(),
+        "a plain click leaves no standing selection"
+    );
+    assert!(
+        copied.lock().unwrap().is_empty(),
+        "a plain click copies nothing"
+    );
+}
+
+#[test]
+fn ambient_press_outside_content_clears_selection() {
+    // Once a selection stands, a left press anywhere outside the content region drops it
+    // (click-away deselect). Column 5 is the tree/outside region (content starts at x 41).
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("code.rs"), "placeholder\n").unwrap();
+    let (mut ctrl, _copied) = controller_with_clipboard(dir.path(), MultiLine);
+    setup_ambient(&mut ctrl);
+    ambient_drag_line1_to_line2(&mut ctrl);
+    assert!(
+        ctrl.view_state().content_selection.is_some(),
+        "precondition: a selection stands"
+    );
+
+    let fx = ctrl.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 5, 3));
+    assert!(fx.redraw, "clearing the selection redraws");
+    assert!(
+        ctrl.view_state().content_selection.is_none(),
+        "a press outside the content region clears the standing selection"
+    );
+}
+
+#[test]
+fn ambient_esc_clears_selection_before_quitting() {
+    // Esc (Intent::Close) dismisses a standing ambient selection first, before it would unzoom or
+    // quit — the outermost layer of the Esc stack. It must redraw and NOT quit.
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("code.rs"), "placeholder\n").unwrap();
+    let (mut ctrl, _copied) = controller_with_clipboard(dir.path(), MultiLine);
+    setup_ambient(&mut ctrl);
+    ambient_drag_line1_to_line2(&mut ctrl);
+    assert!(
+        ctrl.view_state().content_selection.is_some(),
+        "precondition: a selection stands"
+    );
+
+    let fx = ctrl.handle(Intent::Close);
+    assert!(fx.redraw, "dismissing the selection redraws");
+    assert!(
+        !fx.quit,
+        "the first Esc dismisses the selection, it does not quit"
+    );
+    assert!(
+        ctrl.view_state().content_selection.is_none(),
+        "Esc clears the ambient selection"
+    );
+}
+
+#[test]
+fn ambient_selection_cleared_on_content_change() {
+    // Any displayed-content change drops a standing selection so a stale highlight never maps onto
+    // different text. Cycling the view re-renders through dispatch_render, which clears it.
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("code.rs"), "placeholder\n").unwrap();
+    let (mut ctrl, _copied) = controller_with_clipboard(dir.path(), MultiLine);
+    setup_ambient(&mut ctrl);
+    ambient_drag_line1_to_line2(&mut ctrl);
+    assert!(
+        ctrl.view_state().content_selection.is_some(),
+        "precondition: a selection stands"
+    );
+
+    ctrl.handle(Intent::CycleView);
+    assert!(
+        ctrl.view_state().content_selection.is_none(),
+        "a content change (view cycle → dispatch_render) clears the selection"
+    );
+}
+
+#[test]
+fn ambient_shift_drag_is_left_for_the_terminal() {
+    // Shift+mouse is reserved for the terminal's own native selection — it must not start an
+    // ambient selection nor redraw.
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("code.rs"), "placeholder\n").unwrap();
+    let (mut ctrl, _copied) = controller_with_clipboard(dir.path(), MultiLine);
+    setup_ambient(&mut ctrl);
+
+    let fx = ctrl.handle_mouse(shift_mouse(MouseEventKind::Down(MouseButton::Left), 45, 3));
+    assert!(!fx.redraw, "a Shift+press is inert (left for the terminal)");
+    assert!(
+        ctrl.view_state().content_selection.is_none(),
+        "Shift+mouse must not start an ambient selection"
+    );
+}
+
+#[test]
+fn entering_line_select_clears_an_ambient_selection() {
+    // The two selections never coexist: entering L mode drops any standing ambient selection so L
+    // starts with a fresh line marker, not the inherited mouse span.
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("code.rs"), "placeholder\n").unwrap();
+    let (mut ctrl, _copied) = controller_with_clipboard(dir.path(), MultiLine);
+    setup_ambient(&mut ctrl);
+    ambient_drag_line1_to_line2(&mut ctrl);
+    assert!(
+        ctrl.view_state().content_selection.is_some(),
+        "precondition: a selection stands"
+    );
+
+    ctrl.enter_line_select_at_top();
+    assert!(ctrl.line_select_active(), "L mode is now active");
+    let vs = ctrl.view_state();
+    assert!(
+        vs.content_selection.is_none(),
+        "the ambient selection is cleared on entering L mode"
+    );
+    assert_eq!(
+        ctrl.line_selection(),
+        Some((1, 1)),
+        "L mode starts with a fresh line-1 marker, not the ambient span"
+    );
+}
+
+#[test]
+fn ambient_drag_over_directory_guidance_copies_nothing() {
+    // The pane can show first-party guidance ("Directory — select a file to view") when a directory
+    // is selected. Dragging over it must copy nothing — the is_file guard, shared with the L-mode
+    // copy path. A temp dir whose only entry is a subdirectory selects that directory by default.
+    let dir = TempDir::new();
+    std::fs::create_dir(dir.path().join("sub")).unwrap();
+    std::fs::write(dir.path().join("sub").join("inner.rs"), "x\n").unwrap();
+    let (mut ctrl, copied) = controller_with_clipboard(dir.path(), MultiLine);
+    await_marker(&mut ctrl, "Directory \u{2014}"); // the directory-selected guidance ("Directory —")
+    ctrl.set_content_viewport(80, 20);
+    ctrl.set_pane_geometry(content_geometry());
+
+    // Drag across the guidance line (line 1) and release.
+    ctrl.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 41, 1));
+    ctrl.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 50, 1));
+    ctrl.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 50, 1));
+
+    assert!(
+        copied.lock().unwrap().is_empty(),
+        "dragging over directory guidance copies nothing (is_file guard)"
+    );
+}
+
+#[test]
+fn held_ambient_press_does_not_leak_into_line_select() {
+    // A still-held ambient press must not bleed into L mode: entering L mode (the `L` key) mid-press
+    // resets the in-flight drag, so the next mouse-move is inert for L mode. Without the reset the
+    // held `Drag::ContentSelect` would extend the fresh L-mode selection from (top, col 0) to the
+    // cursor — a character selection the user never initiated with an L-mode press.
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("code.rs"), "placeholder\n").unwrap();
+    let (mut ctrl, copied) = controller_with_clipboard(dir.path(), MultiLine);
+    setup_ambient(&mut ctrl);
+
+    // Press and HOLD in the content pane (ambient selection begins; drag == ContentSelect).
+    ctrl.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 41, 1));
+    // Enter L mode without releasing the button.
+    ctrl.enter_line_select_at_top();
+    assert!(
+        ctrl.line_select_active(),
+        "precondition: L mode is now active"
+    );
+
+    // A held-mouse move must be inert for L mode — no L-mode press ever happened.
+    ctrl.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 55, 4));
+    assert_eq!(
+        ctrl.line_selection(),
+        Some((1, 1)),
+        "the L-mode selection stays collapsed on the top line — the held ambient drag did not leak in"
+    );
+    let ls = ctrl
+        .view_state()
+        .line_select
+        .expect("L-mode overlay present");
+    assert!(
+        ls.char_sel.is_none(),
+        "a leaked drag would have produced a character selection; there must be none"
+    );
+
+    // Enter copies the whole top line (line granularity), not an unintended dragged span.
+    ctrl.handle_line_select_key(key(KeyCode::Enter));
+    assert_eq!(
+        copied.lock().unwrap().last().map(String::as_str),
+        Some("line0"),
+        "Enter copies the whole top line (line 1 == \"line0\"), not a dragged char span"
+    );
+}
+
+#[test]
+fn ambient_drag_over_rendering_placeholder_copies_nothing() {
+    // While a render is in flight the pane shows the non-empty "Rendering…" placeholder with a FILE
+    // still selected — so the is_file guard does NOT block it. A press over the placeholder must not
+    // seed a selection (the `content_rendering` press-time guard), so a drag copies nothing.
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("code.rs"), "placeholder\n").unwrap();
+    let (mut ctrl, copied) = controller_with_clipboard(dir.path(), MultiLine);
+    // Do NOT poll: the pane is still showing the "Rendering…" placeholder (content_rendering == true).
+    ctrl.set_content_viewport(80, 20);
+    ctrl.set_pane_geometry(content_geometry());
+    assert!(
+        ctrl.view_state().content_rendering,
+        "precondition: a render is in flight (the placeholder is shown)"
+    );
+
+    ctrl.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 41, 1));
+    ctrl.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 45, 1));
+    ctrl.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 45, 1));
+
+    assert!(
+        ctrl.view_state().content_selection.is_none(),
+        "no selection is seeded over the render placeholder"
+    );
+    assert!(
+        copied.lock().unwrap().is_empty(),
+        "dragging over the \"Rendering…\" placeholder copies nothing"
+    );
+}

--- a/tests/lineselect.rs
+++ b/tests/lineselect.rs
@@ -561,7 +561,8 @@ fn enter_from_source_is_synchronous() {
     );
 }
 
-// ── T-7: Enter copies the selected lines' CONTENT, sanitizes, notifies, and closes the mode ─────
+// ── T-7: the two confirms — Enter copies the `path:line` REFERENCE (the v1.9.0 contract),
+// y/Y copy the selected lines' CONTENT; both sanitize, notify, and close the mode ────────────────
 
 /// Enter line-select at line 5 on a source-view `.rs` file (synchronous fast path).
 fn enter_at_line_five(ctrl: &mut Controller) {
@@ -577,10 +578,10 @@ fn enter_at_line_five(ctrl: &mut Controller) {
 }
 
 #[test]
-fn enter_copies_single_line_content() {
-    // AC-9/AC-10: Enter on a single-line selection copies that line's CONTENT and confirms the
-    // line number in a notice; AC-4-style close: the mode is a completed action so Enter closes it.
-    // MultiLine renders "line0".."line19", so source line 5 is the text "line4".
+fn enter_copies_single_line_reference() {
+    // AC-9/AC-10: Enter on a single-line selection copies the repo-relative `path:line`
+    // REFERENCE — the shipped v1.9.0 contract, unchanged by the copy-content addition — and
+    // confirms it in a notice; AC-4-style close: the mode is a completed action so Enter closes it.
     let dir = TempDir::new();
     std::fs::write(dir.path().join("a.rs"), "placeholder\n").unwrap();
     let (mut ctrl, copied) = controller_with_clipboard(dir.path(), MultiLine);
@@ -590,12 +591,12 @@ fn enter_copies_single_line_content() {
     assert!(fx.redraw, "copying redraws to show the confirmation notice");
     assert_eq!(
         copied.lock().unwrap().last().map(String::as_str),
-        Some("line4"),
-        "AC-9: Enter copies the selected line's content (source line 5 == \"line4\")"
+        Some("a.rs:5"),
+        "AC-9: Enter copies the `path:line` reference (v1.9.0 contract)"
     );
     assert!(
-        ctrl.notices().iter().any(|n| n == "Copied line 5"),
-        "AC-10: the copy is confirmed by line number: {:?}",
+        ctrl.notices().iter().any(|n| n == "Copied a.rs:5"),
+        "AC-10: the copy is confirmed with the reference itself: {:?}",
         ctrl.notices()
     );
     assert!(
@@ -605,9 +606,8 @@ fn enter_copies_single_line_content() {
 }
 
 #[test]
-fn range_copies_lines_joined_by_newline() {
-    // AC-9: Enter on an extended selection copies every selected line's content, joined with '\n'.
-    // Selection 5-8 over MultiLine → "line4".."line7".
+fn enter_copies_range_reference() {
+    // AC-9: Enter on an extended selection copies the `path:start-end` range reference.
     let dir = TempDir::new();
     std::fs::write(dir.path().join("a.rs"), "placeholder\n").unwrap();
     let (mut ctrl, copied) = controller_with_clipboard(dir.path(), MultiLine);
@@ -626,8 +626,35 @@ fn range_copies_lines_joined_by_newline() {
     ctrl.handle_line_select_key(key(KeyCode::Enter));
     assert_eq!(
         copied.lock().unwrap().last().map(String::as_str),
+        Some("a.rs:5-8"),
+        "AC-9: Enter copies the `path:start-end` range reference"
+    );
+}
+
+#[test]
+fn range_copies_lines_joined_by_newline() {
+    // `y` on an extended selection copies every selected line's content, joined with '\n'.
+    // Selection 5-8 over MultiLine → "line4".."line7".
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.rs"), "placeholder\n").unwrap();
+    let (mut ctrl, copied) = controller_with_clipboard(dir.path(), MultiLine);
+    enter_at_line_five(&mut ctrl);
+
+    // Extend the selection from 5 down to 8 (Shift+j, reported as `Char('J')`).
+    ctrl.handle_line_select_key(key(KeyCode::Char('J')));
+    ctrl.handle_line_select_key(key(KeyCode::Char('J')));
+    ctrl.handle_line_select_key(key(KeyCode::Char('J')));
+    assert_eq!(
+        ctrl.line_selection(),
+        Some((5, 8)),
+        "precondition: selection 5-8"
+    );
+
+    ctrl.handle_line_select_key(key(KeyCode::Char('y')));
+    assert_eq!(
+        copied.lock().unwrap().last().map(String::as_str),
         Some("line4\nline5\nline6\nline7"),
-        "AC-9: Enter copies the range's content joined by newlines"
+        "y copies the range's content joined by newlines"
     );
     assert!(
         ctrl.notices().iter().any(|n| n == "Copied lines 5-8"),
@@ -653,12 +680,12 @@ fn copy_strips_line_number_gutter_keeps_indentation() {
         "precondition: marker on line 1"
     );
 
-    // Extend over all three lines (1 → 3) and copy.
+    // Extend over all three lines (1 → 3) and copy the content with `y`.
     ctrl.handle_line_select_key(key(KeyCode::Char('J')));
     ctrl.handle_line_select_key(key(KeyCode::Char('J')));
     assert_eq!(ctrl.line_selection(), Some((1, 3)), "precondition: 1-3");
 
-    ctrl.handle_line_select_key(key(KeyCode::Enter));
+    ctrl.handle_line_select_key(key(KeyCode::Char('y')));
     assert_eq!(
         copied.lock().unwrap().last().map(String::as_str),
         Some("fn main() {\n    let x = 5;\n}"),
@@ -667,9 +694,10 @@ fn copy_strips_line_number_gutter_keeps_indentation() {
 }
 
 #[test]
-fn y_copies_content_like_enter() {
-    // The familiar copy keys `y`/`Y` confirm exactly like Enter (line-select routes every key
-    // through `handle_line_select_key`, so these are wired to the copy path explicitly).
+fn y_copies_single_line_content() {
+    // The familiar copy keys `y`/`Y` copy the selection's CONTENT — the counterpart to Enter's
+    // reference (line-select routes every key through `handle_line_select_key`, so these are
+    // wired to the content-copy path explicitly). One selection, two products.
     let dir = TempDir::new();
     std::fs::write(dir.path().join("a.rs"), "placeholder\n").unwrap();
     let (mut ctrl, copied) = controller_with_clipboard(dir.path(), MultiLine);
@@ -680,7 +708,12 @@ fn y_copies_content_like_enter() {
     assert_eq!(
         copied.lock().unwrap().last().map(String::as_str),
         Some("line4"),
-        "y copies the selected line's content, just like Enter"
+        "y copies the selected line's content (source line 5 == \"line4\")"
+    );
+    assert!(
+        ctrl.notices().iter().any(|n| n == "Copied line 5"),
+        "the content copy is confirmed by line number: {:?}",
+        ctrl.notices()
     );
     assert!(
         !ctrl.line_select_active(),
@@ -705,7 +738,7 @@ fn control_bytes_in_content_are_sanitized_tabs_kept() {
         "precondition: marker on the single line"
     );
 
-    ctrl.handle_line_select_key(key(KeyCode::Enter));
+    ctrl.handle_line_select_key(key(KeyCode::Char('y')));
     let log = copied.lock().unwrap();
     let got = log.last().map(String::as_str).unwrap();
     assert_eq!(
@@ -838,7 +871,7 @@ fn shift_mouse_is_left_for_the_terminal() {
 
 #[test]
 fn drag_selects_characters_across_lines_and_copies() {
-    // Press → drag → release selects a character-granular span; Enter copies exactly that span
+    // Press → drag → release selects a character-granular span; `y` copies exactly that span
     // (the tail of the first line + the head of the last, joined by '\n'). MultiLine renders
     // "line0".."line19" with no gutter, so char carets map straight to columns.
     let dir = TempDir::new();
@@ -857,11 +890,11 @@ fn drag_selects_characters_across_lines_and_copies() {
         "release finalizes the selection but keeps the mode open for Enter/y"
     );
 
-    ctrl.handle_line_select_key(key(KeyCode::Enter));
+    ctrl.handle_line_select_key(key(KeyCode::Char('y')));
     assert_eq!(
         copied.lock().unwrap().last().map(String::as_str),
         Some("line0\nlin"),
-        "Enter copies the character span: all of line 1 + the first 3 chars of line 2"
+        "y copies the character span: all of line 1 + the first 3 chars of line 2"
     );
     assert!(
         ctrl.notices().iter().any(|n| n == "Copied selection"),
@@ -870,7 +903,28 @@ fn drag_selects_characters_across_lines_and_copies() {
     );
     assert!(
         !ctrl.line_select_active(),
-        "Enter closes the mode after copying"
+        "y closes the mode after copying"
+    );
+}
+
+#[test]
+fn enter_after_drag_copies_reference_of_spanned_lines() {
+    // Enter after a mouse drag copies the REFERENCE for the lines the drag spans — the same
+    // selection can produce either product: `y` the dragged characters, Enter the `path:lines`.
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("code.rs"), "placeholder\n").unwrap();
+    let (mut ctrl, copied) = controller_with_clipboard(dir.path(), MultiLine);
+    enter_line_select_top(&mut ctrl);
+
+    ctrl.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 42, 1));
+    ctrl.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 45, 2));
+    ctrl.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 45, 2));
+
+    ctrl.handle_line_select_key(key(KeyCode::Enter));
+    assert_eq!(
+        copied.lock().unwrap().last().map(String::as_str),
+        Some("code.rs:1-2"),
+        "Enter copies the range reference for the dragged lines"
     );
 }
 
@@ -899,10 +953,10 @@ fn drag_populates_char_selection_in_the_view() {
 }
 
 #[test]
-fn click_without_drag_collapses_and_enter_copies_the_line() {
-    // A press with no drag collapses the selection onto one character; Enter then falls back to
-    // copying the whole clicked line, so a plain click-then-Enter still yields a line. Row 3 →
-    // source line 3 == "line2".
+fn click_without_drag_collapses_and_y_copies_the_line() {
+    // A press with no drag collapses the selection onto one character; `y` then falls back to
+    // copying the whole clicked line, so a plain click-then-y still yields a line — and Enter
+    // yields that line's reference. Row 3 → source line 3 == "line2".
     let dir = TempDir::new();
     std::fs::write(dir.path().join("code.rs"), "placeholder\n").unwrap();
     let (mut ctrl, copied) = controller_with_clipboard(dir.path(), MultiLine);
@@ -910,11 +964,22 @@ fn click_without_drag_collapses_and_enter_copies_the_line() {
 
     ctrl.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 50, 3));
     ctrl.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 50, 3));
-    ctrl.handle_line_select_key(key(KeyCode::Enter));
+    ctrl.handle_line_select_key(key(KeyCode::Char('y')));
     assert_eq!(
         copied.lock().unwrap().last().map(String::as_str),
         Some("line2"),
         "a collapsed click copies the whole clicked line (source line 3 == \"line2\")"
+    );
+
+    // The same collapsed click, confirmed with Enter, yields the line's reference.
+    ctrl.enter_line_select_at_top();
+    ctrl.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 50, 3));
+    ctrl.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 50, 3));
+    ctrl.handle_line_select_key(key(KeyCode::Enter));
+    assert_eq!(
+        copied.lock().unwrap().last().map(String::as_str),
+        Some("code.rs:3"),
+        "Enter on the collapsed click copies the clicked line's reference"
     );
 }
 
@@ -1422,12 +1487,12 @@ fn held_ambient_press_does_not_leak_into_line_select() {
         "a leaked drag would have produced a character selection; there must be none"
     );
 
-    // Enter copies the whole top line (line granularity), not an unintended dragged span.
-    ctrl.handle_line_select_key(key(KeyCode::Enter));
+    // `y` copies the whole top line (line granularity), not an unintended dragged span.
+    ctrl.handle_line_select_key(key(KeyCode::Char('y')));
     assert_eq!(
         copied.lock().unwrap().last().map(String::as_str),
         Some("line0"),
-        "Enter copies the whole top line (line 1 == \"line0\"), not a dragged char span"
+        "y copies the whole top line (line 1 == \"line0\"), not a dragged char span"
     );
 }
 

--- a/tests/lineselect.rs
+++ b/tests/lineselect.rs
@@ -60,6 +60,7 @@ impl ContentProvider for MultiLine {
         RenderResult {
             content: Text::raw(lines.join("\n")),
             notices: Vec::new(),
+            source: None,
         }
     }
 }
@@ -79,6 +80,7 @@ impl ContentProvider for WrapBody {
         RenderResult {
             content: Text::raw(lines.join("\n")),
             notices: Vec::new(),
+            source: None,
         }
     }
 }
@@ -169,6 +171,7 @@ impl ContentProvider for EmptyContent {
         RenderResult {
             content: Text::default(),
             notices: Vec::new(),
+            source: None,
         }
     }
 }
@@ -184,6 +187,7 @@ impl ContentProvider for ControlContent {
         RenderResult {
             content: Text::raw("\tcode\x1bhere"),
             notices: Vec::new(),
+            source: None,
         }
     }
 }
@@ -199,6 +203,7 @@ impl ContentProvider for GutterContent {
         RenderResult {
             content: Text::raw(lines.join("\n")),
             notices: Vec::new(),
+            source: None,
         }
     }
 }
@@ -1523,5 +1528,152 @@ fn ambient_drag_over_rendering_placeholder_copies_nothing() {
     assert!(
         copied.lock().unwrap().is_empty(),
         "dragging over the \"Rendering…\" placeholder copies nothing"
+    );
+}
+
+// ── retained source: copies are byte-faithful and the gutter is source-anchored ─────────────
+// A source-mapped render retains the file's raw lines (`RenderResult::source`, 1:1 with the
+// displayed lines). Whole-line copies then return the SOURCE text verbatim (real tabs — the
+// renderer expands them to spaces on screen — and no gutter parsing at all), and the gutter
+// width is anchored by matching the displayed line against its source instead of guessed from
+// leading digits — killing the heuristic's one false positive (a gutter-less line that happens
+// to start with its own line number).
+
+/// Bat-style displayed lines (gutter + tab expanded to 4 spaces) with the REAL source retained,
+/// as the live renderer supplies for `SyntaxContent`.
+#[derive(Clone, Copy)]
+struct GutterWithSource;
+impl ContentProvider for GutterWithSource {
+    fn render(&self, _path: &Path, _mode: ViewMode, _raw_diff: Option<&str>) -> RenderResult {
+        let displayed = ["   1 fn main() {", "   2     let x = 5;", "   3 }"];
+        RenderResult {
+            content: Text::raw(displayed.join("\n")),
+            notices: Vec::new(),
+            source: Some(vec![
+                "fn main() {".to_string(),
+                "\tlet x = 5;".to_string(), // REAL tab in the file; bat shows 4 spaces
+                "}".to_string(),
+            ]),
+        }
+    }
+}
+
+/// A gutter-less view (plain-text fallback) whose line 3 happens to START with "3 " — the exact
+/// input that fools the digit heuristic — with the source retained to anchor the truth.
+#[derive(Clone, Copy)]
+struct PlainWithSource;
+impl ContentProvider for PlainWithSource {
+    fn render(&self, _path: &Path, _mode: ViewMode, _raw_diff: Option<&str>) -> RenderResult {
+        let lines = ["fn main() {", "    let x = 5;", "3 loops below"];
+        RenderResult {
+            content: Text::raw(lines.join("\n")),
+            notices: Vec::new(),
+            source: Some(vec![
+                "fn main() {".to_string(),
+                "\tlet x = 5;".to_string(),
+                "3 loops below".to_string(),
+            ]),
+        }
+    }
+}
+
+#[test]
+fn line_copy_returns_source_verbatim_real_tabs_no_gutter() {
+    // Whole-line copies come from the retained source: the bat gutter never needs stripping and
+    // the file's REAL tab indentation survives (the display shows expanded spaces).
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("code.rs"), "placeholder\n").unwrap();
+    let (mut ctrl, copied) = controller_with_clipboard(dir.path(), GutterWithSource);
+    await_marker(&mut ctrl, "fn main");
+    ctrl.set_content_viewport(80, 10);
+    ctrl.enter_line_select_at_top();
+
+    ctrl.handle_line_select_key(key(KeyCode::Char('J'))); // extend 1 → 2
+    ctrl.handle_line_select_key(key(KeyCode::Char('y')));
+    assert_eq!(
+        copied.lock().unwrap().last().map(String::as_str),
+        Some("fn main() {\n\tlet x = 5;"),
+        "the copy is the SOURCE text: no gutter, and the real tab survives (not 4 spaces)"
+    );
+}
+
+#[test]
+fn gutterless_line_starting_with_its_own_number_is_not_mis_stripped() {
+    // Line 3 of a gutter-less view reads "3 loops below" — the digit heuristic alone would strip
+    // the leading "3 " as a gutter. With the source retained the copy is anchored to the truth.
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("code.rs"), "placeholder\n").unwrap();
+    let (mut ctrl, copied) = controller_with_clipboard(dir.path(), PlainWithSource);
+    await_marker(&mut ctrl, "fn main");
+    ctrl.set_content_viewport(80, 10);
+    ctrl.enter_line_select_at_top();
+
+    ctrl.handle_line_select_key(key(KeyCode::Char('j'))); // 1 → 2
+    ctrl.handle_line_select_key(key(KeyCode::Char('j'))); // 2 → 3
+    ctrl.handle_line_select_key(key(KeyCode::Char('y')));
+    assert_eq!(
+        copied.lock().unwrap().last().map(String::as_str),
+        Some("3 loops below"),
+        "a line that merely starts with its own number keeps its leading digits"
+    );
+}
+
+#[test]
+fn char_drag_gutter_is_source_anchored_not_guessed() {
+    // The same false-positive line, selected char-granularly with the mouse: the source-anchored
+    // gutter is 0 (the displayed line IS the source), so carets [0, 3) map to "3 l" — the digit
+    // heuristic would have mis-based every caret by the phantom 2-char "gutter".
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("code.rs"), "placeholder\n").unwrap();
+    let (mut ctrl, copied) = controller_with_clipboard(dir.path(), PlainWithSource);
+    await_marker(&mut ctrl, "fn main");
+    ctrl.set_content_viewport(80, 10);
+    ctrl.set_pane_geometry(content_geometry());
+    ctrl.enter_line_select_at_top();
+
+    // L-mode geometry: content x=41 + 1 overlay glyph col. Row 3 → source line 3.
+    ctrl.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 42, 3));
+    ctrl.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 45, 3));
+    ctrl.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 45, 3));
+    ctrl.handle_line_select_key(key(KeyCode::Char('y')));
+    assert_eq!(
+        copied.lock().unwrap().last().map(String::as_str),
+        Some("3 l"),
+        "carets are based off the source-anchored gutter (0), not the heuristic's guess"
+    );
+}
+
+#[test]
+fn source_control_bytes_are_still_scrubbed() {
+    // The retained source is untrusted file bytes — the AC-16 control scrub applies to it exactly
+    // as to display extraction (tabs kept, ESC dropped).
+    #[derive(Clone, Copy)]
+    struct HostileSource;
+    impl ContentProvider for HostileSource {
+        fn render(&self, _path: &Path, _mode: ViewMode, _raw_diff: Option<&str>) -> RenderResult {
+            RenderResult {
+                content: Text::raw("clean view"),
+                notices: Vec::new(),
+                source: Some(vec!["\tcode\x1b[2Jhere".to_string()]),
+            }
+        }
+    }
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("code.rs"), "placeholder\n").unwrap();
+    let (mut ctrl, copied) = controller_with_clipboard(dir.path(), HostileSource);
+    await_marker(&mut ctrl, "clean");
+    ctrl.set_content_viewport(80, 10);
+    ctrl.enter_line_select_at_top();
+
+    ctrl.handle_line_select_key(key(KeyCode::Char('y')));
+    let log = copied.lock().unwrap();
+    let got = log.last().map(String::as_str).unwrap();
+    assert_eq!(
+        got, "\tcode[2Jhere",
+        "the ESC byte is dropped from the source-backed copy; the tab survives"
+    );
+    assert!(
+        !got.chars().any(|c| c.is_control() && c != '\t'),
+        "no control byte (other than tab) reaches the clipboard: {got:?}"
     );
 }

--- a/tests/lineselect.rs
+++ b/tests/lineselect.rs
@@ -1531,6 +1531,183 @@ fn ambient_drag_over_rendering_placeholder_copies_nothing() {
     );
 }
 
+// ── wrapped views: mouse selection is char-granular through the break-position map ──────────
+// Under wrap (prose by default, or the `w` override) a source line spans several display rows.
+// `char_at_content_col` maps a click through `text_layout::wrap_row_starts` — the SAME greedy
+// word-packing simulation the wrapped scroll math counts rows with (`wrapped_rows` is defined
+// from it, so they can never drift) — so the caret lands on the character actually under the
+// cursor, and a drag copies exactly the swept span. WrapBody at width 80: source line 1
+// ("a"×170, one word) char-breaks at [0, 80, 160] (display rows 0-2); line 2 ("b"×90) at
+// [0, 80] (rows 3-4). Screen row = display row + 1 (content top y=1), ambient column = 41 + col.
+
+/// Await WrapBody, wire the geometry, and turn the `w` wrap override on WITHOUT entering L mode.
+fn setup_ambient_wrapped(ctrl: &mut Controller) {
+    await_marker(ctrl, "aaa");
+    ctrl.set_content_viewport(80, 20);
+    ctrl.set_pane_geometry(content_geometry());
+    ctrl.handle(Intent::ToggleWrap);
+    assert!(ctrl.wrap_override(), "precondition: wrap override is on");
+    assert!(!ctrl.line_select_active(), "precondition: no modal open");
+}
+
+#[test]
+fn wrapped_ambient_drag_copies_the_exact_char_span() {
+    // Press on screen row 1 col 50 → display row 0 → line 1, row-start 0, caret 9. Drag to screen
+    // row 4 col 50 → display row 3 → line 2's FIRST wrapped row, caret 9. The copy is exactly the
+    // swept span: the tail of line 1 from char 9 + the head of line 2 up to char 9.
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("code.rs"), "placeholder\n").unwrap();
+    let (mut ctrl, copied) = controller_with_clipboard(dir.path(), WrapBody);
+    setup_ambient_wrapped(&mut ctrl);
+
+    ctrl.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 50, 1));
+    ctrl.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 50, 4));
+    let fx = ctrl.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 50, 4));
+
+    assert!(fx.redraw, "the release redraws");
+    let expected = format!("{}\n{}", "a".repeat(161), "b".repeat(9));
+    assert_eq!(
+        copied.lock().unwrap().last().map(String::as_str),
+        Some(expected.as_str()),
+        "the wrapped drag copies the exact char span (line 1 from char 9 + line 2 up to char 9)"
+    );
+    assert!(
+        ctrl.notices().iter().any(|n| n == "Copied selection"),
+        "the notice confirms the selection copy: {:?}",
+        ctrl.notices()
+    );
+}
+
+#[test]
+fn wrapped_drag_across_rows_of_one_line_selects_its_chars() {
+    // Screen rows 1 and 2 are both display rows OF SOURCE LINE 1 (an "a"×170 word char-broken at
+    // 80). Press row 1 col 45 → caret 4; drag row 2 col 60 → row-start 80 + col 19 = caret 99.
+    // The copy is chars [4, 99) of that single line — a word-or-two selection inside one wrapped
+    // paragraph, the exact gesture line-granularity couldn't do.
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("code.rs"), "placeholder\n").unwrap();
+    let (mut ctrl, copied) = controller_with_clipboard(dir.path(), WrapBody);
+    setup_ambient_wrapped(&mut ctrl);
+
+    ctrl.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 45, 1));
+    ctrl.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 60, 2));
+    ctrl.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 60, 2));
+
+    let expected = "a".repeat(95);
+    assert_eq!(
+        copied.lock().unwrap().last().map(String::as_str),
+        Some(expected.as_str()),
+        "chars [4, 99) of the wrapped line — mapped through its row starts [0, 80, 160]"
+    );
+}
+
+#[test]
+fn wrapped_word_break_maps_columns_to_the_right_word() {
+    // Word wrap (not just char wrap): a 50-char word + a 40-char word at width 80 breaks BEFORE
+    // the second word — row 1 starts at char 51 (index 50 is the separator space, which stays on
+    // row 0). A drag on row 1 cols 3..8 must therefore select chars [54, 59) == "bbbbb", proving
+    // the caret map uses real break positions, not a naive row*width offset.
+    #[derive(Clone, Copy)]
+    struct WordWrapBody;
+    impl ContentProvider for WordWrapBody {
+        fn render(&self, _path: &Path, _mode: ViewMode, _raw_diff: Option<&str>) -> RenderResult {
+            RenderResult {
+                content: Text::raw(format!("{} {}", "a".repeat(50), "b".repeat(40))),
+                notices: Vec::new(),
+                source: None,
+            }
+        }
+    }
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("code.rs"), "placeholder\n").unwrap();
+    let (mut ctrl, copied) = controller_with_clipboard(dir.path(), WordWrapBody);
+    await_marker(&mut ctrl, "aaa");
+    ctrl.set_content_viewport(80, 20);
+    ctrl.set_pane_geometry(content_geometry());
+    ctrl.handle(Intent::ToggleWrap);
+    assert!(ctrl.wrap_override(), "precondition: wrap override is on");
+
+    // Screen row 2 = display row 1 = the second word's row (starts at char 51).
+    ctrl.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 44, 2)); // col 3 → caret 54
+    ctrl.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 49, 2)); // col 8 → caret 59
+    ctrl.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 49, 2));
+
+    assert_eq!(
+        copied.lock().unwrap().last().map(String::as_str),
+        Some("bbbbb"),
+        "row 1 begins at the second WORD (char 51) — the break-position map, not row×width"
+    );
+}
+
+#[test]
+fn wrapped_ambient_plain_click_copies_nothing() {
+    // A press + release with no drag under wrap is still a plain click: focus only, no selection,
+    // no copy.
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("code.rs"), "placeholder\n").unwrap();
+    let (mut ctrl, copied) = controller_with_clipboard(dir.path(), WrapBody);
+    setup_ambient_wrapped(&mut ctrl);
+
+    ctrl.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 50, 2));
+    ctrl.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 50, 2));
+
+    assert!(
+        copied.lock().unwrap().is_empty(),
+        "a plain click under wrap copies nothing"
+    );
+    assert!(
+        ctrl.view_state().content_selection.is_none(),
+        "no selection highlight is left standing by a plain click"
+    );
+}
+
+#[test]
+fn wrapped_l_mode_drag_selects_chars_and_both_confirms_work() {
+    // In L mode under wrap the same mapping applies (minus the 1-col ▶ glyph): a press places the
+    // char caret, a drag extends it; `y` copies the swept chars and Enter the range reference.
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("code.rs"), "placeholder\n").unwrap();
+    let (mut ctrl, copied) = controller_with_clipboard(dir.path(), WrapBody);
+    await_marker(&mut ctrl, "aaa");
+    ctrl.set_content_viewport(80, 20);
+    ctrl.set_pane_geometry(content_geometry());
+    ctrl.handle(Intent::ToggleWrap);
+    assert!(ctrl.wrap_override(), "precondition: wrap override is on");
+    ctrl.enter_line_select_at_top();
+
+    // Press screen row 1 col 50 → disp col 8 (pane x 41 + 1 glyph) → line 1 caret 8; drag to
+    // screen row 4 col 50 → line 2 (its first wrapped row) caret 8.
+    ctrl.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 50, 1));
+    ctrl.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 50, 4));
+    ctrl.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 50, 4));
+    assert_eq!(
+        ctrl.line_selection(),
+        Some((1, 2)),
+        "the drag spans source lines 1-2"
+    );
+
+    // y copies the swept char span …
+    ctrl.handle_line_select_key(key(KeyCode::Char('y')));
+    let expected = format!("{}\n{}", "a".repeat(162), "b".repeat(8));
+    assert_eq!(
+        copied.lock().unwrap().last().map(String::as_str),
+        Some(expected.as_str()),
+        "y copies the char span under wrap (line 1 from char 8 + line 2 up to char 8)"
+    );
+
+    // … and Enter (on a fresh identical selection) the range reference.
+    ctrl.enter_line_select_at_top();
+    ctrl.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 50, 1));
+    ctrl.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 50, 4));
+    ctrl.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 50, 4));
+    ctrl.handle_line_select_key(key(KeyCode::Enter));
+    assert_eq!(
+        copied.lock().unwrap().last().map(String::as_str),
+        Some("code.rs:1-2"),
+        "Enter copies the range reference for the wrapped drag"
+    );
+}
+
 // ── retained source: copies are byte-faithful and the gutter is source-anchored ─────────────
 // A source-mapped render retains the file's raw lines (`RenderResult::source`, 1:1 with the
 // displayed lines). Whole-line copies then return the SOURCE text verbatim (real tabs — the
@@ -1675,5 +1852,46 @@ fn source_control_bytes_are_still_scrubbed() {
     assert!(
         !got.chars().any(|c| c.is_control() && c != '\t'),
         "no control byte (other than tab) reaches the clipboard: {got:?}"
+    );
+}
+
+#[test]
+fn wrapped_break_dropped_space_does_not_shift_selection_to_the_line_above() {
+    // Regression (owner-caught live): ratatui DROPS the whitespace at a row break, so a line of
+    // two exact-width words renders in FEWER rows than ceil(chars/width) — the old char-wrap
+    // floor overcounted its rows, shifting the row→line mapping so a click on the next line
+    // selected the line ABOVE. Line 1 ("x"×40 + " " + "y"×40) renders as exactly 2 rows at
+    // width 40; the click on display row 2 (screen row 3) must therefore select line 2.
+    #[derive(Clone, Copy)]
+    struct DropBreakBody;
+    impl ContentProvider for DropBreakBody {
+        fn render(&self, _path: &Path, _mode: ViewMode, _raw_diff: Option<&str>) -> RenderResult {
+            let line1 = format!("{} {}", "x".repeat(40), "y".repeat(40));
+            RenderResult {
+                content: Text::raw(format!("{line1}\nsecond\nthird")),
+                notices: Vec::new(),
+                source: None,
+            }
+        }
+    }
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("code.rs"), "placeholder\n").unwrap();
+    let (mut ctrl, copied) = controller_with_clipboard(dir.path(), DropBreakBody);
+    await_marker(&mut ctrl, "second");
+    ctrl.set_content_viewport(40, 20);
+    ctrl.set_pane_geometry(content_geometry());
+    ctrl.handle(Intent::ToggleWrap);
+    assert!(ctrl.wrap_override(), "precondition: wrap override is on");
+
+    // Screen row 3 = display row 2 = the FIRST row after line 1's two wrapped rows → line 2.
+    // Drag chars [2, 6) of "second" and release: the copy must come from line 2, not line 1.
+    ctrl.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 43, 3));
+    ctrl.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 47, 3));
+    ctrl.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 47, 3));
+
+    assert_eq!(
+        copied.lock().unwrap().last().map(String::as_str),
+        Some("cond"),
+        "the click on display row 2 maps to line 2 (\"second\") — not the line above"
     );
 }

--- a/tests/presenter.rs
+++ b/tests/presenter.rs
@@ -2693,7 +2693,12 @@ fn line_select_state(marker: usize, start: usize, end: usize) -> ViewState {
     st.focus = Focus::Content;
     st.content = to_text("line one\nline two\nline three\nline four\nline five\nline six\n");
     st.content_rows = 6;
-    st.line_select = Some(LineSelectView { marker, start, end });
+    st.line_select = Some(LineSelectView {
+        marker,
+        start,
+        end,
+        char_sel: None,
+    });
     st
 }
 

--- a/tests/presenter.rs
+++ b/tests/presenter.rs
@@ -3,8 +3,8 @@
 
 use herdr_file_viewer::git::Status;
 use herdr_file_viewer::presenter::{
-    ContentSearch, FinderView, Focus, HelpView, LineSelectView, PickerRowView, PickerView,
-    ViewState, draw,
+    CharSelView, ContentSearch, FinderView, Focus, HelpView, LineSelectView, PickerRowView,
+    PickerView, ViewState, draw,
 };
 use herdr_file_viewer::render::to_text;
 use herdr_file_viewer::search::Match;
@@ -87,6 +87,7 @@ fn sample_state() -> ViewState {
         content_rendering: false,
         search: None,
         line_select: None,
+        content_selection: None,
         help: None,
     }
 }
@@ -2792,6 +2793,75 @@ fn line_select_marker_and_selection_carry_theme_styles() {
         out_bg,
         HIGHLIGHT.bg.unwrap(),
         "a row outside the selection must not be highlighted"
+    );
+}
+
+// ── content_selection overlay — ambient mouse drag-select (gutter-less char highlight) ───────
+
+#[test]
+fn ambient_selection_highlights_only_selected_chars_without_shifting_content() {
+    // The ambient (no-modal) selection overlay highlights ONLY the dragged characters and prepends
+    // NO gutter glyph — so, unlike the L-mode overlay, the content is not shifted right one column.
+    use herdr_file_viewer::highlight::HIGHLIGHT;
+    use herdr_file_viewer::presenter::geometry;
+    use herdr_file_viewer::render::to_text;
+    use ratatui::layout::Rect;
+
+    // Content "line one\n…"; select chars [5, 8) of line 1 → "one" (gutter 0, no bat gutter).
+    let mut st = sample_state();
+    st.notices = vec![];
+    st.focus = Focus::Content;
+    st.content = to_text("line one\nline two\nline three\n");
+    st.content_rows = 3;
+    st.content_selection = Some(CharSelView {
+        start_line: 1,
+        start_col: 5,
+        end_line: 1,
+        end_col: 8,
+        gutter: 0,
+    });
+
+    let (w, h) = (100u16, 24u16);
+    let area = Rect {
+        x: 0,
+        y: 0,
+        width: w,
+        height: h,
+    };
+    let buf = render_buffer(&st, w, h);
+    let content_inner = geometry(area, &st)
+        .content_inner
+        .expect("content inner must be present");
+    let (first, top) = (content_inner.x, content_inner.y);
+
+    // No gutter glyph: the very first content cell is the real first char 'l' of "line one", not a
+    // ▶/│ glyph or a shifted char (the L-mode overlay would put a glyph here instead).
+    assert_eq!(
+        buf.cell((first, top)).unwrap().symbol(),
+        "l",
+        "the ambient overlay prepends no gutter glyph — content is not shifted right"
+    );
+
+    // The selected chars "one" (cols 5..8) carry the HIGHLIGHT background.
+    for dx in 5..8u16 {
+        let bg = buf.cell((first + dx, top)).unwrap().bg;
+        assert_eq!(
+            bg,
+            HIGHLIGHT.bg.unwrap(),
+            "selected char at col {dx} must carry the HIGHLIGHT background"
+        );
+    }
+    // The space just before the selection (col 4) is NOT highlighted.
+    assert_ne!(
+        buf.cell((first + 4, top)).unwrap().bg,
+        HIGHLIGHT.bg.unwrap(),
+        "an unselected char on the boundary line must not be highlighted"
+    );
+    // A line outside the selection (line 2) is entirely unselected.
+    assert_ne!(
+        buf.cell((first, top + 1)).unwrap().bg,
+        HIGHLIGHT.bg.unwrap(),
+        "a line outside the selection must not be highlighted"
     );
 }
 

--- a/tests/presenter_narrow.rs
+++ b/tests/presenter_narrow.rs
@@ -51,6 +51,7 @@ fn state(width: u16, focus: Focus) -> ViewState {
         content_rendering: false,
         search: None,
         line_select: None,
+        content_selection: None,
         help: None,
     }
 }

--- a/tests/reroot.rs
+++ b/tests/reroot.rs
@@ -68,6 +68,7 @@ impl ContentProvider for FakeContent {
         RenderResult {
             content: Text::raw("fake-rendered-content"),
             notices: Vec::new(),
+            source: None,
         }
     }
 }
@@ -648,6 +649,7 @@ impl ContentProvider for EchoDiffContent {
         RenderResult {
             content,
             notices: Vec::new(),
+            source: None,
         }
     }
 }

--- a/tests/reveal_open.rs
+++ b/tests/reveal_open.rs
@@ -73,6 +73,7 @@ impl ContentProvider for StubContent {
         RenderResult {
             content: Text::raw("stub"),
             notices: Vec::new(),
+            source: None,
         }
     }
 }

--- a/tests/search_integration.rs
+++ b/tests/search_integration.rs
@@ -125,6 +125,7 @@ impl ContentProvider for SearchContent {
         RenderResult {
             content: Text::raw(lines.join("\n")),
             notices: Vec::new(),
+            source: None,
         }
     }
 }
@@ -148,6 +149,7 @@ impl ContentProvider for TruncatedContent {
         RenderResult {
             content: Text::raw(shown.join("\n")),
             notices: Vec::new(),
+            source: None,
         }
     }
 }

--- a/tests/update_banner.rs
+++ b/tests/update_banner.rs
@@ -40,6 +40,7 @@ impl ContentProvider for Content {
         RenderResult {
             content: Text::raw(""),
             notices: Vec::new(),
+            source: None,
         }
     }
 }


### PR DESCRIPTION
## Summary

Two related improvements to mouse text selection in the content pane.

### 1. Line-select mode copies content (and supports mouse selection)
- Adds click-drag mouse text selection in line-select mode: press to start, drag to extend (auto-scrolling past an edge), release to finish, with the selection highlighted live as you drag.
- `Enter`/`y`/`Y` now copies the actual selected content instead of a `path:line` reference — the joined line text for a keyboard selection, or the exact dragged character span for a mouse selection. The `bat --style=numbers` line-number gutter is stripped, indentation is preserved, and stray control bytes are removed before hitting the clipboard (tabs kept).
- Confirmation notice names what was copied (e.g. "Copied lines 42-58" / "Copied selection").
- A mouse press now places the selection caret; a plain click no longer drops a line marker, and double-click no longer copies.

### 2. Ambient drag-select (no mode required)
- Click-drag over the content pane during **normal navigation** — no mode to enter — selects text character-by-character; releasing the drag **auto-copies** it to the clipboard ("Copied selection"), leaving the highlight standing for feedback.
- Implemented via a `content_selection` field held **outside** the `Modal` enum, so `Modal::None` stays in force and every keyboard binding keeps its normal meaning (that's what makes it ambient, not a mode). It reuses the line-select char primitives verbatim; **L line-select mode is left untouched** and keyboard-driven, and the two are mutually exclusive by construction.
- Drawn with a gutter-less overlay (no ▶/│ glyph, no content shift) so it reads as a plain text selection.
- Cleared on any content change, `Esc`, a click-away, a plain click, or entering L mode; it survives content scrolling. Guards: `Shift`+drag stays reserved for the terminal's native selection; copying is blocked over a non-file selection and while a render is in flight.

### Both
- `Shift`+mouse is left alone so the terminal's own native selection still works.
- No changes to `intent.rs`, `input.rs`, or `app.rs`.

Closes #76

## Test plan
- [x] `cargo test` — unit + integration coverage in `tests/lineselect.rs` (line-select + ambient: auto-copy on release, plain-click focuses, click-away/Esc/content-change clears, Shift inert, directory/render-placeholder guards, no leak into L mode) and `tests/presenter.rs` (gutter-less char highlight, no content shift). One pre-existing e2e pty test (`search_routes_keys_…`) is flaky on macOS and fails identically on the base branch.
- [x] `cargo clippy --all-targets -- -D warnings` and `cargo fmt --all --check` clean under the CI-pinned toolchain (1.96.0).
- [x] Manually verified the line-select mouse selection/copy in a real terminal (ghostty, per #76).
- [x] Manual spin of the **ambient** drag-select in a real terminal still pending — the ambient path is exercised by the automated mouse-handler tests above, but has not yet been driven live.


## Screenshots

### No mode
<img width="3680" height="2392" alt="image" src="https://github.com/user-attachments/assets/036c4bde-bcad-4a10-86ed-142ade54919d" />

### Line selection mode

<img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/e29006a5-957b-4f34-bb68-b3e21f038b4b" />
