### PR TITLE
fix: left gap between border and text in markdown/diff views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ All notable changes to this project are documented here. The format is based on
 - **In line-select mode, a mouse press now places the selection caret** (previously a click placed
   the line marker, and a double-click copied — copying is now always an explicit `Enter`/`y`).
 
+### Fixed
+- **Left gap in the rendered-markdown and diff views.** These views now sit one column in from the
+  content pane's left border instead of hugging it, matching the gap syntax-highlighted files
+  already get from their line-number gutter. Purely visual: the border, scrollbars, and mouse
+  hit-testing are unchanged.
+
 ## [1.10.0] - 2026-07-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,8 +36,8 @@ All notable changes to this project are documented here. The format is based on
 ### Fixed
 - **Left gap in the rendered-markdown and diff views.** These views now sit one column in from the
   content pane's left border instead of hugging it, matching the gap syntax-highlighted files
-  already get from their line-number gutter. Purely visual: the border, scrollbars, and mouse
-  hit-testing are unchanged.
+  already get from their line-number gutter. Purely visual: the content interior is one column
+  narrower, and its text and mouse hit-testing shift together so clicks still map correctly.
 
 ## [1.10.0] - 2026-07-07
 

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -972,6 +972,17 @@ impl Controller {
         // mis-sizing the thumb / hiding the bar). Computed with the wrap we already have — no extra
         // tree walk.
         let content_rows = self.rendered_line_count_for(wrap);
+        // Inset the transformed views (rendered markdown / diff) one column from the left border so
+        // their delegate output — which starts at column 0 — doesn't hug it; syntax/plain files
+        // already get that gap from bat's line-number gutter, so they stay flush (no double gap).
+        // Keyed off the DISPLAYED content's file (`content_path`, the title's source of truth), so
+        // the gap switches in lockstep with the body — never off a still-loading selection.
+        let content_pad_left = self.content_path.as_ref().is_some_and(|p| {
+            matches!(
+                self.effective_mode(p),
+                ViewMode::RenderedMarkdown | ViewMode::Diff | ViewMode::FullDiff
+            )
+        });
         // Gutter width for a character selection's highlight (0 when not applicable); computed once
         // here so the line-select snapshot below stays a pure read.
         let sel_gutter = self.selection_gutter_len();
@@ -990,6 +1001,7 @@ impl Controller {
             tree_hscroll: self.tree_hscroll,
             content_rows,
             wrap,
+            content_pad_left,
             split_pct: self.split_pct,
             zoomed: self.zoomed,
             update_banner: self.update_banner(),

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -68,6 +68,12 @@ pub struct ViewState {
     /// Wrap long content lines (prose: markdown / plain text) instead of truncating them.
     /// Off for diffs and code, whose column alignment must be preserved.
     pub wrap: bool,
+    /// Inset the content text one column from the left border. Set for the transformed views
+    /// (rendered markdown, diff) whose delegate output starts at column 0 and otherwise hugs the
+    /// border; syntax/plain files get the same visual gap for free from bat's line-number gutter,
+    /// so it stays off for them (no double gap). Applied identically by [`draw_content`] and
+    /// [`geometry`] so the drawn text rect and the hit-test geometry inset the border in lockstep.
+    pub content_pad_left: bool,
     /// The tree column's share of the width, as a percentage (the content pane takes the
     /// rest). Adjustable from the keyboard; used only in the wide two-column layout.
     pub split_pct: u16,
@@ -747,6 +753,19 @@ fn draw_tree(frame: &mut Frame, area: Rect, state: &ViewState) {
     }
 }
 
+/// The content pane's outer block (border + optional left gap), WITHOUT its titles/styles.
+/// Shared by [`draw_content`] and [`geometry`] so the drawn text rect and the hit-test geometry
+/// inset the border identically — a mismatch would map a content-pane click one column off under
+/// the [`ViewState::content_pad_left`] gap.
+fn content_block(state: &ViewState) -> Block<'static> {
+    let block = Block::bordered();
+    if state.content_pad_left {
+        block.padding(Padding::left(1))
+    } else {
+        block
+    }
+}
+
 /// Draw the right column: a notices strip (if any) above the content pane. Returns the
 /// content viewport `(width, height)` so the controller can clamp scrolling to it.
 fn draw_content(frame: &mut Frame, area: Rect, state: &ViewState) -> (u16, u16) {
@@ -774,7 +793,7 @@ fn draw_content(frame: &mut Frame, area: Rect, state: &ViewState) -> (u16, u16) 
     // row (not the layout), so it never crowds the content or steals a row.
     let hint =
         Line::styled(sanitize_control(HELP_HINT), Style::new().fg(Color::Reset)).right_aligned();
-    let block = Block::bordered()
+    let block = content_block(state)
         .title(title)
         .title_bottom(hint)
         .border_style(border_style(state.focus == Focus::Content));
@@ -1039,20 +1058,22 @@ pub fn geometry(area: Rect, state: &ViewState) -> PaneGeometry {
         0
     };
 
-    // Content: notices split, then the same bar layout `draw_content` computes.
-    let (content_inner, content_vbar, content_hbar) = match content.map(inner) {
-        Some(ci) => {
-            let (_notices, content_area) = content_notice_split(ci, state.notices.len());
-            let (text, v, h) = content_bars(
-                content_area,
-                state.content_rows as usize,
-                content_max_line_width(&state.content),
-                state.wrap,
-            );
-            (Some(text), v, h)
-        }
-        None => (None, None, None),
-    };
+    // Content: the SAME block `draw_content` builds (border + optional left gap), then the notices
+    // split and bar layout it computes — so a click maps against the padded interior actually drawn.
+    let (content_inner, content_vbar, content_hbar) =
+        match content.map(|r| content_block(state).inner(r)) {
+            Some(ci) => {
+                let (_notices, content_area) = content_notice_split(ci, state.notices.len());
+                let (text, v, h) = content_bars(
+                    content_area,
+                    state.content_rows as usize,
+                    content_max_line_width(&state.content),
+                    state.wrap,
+                );
+                (Some(text), v, h)
+            }
+            None => (None, None, None),
+        };
 
     // Finder: if the finder overlay is open, compute its layout with the same helper
     // `draw_finder_overlay` uses (same `area` = `frame.area()` = the full terminal rect),

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -965,6 +965,65 @@ fn wrap_is_on_for_markdown_and_off_for_code() {
 }
 
 #[test]
+fn content_pad_left_is_on_for_the_transformed_views_and_off_for_syntax() {
+    // The transformed views (rendered markdown, diff) get a one-column left gap so their
+    // border-hugging delegate output doesn't touch the border; syntax content stays flush because
+    // bat's line-number gutter already supplies the gap. The flag tracks the DISPLAYED content's
+    // effective mode, so it is asserted only after the render lands (`content_path` set).
+    let md = TempDir::new();
+    std::fs::write(md.path().join("a.md"), "# hi\n").unwrap();
+    let (mut ctrl_md, _, _) = controller(md.path(), false, StubGit::default(), false);
+    await_marker(&mut ctrl_md, "stub-content");
+    assert!(
+        ctrl_md.view_state().content_pad_left,
+        "rendered markdown is inset from the border"
+    );
+
+    let rs = TempDir::new();
+    std::fs::write(rs.path().join("a.rs"), "fn main() {}\n").unwrap();
+    let (mut ctrl_rs, _, _) = controller(rs.path(), false, StubGit::default(), false);
+    await_marker(&mut ctrl_rs, "stub-content");
+    assert!(
+        !ctrl_rs.view_state().content_pad_left,
+        "syntax content stays flush (bat's gutter already gaps it)"
+    );
+
+    // A changed file (diff view) is inset; cycling it to the syntax view drops the gap.
+    let diff = TempDir::new();
+    std::fs::write(diff.path().join("changed.rs"), "fn main() {}\n").unwrap();
+    let mut changed = BTreeMap::new();
+    changed.insert(PathBuf::from("changed.rs"), Status::Modified);
+    let git = StubGit {
+        status: changed.clone(),
+        changed,
+        ..StubGit::default()
+    };
+    let (mut ctrl_diff, _, _) = controller(diff.path(), true, git, false);
+    await_marker(&mut ctrl_diff, "stub-content");
+    assert_eq!(ctrl_diff.selected_view_mode(), Some(ViewMode::Diff));
+    assert!(
+        ctrl_diff.view_state().content_pad_left,
+        "a diff is inset from the border"
+    );
+    ctrl_diff.handle(Intent::CycleView); // Diff → FullDiff — still transformed, still inset
+    await_marker(&mut ctrl_diff, "stub-content");
+    assert!(
+        ctrl_diff.view_state().content_pad_left,
+        "the full-context diff is inset too"
+    );
+    ctrl_diff.handle(Intent::CycleView); // FullDiff → SyntaxContent — gap drops
+    await_marker(&mut ctrl_diff, "stub-content");
+    assert_eq!(
+        ctrl_diff.selected_view_mode(),
+        Some(ViewMode::SyntaxContent)
+    );
+    assert!(
+        !ctrl_diff.view_state().content_pad_left,
+        "cycling the diff to the syntax view drops the gap"
+    );
+}
+
+#[test]
 fn wrap_toggle_forces_wrapping_on_for_code_then_back_to_the_mode_default() {
     // The mode default leaves code/diffs unwrapped (aligned); `w` forces wrap on so long
     // lines can be read, and toggles back to the default.

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -973,10 +973,21 @@ fn content_pad_left_is_on_for_the_transformed_views_and_off_for_syntax() {
     let md = TempDir::new();
     std::fs::write(md.path().join("a.md"), "# hi\n").unwrap();
     let (mut ctrl_md, _, _) = controller(md.path(), false, StubGit::default(), false);
+    // Keyed off the DISPLAYED content (`content_path`), not the tree cursor: before any body has
+    // landed the flag is false even though a markdown file is selected (a.md would render markdown).
+    assert_eq!(
+        ctrl_md.selected_view_mode(),
+        Some(ViewMode::RenderedMarkdown),
+        "precondition: the selected file would render as markdown"
+    );
+    assert!(
+        !ctrl_md.view_state().content_pad_left,
+        "no gap until the body lands — the flag follows content_path, which is None pre-render"
+    );
     await_marker(&mut ctrl_md, "stub-content");
     assert!(
         ctrl_md.view_state().content_pad_left,
-        "rendered markdown is inset from the border"
+        "rendered markdown is inset from the border once its body has landed"
     );
 
     let rs = TempDir::new();

--- a/tests/controller_async.rs
+++ b/tests/controller_async.rs
@@ -438,6 +438,79 @@ fn a_slow_render_shows_a_loading_placeholder_and_switches_title_with_body() {
     );
 }
 
+/// the content-pane left gap (`content_pad_left`) keys off the DISPLAYED content, not the tree
+/// cursor — the same lockstep the title obeys. Selecting a markdown file while a code file is shown
+/// must NOT flip the gap on before the markdown body lands, or the gap would jump ahead of the body
+/// during an async render (the exact bug the `content_path`-keyed design avoids).
+#[test]
+fn the_left_gap_follows_the_displayed_file_not_the_selection_during_a_slow_render() {
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.rs"), "fn main() {}\n").unwrap(); // code → no gap
+    std::fs::write(dir.path().join("b.md"), "# hi\n").unwrap(); // markdown → gap
+
+    let delay = Duration::from_millis(120);
+    let components = Components {
+        providers: Box::new(move |_resolved| RootProviders {
+            git: Arc::new(NoGit),
+            content: Box::new(SlowContent { delay }),
+        }),
+        editor: Box::new(NoEditor),
+        clipboard: Box::new(common::RecordingClipboard::default()),
+        renderers: None,
+    };
+    let mut ctrl = Controller::new(
+        common::resolved(dir.path().to_path_buf(), false),
+        Baseline::Head,
+        components,
+    );
+
+    // Land a.rs (code): no gap.
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        ctrl.poll();
+        if flatten(ctrl.content()) == "rendered:a.rs" {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "initial a.rs render never landed"
+        );
+        std::thread::sleep(Duration::from_millis(5));
+    }
+    assert!(
+        !ctrl.view_state().content_pad_left,
+        "precondition: the displayed code file has no gap"
+    );
+
+    // Select b.md (markdown). Its render is in flight: the gap must STAY OFF (it follows the still-
+    // displayed a.rs), exactly as the title stays on a.rs — never flipping to b.md's mode early.
+    ctrl.handle(Intent::NavDown);
+    assert_eq!(
+        flatten(ctrl.content()),
+        LOADING_PLACEHOLDER,
+        "precondition: b.md's render is in flight"
+    );
+    assert!(
+        !ctrl.view_state().content_pad_left,
+        "the gap does not flip on ahead of the body — it tracks the displayed a.rs, not selected b.md"
+    );
+
+    // b.md's body lands: now the gap turns on, in lockstep with the body/title.
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        ctrl.poll();
+        if flatten(ctrl.content()) == "rendered:b.md" {
+            break;
+        }
+        assert!(Instant::now() < deadline, "b.md render never landed");
+        std::thread::sleep(Duration::from_millis(5));
+    }
+    assert!(
+        ctrl.view_state().content_pad_left,
+        "once the markdown body lands, the gap is on"
+    );
+}
+
 /// a superseded render result (the user navigated on before it landed) must not
 /// overwrite the loading placeholder nor the current pane — it's dropped by the seq guard in
 /// `poll`. Two back-to-back selects leave only the LATEST file's render eligible to land.

--- a/tests/presenter.rs
+++ b/tests/presenter.rs
@@ -1221,6 +1221,44 @@ fn content_pad_left_insets_the_transformed_views_one_column() {
 }
 
 #[test]
+fn content_pad_left_shifts_the_drawn_text_one_column() {
+    // The gap must land in the DRAWN buffer, not only in `geometry()`. A regression that dropped
+    // `content_block(state)` from `draw_content` while leaving `geometry` padded would keep the
+    // geometry test above green yet silently revert the visible text to hugging the border — so this
+    // renders both and compares the first content glyph's column. Zoomed so content fills the frame.
+    fn first_content_glyph_x(pad: bool) -> u16 {
+        let mut st = sample_state();
+        st.notices = vec![];
+        st.zoomed = true;
+        st.content_pad_left = pad;
+        let mut terminal = Terminal::new(TestBackend::new(40, 6)).unwrap();
+        terminal
+            .draw(|f| {
+                draw(f, &st);
+            })
+            .unwrap();
+        let buf = terminal.backend().buffer().clone();
+        // Body row 0 is at y=1 (just inside the top border). The border cell sits at x=0; the first
+        // cell that is neither the border nor a pad space is the leading 'f' of "fn main() {".
+        (1..buf.area().width)
+            .find(|&x| {
+                buf.cell((x, 1))
+                    .map(|c| c.symbol())
+                    .is_some_and(|s| s != " " && s != "│")
+            })
+            .expect("a content glyph is drawn on the first body row")
+    }
+    let x_flush = first_content_glyph_x(false);
+    let x_padded = first_content_glyph_x(true);
+    assert_eq!(
+        x_padded,
+        x_flush + 1,
+        "the drawn content text starts one column further right when padded \
+         (flush={x_flush}, padded={x_padded})"
+    );
+}
+
+#[test]
 fn zoomed_layout_hides_the_tree_and_fills_with_content() {
     // The `z` zoom toggle hides the tree so the content pane fills the whole frame — even at a
     // wide width that would normally show both columns.

--- a/tests/presenter.rs
+++ b/tests/presenter.rs
@@ -75,6 +75,7 @@ fn sample_state() -> ViewState {
         tree_hscroll: 0,
         content_rows: 3, // the fixture content is three lines
         wrap: false,
+        content_pad_left: false,
         split_pct: 40,
         zoomed: false,
         update_banner: None,
@@ -1176,6 +1177,47 @@ fn geometry_matches_the_wide_two_column_layout() {
         "a wide layout has a draggable divider"
     );
     assert_eq!((g.area_x, g.area_width), (0, 100));
+}
+
+#[test]
+fn content_pad_left_insets_the_transformed_views_one_column() {
+    // Rendered-markdown / diff views set `content_pad_left` so their border-hugging delegate output
+    // gains a one-column left gap. The gap must land in BOTH the drawn text and the hit-test
+    // geometry (else a content click maps one column off), so assert on `content_inner` — the single
+    // rect that drives both.
+    use herdr_file_viewer::presenter::geometry;
+    use ratatui::layout::Rect;
+    let area = Rect {
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 24,
+    };
+    let mut flush = sample_state();
+    flush.content_pad_left = false;
+    let mut padded = sample_state();
+    padded.content_pad_left = true;
+
+    let x_flush = geometry(area, &flush).content_inner.unwrap().x;
+    let x_padded = geometry(area, &padded).content_inner.unwrap().x;
+    assert_eq!(
+        x_padded,
+        x_flush + 1,
+        "the left gap shifts the content interior exactly one column right"
+    );
+    // The gap only insets the left: the interior narrows by the same one column, and everything
+    // else (the tree column) is untouched.
+    let g_flush = geometry(area, &flush);
+    let g_padded = geometry(area, &padded);
+    assert_eq!(
+        g_padded.content_inner.unwrap().width + 1,
+        g_flush.content_inner.unwrap().width,
+        "the gap comes out of the content width, not the border"
+    );
+    assert_eq!(
+        g_padded.tree_inner, g_flush.tree_inner,
+        "the tree column is never padded"
+    );
 }
 
 #[test]

--- a/tests/presenter_narrow.rs
+++ b/tests/presenter_narrow.rs
@@ -39,6 +39,7 @@ fn state(width: u16, focus: Focus) -> ViewState {
         tree_hscroll: 0,
         content_rows: 1, // the fixture content is one line
         wrap: false,
+        content_pad_left: false,
         split_pct: 40,
         zoomed: false,
         update_banner: None,


### PR DESCRIPTION
## What

The rendered-markdown (glow) and diff (delta) views drew their delegate output starting at column 0, so the text hugged the content pane's left border. Syntax-highlighted files already get a small gap from `bat`'s line-number gutter; markdown and diff had none, so they looked inconsistent.

This insets those two transformed views one column from the left border, matching the gap the other files already have.

**Before / after** (zoomed content pane):

```
before (flush)          after (padded)
┌main.rs──────┐         ┌main.rs──────┐
│fn main() {  │         │ fn main() { │
│}            │         │ }           │
└─────? help──┘         └─────? help──┘
```

## How

- New `content_pad_left: bool` on `ViewState`, set by the controller from the **displayed** content's effective mode (`RenderedMarkdown` / `Diff` / `FullDiff`). Syntax/plain files stay flush so they don't get a double gap.
- The pad is applied through a shared `content_block` helper used by **both** `draw_content` and `geometry`, so the drawn text rect and the mouse hit-test geometry inset the border in lockstep (a mismatch would map a content-pane click one column off).

Purely visual: the border, scrollbars, and mouse hit-testing are unchanged.

## Tests

- Presenter geometry test: the content interior shifts exactly one column right when padded, the width narrows by one, and the tree column is never touched.
- Controller test: markdown and diff set the flag, syntax does not, and cycling a diff to the syntax view drops the gap.
- Full suite green (815 tests); `cargo fmt`/`clippy`/`audit` clean.