### PR TITLE
fix: open-in-tab no longer switches to a viewer in another workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ All notable changes to this project are documented here. The format is based on
   the line marker, and a double-click copied — copying is now always an explicit `Enter`/`y`).
 
 ### Fixed
+- **Open-in-tab (`prefix+shift+f`) no longer jumps to a viewer in another workspace.** When a file
+  viewer tab is already open in one workspace, invoking the tab action from a *different* workspace
+  now opens a fresh viewer in the current workspace instead of switching you to the other
+  workspace's tab. The open-or-switch idempotency stays intact within a workspace (still switches
+  to an existing viewer tab of the same workspace, and toggles off when you're on it).
 - **Left gap in the rendered-markdown and diff views.** These views now sit one column in from the
   content pane's left border instead of hugging it, matching the gap syntax-highlighted files
   already get from their line-number gutter. Purely visual: the content interior is one column

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -47,12 +47,16 @@ viewer via the same idempotent launcher. (Alternatively, `command` may invoke
 
 **Open in a tab instead of a split.** A second action, `open-file-viewer-tab`, opens the viewer
 in its **own tab** (`scripts/open-file-viewer-tab.sh`, `--placement tab`). Its launcher is
-idempotent *across tabs* — *open-or-switch-or-toggle*:
+idempotent *across the tabs of the current workspace* — *open-or-switch-or-toggle*:
 
-- no viewer anywhere → open it in a new tab (focused)
-- a viewer in another tab → **switch to that tab** (never a duplicate)
+- no viewer in this workspace → open it in a new tab (focused)
+- a viewer in another tab of this workspace → **switch to that tab** (never a duplicate)
 - a viewer in the current tab, not focused → focus it in place
 - the viewer already focused → close it (herdr auto-closes the emptied tab)
+
+The idempotency is scoped to the **current workspace**: a viewer already open in a *different*
+workspace is left where it is, and a fresh one opens here — the action reaches this workspace's
+viewer, it never pulls you across workspaces.
 
 Bind it to its own key — e.g. `prefix+shift+f` alongside `prefix+f` for the split:
 

--- a/scripts/open-file-viewer-tab.ps1
+++ b/scripts/open-file-viewer-tab.ps1
@@ -2,13 +2,16 @@
 #
 # Idempotent launcher for the file viewer in its own TAB -- used by the `open-file-viewer-tab-windows`
 # action and a herdr keybinding (e.g. `prefix+shift+f`). "Open-or-switch, toggle on repeat",
-# scoped across tabs:
-#   - no Files pane anywhere                  -> open the viewer in a new tab (focused)
-#   - a Files pane lives in another tab       -> switch to that tab (no duplicate viewer)
+# scoped across the tabs of the CURRENT WORKSPACE:
+#   - no Files pane in this workspace         -> open the viewer in a new tab (focused)
+#   - a Files pane in another tab of this
+#     workspace                               -> switch to that tab (no duplicate viewer)
 #   - a Files pane is in the current tab,
 #     but not focused                         -> focus it in place
 #   - the focused pane IS the Files pane      -> close it ("toggle off"; herdr auto-closes the
 #                                               now-empty tab -- verified)
+# A viewer open in a DIFFERENT workspace is left alone and a fresh one opens here (never switches
+# you across workspaces).
 #
 # Sibling of scripts/open-file-viewer.ps1 (the split-pane variant) -- see its header for WHY the
 # Windows launchers spawn the viewer by ABSOLUTE path (`tab create` + `pane run`) instead of

--- a/scripts/open-file-viewer-tab.sh
+++ b/scripts/open-file-viewer-tab.sh
@@ -1,13 +1,16 @@
 #!/usr/bin/env bash
 # Idempotent launcher for the file viewer in its own TAB — used by the `open-file-viewer-tab`
 # action and a herdr keybinding (e.g. `prefix+shift+f`). "Open-or-switch, toggle on repeat",
-# scoped across tabs:
-#   - no Files pane anywhere                 -> open the viewer in a new tab (focused)
-#   - a Files pane lives in another tab      -> switch to that tab (no duplicate viewer)
+# scoped across the tabs of the CURRENT WORKSPACE:
+#   - no Files pane in this workspace        -> open the viewer in a new tab (focused)
+#   - a Files pane in another tab of this
+#     workspace                              -> switch to that tab (no duplicate viewer)
 #   - a Files pane is in the current tab,
 #     but not focused                        -> focus it in place
 #   - the focused pane IS the Files pane      -> close it ("toggle off"; herdr auto-closes the
 #                                               now-empty tab — verified)
+# A viewer open in a DIFFERENT workspace is left alone and a fresh one opens here — the action
+# reaches this workspace's viewer, it never switches you across workspaces.
 #
 # Sibling of scripts/open-file-viewer.sh (the split-pane variant). The OPEN/SWITCHTAB/FOCUS/
 # CLOSE decision is computed in-process by the viewer binary (`--launch-decision-tab`, fed the

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -21,6 +21,7 @@ struct Pane {
     #[serde(default)]
     focused: bool,
     tab_id: Option<String>,
+    workspace_id: Option<String>,
 }
 
 /// Decide the launcher action from a herdr `pane list` JSON, returning one line: `OPEN`,
@@ -63,15 +64,17 @@ pub fn launch_decision(pane_list_json: &str) -> String {
 /// Decide the launcher action for the **tab** variant (`scripts/open-file-viewer-tab.sh`),
 /// returning one line: `OPEN`, `SWITCHTAB <tab_id>`, `FOCUS <pane_id>`, or `CLOSE <pane_id>`.
 ///
-/// Like [`launch_decision`] but tab-scoped: a `"Files"` pane in *another* tab is **switched to**
-/// (`herdr tab focus <tab_id>`) rather than duplicated — the idempotency that makes a single
-/// keystroke reach the one viewer wherever it lives.
+/// Like [`launch_decision`] but tab-scoped: a `"Files"` pane in *another tab of the same
+/// workspace* is **switched to** (`herdr tab focus <tab_id>`) rather than duplicated — the
+/// idempotency that makes a single keystroke reach the one viewer in this workspace.
 ///
 /// - Unparseable JSON, or no focused pane (current tab unknown) → `OPEN`.
 /// - A `"Files"` pane in the **focused** tab: `CLOSE` it when it *is* the focused pane (toggle
 ///   off — herdr auto-closes the emptied tab), otherwise `FOCUS` it in place.
-/// - Else a `"Files"` pane in **any other** tab: `SWITCHTAB` to its tab.
-/// - Else `OPEN`.
+/// - Else a `"Files"` pane in **another tab of the focused pane's workspace**: `SWITCHTAB` to it.
+/// - Else `OPEN`. In particular a viewer that lives only in a **different workspace** is left
+///   alone and a fresh viewer is opened here — switching to it would yank the user across
+///   workspaces (the launcher is meant to reach *this* workspace's viewer, not teleport away).
 /// - A pane/tab id that is not flag-safe is never emitted (→ `OPEN`), so a host-supplied id can
 ///   never option-inject when the launcher passes it to `herdr pane`/`herdr tab`.
 pub fn launch_decision_tab(pane_list_json: &str) -> String {
@@ -99,13 +102,32 @@ pub fn launch_decision_tab(pane_list_json: &str) -> String {
         };
     }
 
-    // Otherwise switch to a viewer living in another tab, by its (validated) tab id.
-    if let Some(elsewhere) = panes.iter().find(is_viewer)
+    // Otherwise switch to a viewer living in another tab OF THE SAME WORKSPACE, by its
+    // (validated) tab id. A viewer in a different workspace is deliberately ignored: switching
+    // to it would pull the user out of their current workspace, so we OPEN a fresh viewer here
+    // instead. If the focused pane's workspace is unknown, we can't scope safely → OPEN.
+    let focused_ws = workspace_of(focused);
+    if focused_ws.is_some()
+        && let Some(elsewhere) = panes
+            .iter()
+            .find(|p| is_viewer(p) && workspace_of(p) == focused_ws)
         && let Some(tab) = elsewhere.tab_id.as_deref().filter(|t| is_flag_safe(t))
     {
         return format!("SWITCHTAB {tab}");
     }
     "OPEN".to_string()
+}
+
+/// The workspace a pane belongs to: herdr's explicit `workspace_id` when present, else the
+/// prefix of its `tab_id`/`pane_id` (herdr ids are `workspace:...` tokens, e.g. `w19:tB`).
+/// `None` when nothing identifies the workspace, so the caller degrades to `OPEN` rather than
+/// guess.
+fn workspace_of(p: &Pane) -> Option<&str> {
+    p.workspace_id
+        .as_deref()
+        .or_else(|| p.tab_id.as_deref().and_then(|t| t.split(':').next()))
+        .or_else(|| p.pane_id.as_deref().and_then(|t| t.split(':').next()))
+        .filter(|w| !w.is_empty())
 }
 
 /// A pane id is safe to place in an argv iff it is a non-empty token of `[A-Za-z0-9_:.-]` that
@@ -124,7 +146,12 @@ mod tests {
     use super::*;
 
     fn pane(id: &str, label: &str, focused: bool, tab: &str) -> String {
-        format!(r#"{{"pane_id":"{id}","label":"{label}","focused":{focused},"tab_id":"{tab}"}}"#)
+        // Derive workspace_id from the id prefix (herdr ids are `workspace:...`), mirroring the
+        // real `pane list` payload, so fixtures exercise the workspace-scoping path.
+        let ws = tab.split(':').next().unwrap_or("");
+        format!(
+            r#"{{"pane_id":"{id}","label":"{label}","focused":{focused},"tab_id":"{tab}","workspace_id":"{ws}"}}"#
+        )
     }
     fn list(panes: &[String]) -> String {
         format!(r#"{{"result":{{"panes":[{}]}}}}"#, panes.join(","))
@@ -223,6 +250,30 @@ mod tests {
             pane("wE:pD", "Files", false, "wE:t4"),
         ]);
         assert_eq!(launch_decision_tab(&j), "SWITCHTAB wE:t4");
+    }
+
+    #[test]
+    fn tab_viewer_only_in_another_workspace_opens_here() {
+        // Regression (cross-workspace jump): the focused pane is in workspace wQ; the only Files
+        // viewer lives in workspace w19. Switching to it would yank the user out of wQ, so the
+        // launcher must OPEN a fresh viewer in the current workspace instead.
+        let j = list(&[
+            pane("wQ:p2K", "", true, "wQ:tH"),
+            pane("w19:pT", "Files", false, "w19:tB"),
+        ]);
+        assert_eq!(launch_decision_tab(&j), "OPEN");
+    }
+
+    #[test]
+    fn tab_prefers_a_same_workspace_viewer_over_one_in_another_workspace() {
+        // A viewer exists both in another tab of THIS workspace and in a different workspace →
+        // switch to the one in this workspace, never the foreign one.
+        let j = list(&[
+            pane("wQ:p2K", "", true, "wQ:tH"),
+            pane("wQ:pV", "Files", false, "wQ:tE"),
+            pane("w19:pT", "Files", false, "w19:tB"),
+        ]);
+        assert_eq!(launch_decision_tab(&j), "SWITCHTAB wQ:tE");
     }
 
     #[test]

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -21,7 +21,6 @@ struct Pane {
     #[serde(default)]
     focused: bool,
     tab_id: Option<String>,
-    workspace_id: Option<String>,
 }
 
 /// Decide the launcher action from a herdr `pane list` JSON, returning one line: `OPEN`,
@@ -118,15 +117,20 @@ pub fn launch_decision_tab(pane_list_json: &str) -> String {
     "OPEN".to_string()
 }
 
-/// The workspace a pane belongs to: herdr's explicit `workspace_id` when present, else the
-/// prefix of its `tab_id`/`pane_id` (herdr ids are `workspace:...` tokens, e.g. `w19:tB`).
-/// `None` when nothing identifies the workspace, so the caller degrades to `OPEN` rather than
-/// guess.
+/// The workspace a pane belongs to, taken from the prefix of the id we actually act on — its
+/// `tab_id` (what `SWITCHTAB` emits), falling back to its `pane_id`. herdr ids are `workspace:…`
+/// tokens (e.g. `w19:tB`), so the segment before the first `:` is the workspace. Deriving the
+/// scope from the acted-upon id — rather than the separate `workspace_id` field, which a
+/// malformed `pane list` could set to a value that disagrees with the tab we would switch to —
+/// keeps the scope check and the emitted target self-consistent: we compare and switch on the
+/// same id. `None` when the id carries no `workspace:` prefix (an unqualified id is treated as
+/// unknown, never as a bare workspace), so the caller degrades to `OPEN` rather than guess.
 fn workspace_of(p: &Pane) -> Option<&str> {
-    p.workspace_id
+    p.tab_id
         .as_deref()
-        .or_else(|| p.tab_id.as_deref().and_then(|t| t.split(':').next()))
-        .or_else(|| p.pane_id.as_deref().and_then(|t| t.split(':').next()))
+        .and_then(|t| t.split_once(':'))
+        .or_else(|| p.pane_id.as_deref().and_then(|t| t.split_once(':')))
+        .map(|(ws, _)| ws)
         .filter(|w| !w.is_empty())
 }
 
@@ -146,9 +150,15 @@ mod tests {
     use super::*;
 
     fn pane(id: &str, label: &str, focused: bool, tab: &str) -> String {
-        // Derive workspace_id from the id prefix (herdr ids are `workspace:...`), mirroring the
-        // real `pane list` payload, so fixtures exercise the workspace-scoping path.
+        // Mirror the real `pane list` payload, including the `workspace_id` field herdr emits
+        // (derived here from the id prefix) — the decision logic deliberately ignores it and
+        // scopes off the `tab_id` prefix instead, so fixtures carry it to prove it is unused.
         let ws = tab.split(':').next().unwrap_or("");
+        pane_ws(id, label, focused, tab, ws)
+    }
+    // Like `pane`, but with an explicit `workspace_id` so a test can make it DISAGREE with the
+    // `tab_id` prefix (a malformed/hostile `pane list`).
+    fn pane_ws(id: &str, label: &str, focused: bool, tab: &str, ws: &str) -> String {
         format!(
             r#"{{"pane_id":"{id}","label":"{label}","focused":{focused},"tab_id":"{tab}","workspace_id":"{ws}"}}"#
         )
@@ -274,6 +284,30 @@ mod tests {
             pane("w19:pT", "Files", false, "w19:tB"),
         ]);
         assert_eq!(launch_decision_tab(&j), "SWITCHTAB wQ:tE");
+    }
+
+    #[test]
+    fn tab_spoofed_workspace_id_cannot_force_a_cross_workspace_switch() {
+        // Hostile/malformed `pane list`: the viewer's `workspace_id` is spoofed to the focused
+        // workspace (wQ) while its `tab_id` still names another workspace (w19:tB). Because the
+        // scope is derived from the `tab_id` prefix we actually switch on — not the separate
+        // `workspace_id` field — the mismatch is caught and we OPEN here, never SWITCHTAB across.
+        let j = list(&[
+            pane("wQ:p2K", "", true, "wQ:tH"),
+            pane_ws("w19:pT", "Files", false, "w19:tB", "wQ"),
+        ]);
+        assert_eq!(launch_decision_tab(&j), "OPEN");
+    }
+
+    #[test]
+    fn tab_id_without_a_workspace_prefix_opens_rather_than_guessing() {
+        // An id with no `workspace:` delimiter has an unknown workspace; it must not be treated as
+        // a bare workspace that could spuriously match. Focused id `p2K` (no `:`) → OPEN.
+        let j = list(&[
+            pane_ws("p2K", "", true, "tH", ""),
+            pane("w19:pT", "Files", false, "w19:tB"),
+        ]);
+        assert_eq!(launch_decision_tab(&j), "OPEN");
     }
 
     #[test]


### PR DESCRIPTION
## The bug

`prefix+shift+f` (the `open-file-viewer-tab` action) is idempotent by design: if a file-viewer tab is already open, it switches to it rather than duplicating. But the switch logic (`launch_decision_tab`) matched a `Files` viewer in **any** tab, including one in a *different workspace* — so invoking it from workspace B emitted `SWITCHTAB <workspace-A-tab>` and `herdr tab focus` yanked the user across to workspace A instead of opening a viewer in B.

## The fix

Scope the `SWITCHTAB` search to the **focused pane's own workspace** (herdr's explicit `workspace_id`, falling back to the `workspace:...` id prefix). A viewer that lives only in another workspace is left alone and a fresh viewer opens in the current workspace. If the focused workspace can't be determined, it degrades to `OPEN` — never a cross-workspace jump. The within-workspace open-or-switch-or-toggle idempotency is unchanged.

## Verification

- Reproduced live against a real `herdr pane list` (viewer in `w19`, focused in `wQ`): pre-fix would emit `SWITCHTAB w19:tB`; post-fix emits `OPEN`.
- Two new regression tests: viewer only in another workspace → `OPEN`; viewer in both this and another workspace → switch to the one in this workspace.
- Full suite green; `cargo fmt --check` + `cargo clippy --all-targets -D warnings` clean.

## Files

- `src/launch.rs` — workspace-scoped switch + `workspace_of` helper + 2 tests
- `CHANGELOG.md` — `Fixed` entry under `[Unreleased]`
- `docs/usage.md` — tab-launcher idempotency now described as workspace-scoped

Read-only; no new dependencies.
