### PR TITLE
fix: render wide markdown tables to fit the pane, with a `w` wide/scroll view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,20 +6,15 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
-### Changed
-- **`w` now toggles rendered markdown between fit-to-pane and a wide, horizontally-scrollable
-  view.** In the wide view a table renders at its full natural width with every cell intact, and
-  the content pane scrolls sideways (`←`/`→` or the scrollbar) to reveal it; press `w` again to
-  return to the fit view. Previously `w` had no effect on markdown (which always wrapped). `w`
-  remains a uniform wrap on/off preference, so it never springs an unexpected wrap on a code file.
-
 ### Fixed
-- **Wide tables in the rendered-markdown view.** In the default (fit) view a table is now laid out
-  to fit the content pane (columns sized to the pane width, over-long cells ellipsized with `…`)
-  instead of overflowing at its natural width and being shattered across the border rows by the
-  pane's line-wrapping. Resizing the pane (or dragging the split bar) reflows the table to the new
-  width, keeping your scroll position and any active search. To read a truncated cell in full,
-  press `w` for the wide, horizontally-scrollable view (see above).
+- **Wide tables in the rendered-markdown view no longer shatter.** A table is now laid out to fit
+  the content pane (columns sized to the pane width, over-long cells ellipsized with `…`) instead
+  of overflowing at its natural width and being broken across the border rows by the pane's
+  line-wrapping. Resizing the pane (or dragging the split bar) reflows the table, preserving your
+  scroll position and any active search. Press `w` to switch to a wide, horizontally-scrollable
+  view that renders the table at full natural width with every cell intact (`←`/`→` or the
+  scrollbar to pan); press `w` again to return. (`w` remains a uniform wrap on/off preference, so
+  it never springs an unexpected wrap on a code file.)
 
 ## [1.11.0] - 2026-07-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,20 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+### Changed
+- **`w` now toggles rendered markdown between fit-to-pane and a wide, horizontally-scrollable
+  view.** In the wide view a table renders at its full natural width with every cell intact, and
+  the content pane scrolls sideways (`←`/`→` or the scrollbar) to reveal it; press `w` again to
+  return to the fit view. Previously `w` had no effect on markdown (which always wrapped). `w`
+  remains a uniform wrap on/off preference, so it never springs an unexpected wrap on a code file.
+
 ### Fixed
-- **Wide tables in the rendered-markdown view.** A table is now laid out to fit the content pane
-  (columns sized to the pane width, over-long cells ellipsized with `…`) instead of overflowing at
-  its natural width and being shattered across the border rows by the pane's line-wrapping.
-  Resizing the pane (or dragging the split bar) reflows the table to the new width, keeping your
-  scroll position and any active search.
+- **Wide tables in the rendered-markdown view.** In the default (fit) view a table is now laid out
+  to fit the content pane (columns sized to the pane width, over-long cells ellipsized with `…`)
+  instead of overflowing at its natural width and being shattered across the border rows by the
+  pane's line-wrapping. Resizing the pane (or dragging the split bar) reflows the table to the new
+  width, keeping your scroll position and any active search. To read a truncated cell in full,
+  press `w` for the wide, horizontally-scrollable view (see above).
 
 ## [1.11.0] - 2026-07-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Wide tables in the rendered-markdown view.** A table is now laid out to fit the content pane
+  (columns sized to the pane width, over-long cells ellipsized with `…`) instead of overflowing at
+  its natural width and being shattered across the border rows by the pane's line-wrapping.
+  Resizing the pane (or dragging the split bar) reflows the table to the new width, keeping your
+  scroll position and any active search.
+
 ## [1.11.0] - 2026-07-09
 
 Mouse-driven text selection in the content pane, plus content copy in line-select mode.

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ PowerShell launcher scripts.
 | `Y` | Copy the selected file's **absolute** path to the clipboard |
 | `Tab` | Move focus between the tree and content columns |
 | `<` / `>` | Narrow / widen the tree column (move the divider) |
-| `w` | Toggle line wrapping for the content pane |
+| `w` | Toggle line wrapping for the content pane. For rendered markdown this switches between the fit-to-pane view (wide tables sized to fit, over-long cells shown as `…`) and a wide view that renders tables at full width and scrolls horizontally (`←`/`→`) so you can read every cell |
 | `z` | Zoom: hide the tree so the content pane fills the frame; press again (or `q`/`Esc`) to restore the two-column layout |
 | `r` | Refresh git state: pick up changes made outside the viewer (a merge / pull / commit elsewhere) |
 | `W` (Shift+`w`) | **Switch worktree**: open a picker of the repo's git worktrees and re-root the viewer to the one you pick (read-only; no branch checkout). Marks the current worktree and pre-selects the one with an active herdr agent; `↑`/`↓` move, `←`/`→` scroll long paths, `Enter` switches, `Esc` cancels |
@@ -184,8 +184,10 @@ PowerShell launcher scripts.
 `Tab` to the content pane, then the arrow keys (or `h`/`j`/`k`/`l`) scroll it in all four
 directions; `Tab` back to the tree to move between files. Long lines wrap in prose (markdown /
 plain text); diffs and code keep their original lines so columns stay aligned. Scroll
-sideways with `←`/`→`, or press `w` to wrap them instead. The layout reflows automatically
-when the pane is resized.
+sideways with `←`/`→`, or press `w` to wrap them instead. Rendered markdown fits the pane by
+default (wide tables sized to fit, over-long cells shown as `…`); press `w` for a wide view that
+renders tables at full width and scrolls sideways so you can read every cell. The layout reflows
+automatically when the pane is resized.
 
 **Git state stays current.** The viewer re-reads git status when the pane **regains focus**, so
 changes you make outside it (a merge, pull, or commit in another pane) show up automatically; `r`

--- a/src/app.rs
+++ b/src/app.rs
@@ -297,6 +297,17 @@ struct LiveContent {
 
 impl ContentProvider for LiveContent {
     fn render(&self, path: &Path, mode: ViewMode, raw_diff: Option<&str>) -> RenderResult {
+        // The width-less entry point: no pane width known, so glow keeps its `-w 0` (no wrap).
+        self.render_at_width(path, mode, raw_diff, None)
+    }
+
+    fn render_at_width(
+        &self,
+        path: &Path,
+        mode: ViewMode,
+        raw_diff: Option<&str>,
+        width: Option<u16>,
+    ) -> RenderResult {
         // Both diff modes render from git's diff text, not the file bytes — so a deleted or
         // binary file still shows its diff (AC-9), and there is no point classifying (a wasted
         // bounded file read). Other modes classify first (binary / size guards, AC-12/13).
@@ -318,7 +329,23 @@ impl ContentProvider for LiveContent {
             }
             _ => None,
         };
-        let (content, notice) = render::render(&self.renderers, &prepared, mode, raw_diff, name);
+        // For rendered markdown at a known pane width, point glow's `-w` at that width so it lays
+        // out and wraps tables to fit the pane (columns sized, cells ellipsized, borders intact),
+        // and pads every line to exactly that width — the Presenter's re-wrap is then a no-op
+        // rather than shattering a natural-width `-w 0` table across the border rows. The bundled
+        // markdown style has `margin: 0`, so glow's output lines are exactly `width` wide. Every
+        // other mode is width-independent here (delta/bat manage their own width; they h-scroll,
+        // never re-wrap), so they use the base renderers unchanged.
+        let (content, notice) = match (mode, width.filter(|w| *w > 0)) {
+            (ViewMode::RenderedMarkdown, Some(w)) => {
+                let wrapped = Renderers {
+                    markdown: render::with_wrap_width(&self.renderers.markdown, w),
+                    ..self.renderers.clone()
+                };
+                render::render(&wrapped, &prepared, mode, raw_diff, name)
+            }
+            _ => render::render(&self.renderers, &prepared, mode, raw_diff, name),
+        };
         RenderResult {
             content,
             notices: notice.into_iter().collect(),
@@ -750,6 +777,90 @@ mod tests {
             r.syntax.iter().any(|a| a == "--style=numbers"),
             "bat line numbers: {:?}",
             r.syntax
+        );
+    }
+
+    /// A `LiveContent` whose markdown delegate echoes back the `-w` value it was actually invoked
+    /// with (as `W=<n>`), so a test can prove the pane width was threaded into glow's `-w`. The
+    /// base `-w` is `0` (matching the real default), so an unknown/zero width reads back `W=0`.
+    #[cfg(unix)]
+    fn echoing_md_content(root: &Path) -> LiveContent {
+        LiveContent {
+            root: root.to_path_buf(),
+            renderers: Renderers {
+                // `sh -c SCRIPT sh -w 0 -`: inside SCRIPT, `$2` is the token after `-w`, which
+                // `render_at_width` rewrites (via `with_wrap_width`) to the requested width.
+                // `cat >/dev/null` drains the piped (untrusted) stdin so the writer never hits a
+                // broken pipe.
+                markdown: vec![
+                    "sh".into(),
+                    "-c".into(),
+                    "printf 'W=%s' \"$2\"; cat >/dev/null".into(),
+                    "sh".into(),
+                    "-w".into(),
+                    "0".into(),
+                    "-".into(),
+                ],
+                diff: vec!["cat".into()],
+                full_diff: vec!["cat".into()],
+                syntax: vec!["cat".into()],
+                timeout: Duration::from_secs(5),
+            },
+        }
+    }
+
+    #[cfg(unix)]
+    fn flatten_content(r: &RenderResult) -> String {
+        r.content
+            .lines
+            .iter()
+            .flat_map(|l| l.spans.iter())
+            .map(|s| s.content.as_ref())
+            .collect()
+    }
+
+    /// The table fix: rendered markdown at a known pane width hands glow `-w <width>` so it lays
+    /// out (and wraps) tables to fit the pane, instead of overflowing at natural `-w 0` width and
+    /// being shattered by the Presenter's re-wrap.
+    #[cfg(unix)]
+    #[test]
+    fn render_at_width_points_markdown_wrap_at_the_pane_width() {
+        let root = tmp("md-wrap-width");
+        let md = root.join("doc.md");
+        std::fs::write(&md, "| a | b |\n|---|---|\n| 1 | 2 |\n").unwrap();
+        let content = echoing_md_content(&root);
+        let out = content.render_at_width(&md, ViewMode::RenderedMarkdown, None, Some(80));
+        assert!(
+            flatten_content(&out).contains("W=80"),
+            "the pane width must reach glow's -w: {:?}",
+            flatten_content(&out)
+        );
+    }
+
+    /// No width known yet (the first render, before the first draw has measured the pane) — glow
+    /// keeps its `-w 0` (no wrap). The width-less `render` entry point delegates to the same path
+    /// with `None`, so it too leaves `-w 0`.
+    #[cfg(unix)]
+    #[test]
+    fn render_at_width_leaves_wrap_unbounded_without_a_pane_width() {
+        let root = tmp("md-wrap-none");
+        let md = root.join("doc.md");
+        std::fs::write(&md, "# Title\n").unwrap();
+        let content = echoing_md_content(&root);
+        // Explicit None, an inert zero width, and the width-less `render` all keep the base `-w 0`.
+        for w in [None, Some(0)] {
+            let out = content.render_at_width(&md, ViewMode::RenderedMarkdown, None, w);
+            assert!(
+                flatten_content(&out).contains("W=0"),
+                "width {w:?} must leave -w at 0: {:?}",
+                flatten_content(&out)
+            );
+        }
+        let via_render = content.render(&md, ViewMode::RenderedMarkdown, None);
+        assert!(
+            flatten_content(&via_render).contains("W=0"),
+            "the width-less render() must keep -w 0: {:?}",
+            flatten_content(&via_render)
         );
     }
 

--- a/src/controller/infile.rs
+++ b/src/controller/infile.rs
@@ -289,4 +289,33 @@ impl Controller {
             current,
         });
     }
+
+    /// Re-run a COMMITTED search (the prompt is closed, so [`refresh_search`] — which reads the live
+    /// prompt buffer — does not apply) against the freshly-rendered content, keeping the selected
+    /// match ordinal where it still exists. Called by `poll` after a width reflow re-renders the
+    /// same markdown file: match line indices are computed against the *rendered* lines, which shift
+    /// when glow re-lays-out a table at the new width, so stale highlights are recomputed rather than
+    /// dropped — a resize must not silently clear an active search. Unlike `refresh_search`, it does
+    /// NOT scroll (the reflow preserves the user's position). A no-op when no search is active or the
+    /// stored query is empty.
+    ///
+    /// [`refresh_search`]: Self::refresh_search
+    pub(super) fn recompute_committed_search(&mut self) {
+        let Some(prev) = self.search.take() else {
+            return;
+        };
+        if prev.query.is_empty() {
+            return;
+        }
+        let plain = self.content_plain_lines();
+        let matches = crate::search::find_matches(&prev.query, &plain);
+        // Keep the same ordinal where possible; clamp if the reflow reduced the match count (an
+        // empty result leaves `current` at 0 with no matches — the status line reads "no matches").
+        let current = prev.current.min(matches.len().saturating_sub(1));
+        self.search = Some(SearchState {
+            query: prev.query,
+            matches,
+            current,
+        });
+    }
 }

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -111,6 +111,26 @@ pub struct RenderResult {
 /// worker thread (AC-23). Behind a trait so tests stub it instead of spawning glow/delta/bat.
 pub trait ContentProvider: Send {
     fn render(&self, path: &Path, mode: ViewMode, raw_diff: Option<&str>) -> RenderResult;
+
+    /// Render honoring the content pane's drawable text `width` (columns), so a width-sensitive
+    /// delegate (glow, for markdown) can lay out and wrap tables to fit the pane rather than
+    /// overflow it. `None` (or `0`) means "unknown / no bound" — behave exactly as [`render`].
+    ///
+    /// Defaulted to call [`render`], so a test double (which never spawns a real width-sensitive
+    /// renderer) need not implement it; only the live [`LiveContent`] overrides it to thread the
+    /// width into glow's `-w`.
+    ///
+    /// [`render`]: ContentProvider::render
+    fn render_at_width(
+        &self,
+        path: &Path,
+        mode: ViewMode,
+        raw_diff: Option<&str>,
+        width: Option<u16>,
+    ) -> RenderResult {
+        let _ = width;
+        self.render(path, mode, raw_diff)
+    }
 }
 
 /// The outcome of an editor hand-off (AC-19). Distinguishing the failure modes lets the
@@ -238,6 +258,11 @@ struct RenderJob {
     mode: ViewMode,
     baseline: Baseline,
     is_git: bool,
+    /// The content pane's drawable text width (columns) at dispatch, or `None` when unknown
+    /// (e.g. the very first render before the first draw measured the pane). Only the markdown
+    /// delegate uses it: glow lays out and wraps tables to this width so they fit the pane
+    /// instead of overflowing and being shattered by the Presenter's re-wrap.
+    wrap_width: Option<u16>,
 }
 
 /// A re-root's off-thread git result: the working-tree status (tree markers, AC-7) and the
@@ -415,6 +440,14 @@ pub struct Controller {
     job_tx: mpsc::Sender<RenderJob>,
     result_rx: mpsc::Receiver<(u64, RenderResult)>,
     latest_seq: u64,
+    /// The `seq` of an in-flight markdown re-render triggered by a content-pane *resize*
+    /// ([`rerender_markdown_for_width`]), as opposed to a selection change. When [`poll`] applies a
+    /// result whose seq matches, it preserves the current scroll and recomputes an active search
+    /// (a resize must not jump to the top or drop the search), instead of the from-scratch reset a
+    /// selection-change render gets. `None` when no resize re-render is pending.
+    ///
+    /// [`rerender_markdown_for_width`]: Controller::rerender_markdown_for_width
+    reflow_seq: Option<u64>,
     /// Hit-test geometry from the last drawn frame (fed back by the Presenter), so a mouse
     /// event can be mapped to a tree row / the content pane / the divider.
     geom: PaneGeometry,
@@ -575,6 +608,7 @@ impl Controller {
             job_tx,
             result_rx,
             latest_seq: 0,
+            reflow_seq: None,
             geom: PaneGeometry::default(),
             last_click: None,
             drag: None,
@@ -635,7 +669,12 @@ impl Controller {
                         } else {
                             None
                         };
-                    content.render(&job.path, job.mode, raw_diff.as_deref())
+                    content.render_at_width(
+                        &job.path,
+                        job.mode,
+                        raw_diff.as_deref(),
+                        job.wrap_width,
+                    )
                 }))
                 .unwrap_or_else(|_| RenderResult {
                     content: Text::raw("[content unavailable: renderer error]"),
@@ -910,12 +949,20 @@ impl Controller {
         if width == self.content_width && height == self.content_height {
             return; // unchanged — avoid recomputing the clamp on every (mostly idle) draw
         }
+        let width_changed = width != self.content_width;
         self.content_width = width;
         self.content_height = height;
         // A smaller viewport shrinks the max offset, so an existing scroll could now point past
         // the end, leaving blank space; re-clamp both axes to the new geometry.
         self.content_scroll = self.content_scroll.min(self.max_content_scroll());
         self.content_hscroll = self.content_hscroll.min(self.max_content_hscroll());
+        // Rendered markdown is laid out by glow to the pane's drawable width so tables fit; a width
+        // change (terminal resize or split-bar drag) must therefore reflow it, preserving scroll and
+        // search (unlike a selection-change render). No-op for other modes and when nothing is shown.
+        // A height-only change never affects glow's layout, so it does not re-render.
+        if width_changed {
+            self.rerender_markdown_for_width();
+        }
     }
 
     /// Receive the hit-test geometry the Presenter drew this frame (fed back from the draw
@@ -1858,6 +1905,49 @@ impl Controller {
 
     // ---- content coordination ----------------------------------------------------------
 
+    /// The markdown wrap width to hand a render job: the content pane's drawable text width, or
+    /// `None` before the first draw has measured it (`content_width == 0`). Only the markdown
+    /// delegate consumes it — glow lays out tables to this width so they fit the pane.
+    fn md_wrap_width(&self) -> Option<u16> {
+        (self.content_width > 0).then_some(self.content_width)
+    }
+
+    /// Re-render the current selection at the new content-pane width **without** the view-state
+    /// reset [`dispatch_render`] performs — a resize (terminal resize or a split-bar drag) is not a
+    /// selection change, so scroll position and any active search must survive it. Only rendered
+    /// markdown is re-rendered: glow's table layout is tied to the width we pass it, so a narrower
+    /// pane must reflow the table (otherwise the Presenter re-wraps the now-too-wide `-w` output and
+    /// shatters it). Every other mode is width-independent here (diffs/code h-scroll), so this is a
+    /// no-op for them. The current content stays on screen until the new render lands (no
+    /// `Rendering…` placeholder), so a live split-drag doesn't flash; the worker collapses the
+    /// backlog so only the final width actually renders. [`poll`] applies the result by `seq` and,
+    /// seeing it flagged in `reflow_seq`, keeps the scroll and recomputes an active search.
+    fn rerender_markdown_for_width(&mut self) {
+        let Some(node) = self.tree.selected() else {
+            return;
+        };
+        if node.kind != NodeKind::File
+            || self.effective_mode(&node.path) != ViewMode::RenderedMarkdown
+        {
+            return;
+        }
+        self.latest_seq += 1;
+        let seq = self.latest_seq;
+        self.reflow_seq = Some(seq);
+        let rel = self.rel(&node.path);
+        // Ignore a send error: if the worker is gone the current content simply stays; `poll` will
+        // never receive a result for this seq, which is fine (nothing was cleared).
+        let _ = self.job_tx.send(RenderJob {
+            seq,
+            path: node.path,
+            rel,
+            mode: ViewMode::RenderedMarkdown,
+            baseline: self.baseline,
+            is_git: self.is_git_repo,
+            wrap_width: self.md_wrap_width(),
+        });
+    }
+
     /// Dispatch a render of the current selection to the worker thread (AC-23) — never
     /// blocking and doing **no git or rendering work on the input thread**: the worker reads
     /// the diff and delegates to the external renderer. A directory or empty selection clears
@@ -1923,6 +2013,7 @@ impl Controller {
                 mode,
                 baseline: self.baseline,
                 is_git: self.is_git_repo,
+                wrap_width: self.md_wrap_width(),
             })
             .is_ok()
         {
@@ -1955,13 +2046,28 @@ impl Controller {
         let mut applied = false;
         while let Ok((seq, result)) = self.result_rx.try_recv() {
             if seq == self.latest_seq {
+                // A width-reflow re-render (a resize, not a selection change): its content replaces
+                // the current body, but scroll and search must survive — the user did not navigate.
+                // Cleared unconditionally so a later selection-change render is never mistaken for a
+                // reflow (its seq won't match a stale value anyway, but keep the flag tight).
+                let is_reflow = self.reflow_seq == Some(seq);
+                self.reflow_seq = None;
                 self.content = result.content;
                 // Covers the placeholder→land window: a selection dragged over "Rendering…" after
                 // dispatch_render's clear must not carry its stale coordinates onto the new body.
+                // (Also dropped on a reflow: an ambient selection's line/col coords are against the
+                // pre-reflow rendered lines, so they no longer point at the same text.)
                 self.content_selection = None;
                 self.content_notices = result.notices;
                 self.content_source = result.source; // in lockstep with `content` (copy fidelity)
                 self.applied_seq = seq; // the displayed content is now this render (go-to-line guard)
+                // A reflow keeps the user's scroll position, but the reflowed body may have a
+                // different rendered-row count (a table re-lays-out at the new width), so re-clamp
+                // the offset to the new content. A selection-change render already reset scroll to 0
+                // in dispatch_render, so this is gated to the reflow path.
+                if is_reflow {
+                    self.content_scroll = self.content_scroll.min(self.max_content_scroll());
+                }
                 // the body has landed — now switch the title to match it. The latest
                 // dispatched render always corresponds to the current tree selection (every
                 // selection change calls `dispatch_render`), so the applied result's file is the
@@ -2002,9 +2108,13 @@ impl Controller {
                 // A render that was in flight when a search was opened/committed lands here and
                 // swaps self.content; matches computed against the OLD content are now stale.
                 // Mirror dispatch_render's AC-20 clear: recompute an open Search prompt against
-                // the new content, else drop a committed search.
+                // the new content, else drop a committed search — UNLESS this was a width reflow,
+                // where a committed search must be recomputed (not dropped), so a resize does not
+                // silently clear the user's active highlighting.
                 if self.modal.prompt().map(|p| p.mode) == Some(crate::infile::PromptMode::Search) {
                     self.refresh_search();
+                } else if is_reflow {
+                    self.recompute_committed_search();
                 } else {
                     self.search = None;
                 }

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -390,9 +390,12 @@ pub struct Controller {
     /// The tree column's share of the width, as a percentage (the rest is the content pane).
     /// Adjustable from the keyboard since the viewer owns both columns (ADR-0002).
     split_pct: u16,
-    /// User override forcing content wrap on regardless of view mode (the `w` toggle), so long
-    /// lines in code/diffs can be wrapped on demand. `false` ⇒ the per-mode default applies.
-    wrap_override: bool,
+    /// User override of the per-mode wrap default (the `w` toggle). `None` ⇒ the per-mode default
+    /// applies (prose wraps, code/diffs don't); `Some(true)` ⇒ force wrap on everywhere (read long
+    /// code/diff lines); `Some(false)` ⇒ force wrap off everywhere — which, for rendered markdown,
+    /// switches glow to natural-width layout so a wide table renders in full and the pane scrolls
+    /// horizontally to reveal it (instead of the fit-to-pane view that ellipsizes over-long cells).
+    wrap_override: Option<bool>,
     /// Hide the tree so the content pane fills the frame (the `z` zoom toggle). Pure layout
     /// state — the selection and rendered content are unchanged.
     zoomed: bool,
@@ -590,7 +593,7 @@ impl Controller {
             content_width: 0,
             content_height: 0,
             split_pct: SPLIT_DEFAULT,
-            wrap_override: false,
+            wrap_override: None,
             zoomed: false,
             changed: BTreeMap::new(),
             overrides: HashMap::new(),
@@ -851,9 +854,11 @@ impl Controller {
     pub fn split_pct(&self) -> u16 {
         self.split_pct
     }
-    /// Whether the `w` content-wrap override is on (carried across a re-root, AC-12).
+    /// Whether the `w` override is currently forcing wrap ON (carried across a re-root, AC-12).
+    /// `Some(false)` (force wrap off / horizontal-scroll) and `None` (per-mode default) both read
+    /// as `false` here — the getter reports the force-on state the tests assert after toggling.
     pub fn wrap_override(&self) -> bool {
-        self.wrap_override
+        self.wrap_override == Some(true)
     }
     pub fn tree(&self) -> &TreeModel {
         &self.tree
@@ -956,12 +961,13 @@ impl Controller {
         // the end, leaving blank space; re-clamp both axes to the new geometry.
         self.content_scroll = self.content_scroll.min(self.max_content_scroll());
         self.content_hscroll = self.content_hscroll.min(self.max_content_hscroll());
-        // Rendered markdown is laid out by glow to the pane's drawable width so tables fit; a width
-        // change (terminal resize or split-bar drag) must therefore reflow it, preserving scroll and
-        // search (unlike a selection-change render). No-op for other modes and when nothing is shown.
-        // A height-only change never affects glow's layout, so it does not re-render.
-        if width_changed {
-            self.rerender_markdown_for_width();
+        // When markdown is fit-to-pane (wrapped), glow lays the table out to the pane width, so a
+        // width change (terminal resize or split-bar drag) must reflow it, preserving scroll and
+        // search (unlike a selection-change render). When unwrapped (the `w` horizontal-scroll view)
+        // glow's natural-width output is width-independent — the pane just re-clamps h-scroll, no
+        // re-render. A height-only change never affects glow's layout either.
+        if width_changed && self.effective_wrap() {
+            self.rerender_markdown_reflow();
         }
     }
 
@@ -1196,21 +1202,20 @@ impl Controller {
         Some(line)
     }
 
-    /// Whether the content pane wraps for `node`: forced on by the `w` override, else the
-    /// per-mode default — prose (rendered markdown / plain text) wraps; diffs and code stay
-    /// unwrapped so their columns align. Takes the node so the draw path needn't re-walk.
+    /// Whether the content pane wraps for `node`: the `w` override when set (`Some(true)` forces
+    /// wrap on, `Some(false)` forces it off), else the per-mode default — prose (rendered markdown /
+    /// plain text) wraps; diffs and code stay unwrapped so their columns align. Takes the node so
+    /// the draw path needn't re-walk.
     fn wrap_for(&self, node: Option<&Node>) -> bool {
-        if self.wrap_override {
-            return true;
-        }
-        match node {
+        let default = match node {
             Some(n) if n.kind == NodeKind::File => {
-                // Only prose wraps; diffs (compact and full-context) and code keep their lines
-                // so columns and the line-number gutter stay aligned.
+                // Only prose wraps by default; diffs (compact and full-context) and code keep their
+                // lines so columns and the line-number gutter stay aligned.
                 matches!(self.effective_mode(&n.path), ViewMode::RenderedMarkdown)
             }
             _ => false,
-        }
+        };
+        self.wrap_override.unwrap_or(default)
     }
 
     // ---- intent handling ---------------------------------------------------------------
@@ -1768,14 +1773,22 @@ impl Controller {
         Effects::redraw()
     }
 
-    /// Flip the content-wrap override. Pure layout state — the content text is unchanged, only
-    /// how the Presenter lays it out; the scroll clamp recomputes from the new wrap.
+    /// Flip the content-wrap state (the `w` key): force it to the opposite of what the current
+    /// selection shows now, so a single press always visibly toggles. The override is a session
+    /// preference applied uniformly — `Some(true)` wraps everywhere, `Some(false)` unwraps
+    /// everywhere — so switching files doesn't spring a surprise wrap on the next one.
+    ///
+    /// For code/diffs this is pure layout (the delegate output is unchanged, only how the Presenter
+    /// lays it out). For rendered markdown the wrap state changes glow's `-w` (fit-to-pane vs.
+    /// natural width for horizontal scroll), so the content itself is re-rendered — preserving
+    /// scroll and search, like a resize reflow. The scroll clamp recomputes from the new layout.
     fn toggle_wrap(&mut self) -> Effects {
-        self.wrap_override = !self.wrap_override;
-        // Wrapping changes the content's layout, so re-clamp both offsets: vertical to the new
-        // line count, and horizontal to zero while wrapped (no line overflows the pane).
+        self.wrap_override = Some(!self.effective_wrap());
         self.content_scroll = self.content_scroll.min(self.max_content_scroll());
         self.content_hscroll = self.content_hscroll.min(self.max_content_hscroll());
+        // Markdown must re-render at the new wrap width (fit vs. natural); a no-op for other modes,
+        // which only need the re-clamp above.
+        self.rerender_markdown_reflow();
         Effects::redraw()
     }
 
@@ -1905,24 +1918,26 @@ impl Controller {
 
     // ---- content coordination ----------------------------------------------------------
 
-    /// The markdown wrap width to hand a render job: the content pane's drawable text width, or
-    /// `None` before the first draw has measured it (`content_width == 0`). Only the markdown
-    /// delegate consumes it — glow lays out tables to this width so they fit the pane.
+    /// The wrap width to hand a markdown render job: the content pane's drawable text width when
+    /// markdown is effectively **wrapped** (the fit-to-pane default) so glow lays the table out to
+    /// fit; `None` when unwrapped (the `w` horizontal-scroll view) so glow keeps its base `-w 0`
+    /// natural-width layout and the pane scrolls to reveal the whole table, and `None` before the
+    /// first draw has measured the pane (`content_width == 0`). Only the markdown delegate uses it.
     fn md_wrap_width(&self) -> Option<u16> {
-        (self.content_width > 0).then_some(self.content_width)
+        (self.content_width > 0 && self.effective_wrap()).then_some(self.content_width)
     }
 
-    /// Re-render the current selection at the new content-pane width **without** the view-state
-    /// reset [`dispatch_render`] performs — a resize (terminal resize or a split-bar drag) is not a
-    /// selection change, so scroll position and any active search must survive it. Only rendered
-    /// markdown is re-rendered: glow's table layout is tied to the width we pass it, so a narrower
-    /// pane must reflow the table (otherwise the Presenter re-wraps the now-too-wide `-w` output and
-    /// shatters it). Every other mode is width-independent here (diffs/code h-scroll), so this is a
-    /// no-op for them. The current content stays on screen until the new render lands (no
-    /// `Rendering…` placeholder), so a live split-drag doesn't flash; the worker collapses the
-    /// backlog so only the final width actually renders. [`poll`] applies the result by `seq` and,
-    /// seeing it flagged in `reflow_seq`, keeps the scroll and recomputes an active search.
-    fn rerender_markdown_for_width(&mut self) {
+    /// Re-render the current markdown selection **without** the view-state reset [`dispatch_render`]
+    /// performs — the triggers are a content-pane resize and the `w` wrap toggle, neither of which is
+    /// a selection change, so scroll position and any active search must survive. Only rendered
+    /// markdown is re-rendered: glow's layout is tied to the wrap width we pass it (fit-to-pane vs.
+    /// natural width), so a resize-while-fit or a wrap toggle must re-run glow; every other mode is
+    /// width-independent here (diffs/code re-wrap in the Presenter alone), so this is a no-op for
+    /// them. The current content stays on screen until the new render lands (no `Rendering…`
+    /// placeholder), so a live split-drag doesn't flash; the worker collapses the backlog so only the
+    /// final state renders. [`poll`] applies the result by `seq` and, seeing it flagged in
+    /// `reflow_seq`, keeps the scroll and recomputes an active search.
+    fn rerender_markdown_reflow(&mut self) {
         let Some(node) = self.tree.selected() else {
             return;
         };

--- a/src/render.rs
+++ b/src/render.rs
@@ -560,6 +560,15 @@ mod tests {
     }
 
     #[test]
+    fn with_wrap_width_appends_the_value_when_w_is_the_trailing_arg() {
+        // `-w` present but with no value after it (the `out.get_mut(i + 1)` is `None` branch): the
+        // width is appended rather than replacing a following token.
+        let base: Vec<String> = ["glow", "-w"].iter().map(|s| s.to_string()).collect();
+        let got = with_wrap_width(&base, 70);
+        assert_eq!(got, ["glow", "-w", "70"]);
+    }
+
+    #[test]
     fn small_text_file_is_returned_in_full() {
         let p = tmp("small.txt", b"hello\nworld\n");
         match classify(&std::env::temp_dir(), &p) {

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -1054,6 +1054,58 @@ fn wrap_toggle_forces_wrapping_on_for_code_then_back_to_the_mode_default() {
 }
 
 #[test]
+fn w_toggles_markdown_between_the_fit_and_the_wide_unwrapped_view() {
+    // The table escape hatch: markdown fits the pane (wraps) by default, and `w` switches it to
+    // the wide, unwrapped view so a too-wide table renders in full and the pane scrolls sideways
+    // to reveal it. `w` again returns to the fit view.
+    let md = TempDir::new();
+    std::fs::write(md.path().join("a.md"), "# hi\n").unwrap();
+    let (mut ctrl, _, _) = controller(md.path(), false, StubGit::default(), false);
+    assert!(ctrl.view_state().wrap, "markdown fits (wraps) by default");
+
+    ctrl.handle(Intent::ToggleWrap);
+    assert!(
+        !ctrl.view_state().wrap,
+        "`w` switches markdown to the wide, unwrapped (horizontal-scroll) view"
+    );
+    assert!(
+        !ctrl.wrap_override(),
+        "the force-wrap-on getter is false in the unwrapped state"
+    );
+
+    ctrl.handle(Intent::ToggleWrap);
+    assert!(
+        ctrl.view_state().wrap,
+        "`w` again returns markdown to the fit (wrapped) view"
+    );
+}
+
+#[test]
+fn unwrapping_markdown_does_not_force_wrap_onto_a_code_file_viewed_next() {
+    // The `w` override is a uniform "wrap on/off everywhere" preference, not a per-mode inversion:
+    // turning wrap OFF to horizontally scroll a markdown table must not spring wrap ON for a code
+    // file viewed afterwards — code stays unwrapped so its columns stay aligned.
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.md"), "# hi\n").unwrap();
+    std::fs::write(dir.path().join("z.rs"), "fn main() {}\n").unwrap();
+    let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
+
+    assert!(
+        ctrl.view_state().wrap,
+        "precondition: a.md wraps (fit view)"
+    );
+    ctrl.handle(Intent::ToggleWrap); // unwrap markdown → force-off everywhere
+    assert!(!ctrl.view_state().wrap);
+
+    ctrl.handle(Intent::NavDown); // select z.rs (code)
+    assert_eq!(ctrl.selected_view_mode(), Some(ViewMode::SyntaxContent));
+    assert!(
+        !ctrl.view_state().wrap,
+        "code stays unwrapped — the unwrap did not become a surprise wrap"
+    );
+}
+
+#[test]
 fn left_right_scroll_the_content_horizontally_when_focused_and_unwrapped() {
     // A .rs file renders unwrapped (SyntaxContent), so its long lines can overflow the pane;
     // with the content focused, ←/→ scroll it sideways to read them. (When the tree is

--- a/tests/controller_async.rs
+++ b/tests/controller_async.rs
@@ -780,3 +780,29 @@ fn a_width_change_does_not_reflow_non_markdown() {
         "a resize must not re-render a non-markdown view"
     );
 }
+
+/// `w` flips the wrap width handed to glow: fit-to-pane (`Some(width)`, ellipsized table) when
+/// wrapped, natural width (`None` → glow's base `-w 0`, full table + horizontal scroll) when
+/// unwrapped. Toggling re-renders markdown (preserving view state) rather than only re-laying it out
+/// in the Presenter, because the two views come from different glow invocations.
+#[test]
+fn w_flips_the_markdown_wrap_width_between_fit_and_natural() {
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("doc.md"), "# hi\n").unwrap();
+    let widths = Arc::new(Mutex::new(Vec::new()));
+    let mut ctrl = Controller::new(
+        common::resolved(dir.path().to_path_buf(), false),
+        Baseline::Head,
+        width_probe_components(Arc::clone(&widths), 5),
+    );
+    await_contains(&mut ctrl, "w=None:doc.md"); // initial: pane not measured yet
+
+    ctrl.set_content_viewport(40, 10); // fit view (wrapped default) → glow gets the pane width
+    await_contains(&mut ctrl, "w=Some(40):doc.md");
+
+    ctrl.handle(Intent::ToggleWrap); // → wide/unwrapped → glow gets no width (natural `-w 0`)
+    await_contains(&mut ctrl, "w=None:doc.md");
+
+    ctrl.handle(Intent::ToggleWrap); // → fit again → glow gets the pane width once more
+    await_contains(&mut ctrl, "w=Some(40):doc.md");
+}

--- a/tests/controller_async.rs
+++ b/tests/controller_async.rs
@@ -806,3 +806,154 @@ fn w_flips_the_markdown_wrap_width_between_fit_and_natural() {
     ctrl.handle(Intent::ToggleWrap); // → fit again → glow gets the pane width once more
     await_contains(&mut ctrl, "w=Some(40):doc.md");
 }
+
+// ---- advisory test-coverage backfill (empanel round 1) ---------------------------------------
+
+/// `toggle_wrap` unconditionally calls `rerender_markdown_reflow`, which is a no-op for a
+/// non-markdown selection (the inner mode-guard returns early). Guard against a regression that
+/// drops that guard: toggling `w` on a code file must dispatch NO render.
+#[test]
+fn toggle_wrap_on_a_code_file_dispatches_no_render() {
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.rs"), "fn main() {}\n").unwrap();
+    let widths = Arc::new(Mutex::new(Vec::new()));
+    let mut ctrl = Controller::new(
+        common::resolved(dir.path().to_path_buf(), false),
+        Baseline::Head,
+        width_probe_components(Arc::clone(&widths), 5),
+    );
+    await_contains(&mut ctrl, "w=None:a.rs");
+    ctrl.set_content_viewport(50, 10); // code view is width-independent → no reflow
+    let before = widths.lock().unwrap().len();
+    ctrl.handle(Intent::ToggleWrap); // toggle wrap on a code file
+    std::thread::sleep(Duration::from_millis(50)); // give any (wrong) dispatch time to land
+    ctrl.poll();
+    assert_eq!(
+        widths.lock().unwrap().len(),
+        before,
+        "toggling wrap on a code file must not dispatch a render"
+    );
+}
+
+/// The worker now calls `render_at_width`, so every non-markdown test double relies on the trait's
+/// DEFAULT `render_at_width` forwarding to `render` and ignoring the width. Assert that contract
+/// directly on a stub that implements only `render`.
+#[test]
+fn render_at_width_default_impl_forwards_to_render_ignoring_width() {
+    struct DefaultStub;
+    impl ContentProvider for DefaultStub {
+        fn render(&self, path: &Path, _mode: ViewMode, raw_diff: Option<&str>) -> RenderResult {
+            let name = path.file_name().unwrap().to_string_lossy().into_owned();
+            RenderResult {
+                content: Text::raw(format!("r:{name}:{}", raw_diff.unwrap_or("-"))),
+                notices: Vec::new(),
+                source: None,
+            }
+        }
+    }
+    let s = DefaultStub;
+    let p = Path::new("/x/a.rs");
+    let base = s.render(p, ViewMode::SyntaxContent, Some("d"));
+    let widthed = s.render_at_width(p, ViewMode::SyntaxContent, Some("d"), Some(42));
+    assert_eq!(
+        flatten(&base.content),
+        flatten(&widthed.content),
+        "the default render_at_width ignores the width and forwards to render"
+    );
+}
+
+/// A content provider whose number of `match` lines depends on the wrap width it is handed: the
+/// fit (wide) render carries 8, a narrow one carries 2. A resize that narrows the pane therefore
+/// SHRINKS the committed-search match count, exercising `recompute_committed_search`'s clamp of the
+/// selected ordinal (`current.min(len-1)`) — the path the reflow test with identical tokens can't hit.
+struct WidthDependentMatches;
+impl ContentProvider for WidthDependentMatches {
+    fn render(&self, path: &Path, mode: ViewMode, raw_diff: Option<&str>) -> RenderResult {
+        self.render_at_width(path, mode, raw_diff, None)
+    }
+    fn render_at_width(
+        &self,
+        _path: &Path,
+        _mode: ViewMode,
+        _raw_diff: Option<&str>,
+        width: Option<u16>,
+    ) -> RenderResult {
+        let n = match width {
+            Some(w) if w >= 40 => 8,
+            _ => 2,
+        };
+        let mut s = format!("header n={n}");
+        for _ in 0..n {
+            s.push_str("\nmatch here");
+        }
+        RenderResult {
+            content: Text::raw(s),
+            notices: Vec::new(),
+            source: None,
+        }
+    }
+}
+
+#[test]
+fn a_committed_search_ordinal_is_clamped_when_a_reflow_shrinks_the_match_count() {
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("doc.md"), "# hi\n").unwrap();
+    let components = Components {
+        providers: Box::new(|_resolved| RootProviders {
+            git: Arc::new(NoGit),
+            content: Box::new(WidthDependentMatches),
+        }),
+        editor: Box::new(NoEditor),
+        clipboard: Box::new(common::RecordingClipboard::default()),
+        renderers: None,
+    };
+    let mut ctrl = Controller::new(
+        common::resolved(dir.path().to_path_buf(), false),
+        Baseline::Head,
+        components,
+    );
+    await_contains(&mut ctrl, "n=2"); // initial render (pane not measured → narrow branch)
+
+    // Measure a wide pane → fit reflow → 8 match lines.
+    ctrl.set_content_viewport(50, 20);
+    await_contains(&mut ctrl, "n=8");
+
+    // Commit a search that matches all 8 lines, then advance to the LAST match (ordinal 7).
+    ctrl.handle(Intent::OpenSearch);
+    for c in "match".chars() {
+        ctrl.handle_prompt_key(key(KeyCode::Char(c)));
+    }
+    ctrl.handle_prompt_key(key(KeyCode::Enter));
+    assert_eq!(
+        ctrl.search().map(|s| s.matches.len()),
+        Some(8),
+        "8 matches at the wide width"
+    );
+    for _ in 0..7 {
+        ctrl.handle(Intent::NextMatch);
+    }
+    assert_eq!(
+        ctrl.search().map(|s| s.current),
+        Some(7),
+        "advanced to the last match"
+    );
+
+    // Narrow the pane → reflow to 2 match lines → recompute must clamp the ordinal (7 → 1), never
+    // leaving `current` pointing past the end (which navigation would index out of bounds).
+    ctrl.set_content_viewport(30, 20);
+    await_contains(&mut ctrl, "n=2");
+    let s = ctrl
+        .search()
+        .expect("the committed search survives the reflow");
+    assert_eq!(
+        s.matches.len(),
+        2,
+        "the match count shrank on the narrower reflow"
+    );
+    assert_eq!(
+        s.current, 1,
+        "the ordinal is clamped to the last valid match (no out-of-bounds)"
+    );
+    // And navigation on the clamped state does not panic.
+    ctrl.handle(Intent::NextMatch);
+}

--- a/tests/controller_async.rs
+++ b/tests/controller_async.rs
@@ -6,6 +6,7 @@
 mod common;
 
 use common::TempDir;
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use herdr_file_viewer::controller::{
     Components, ContentProvider, Controller, EditorHandoff, EditorOutcome, GitService,
     RenderResult, RootProviders,
@@ -583,5 +584,199 @@ fn a_superseded_render_does_not_overwrite_the_loading_placeholder_nor_the_pane()
         flatten(ctrl.content()),
         "rendered:c.rs",
         "a superseded render (b.rs) must not overwrite the newer selection (c.rs)"
+    );
+}
+
+// ---- content-pane resize → markdown reflow (the table fix) --------------------------------
+
+/// A content provider that records the wrap `width` handed to every `render_at_width` call and
+/// returns `lines` short lines, the first of which encodes that width (`w=<width>:<name>`). It lets
+/// a test observe (a) that a content-pane resize threads the new pane width into the render, and
+/// (b) that a reflow preserves view state — the body has enough lines to scroll and carries a
+/// stable `lineN` token to search for.
+struct WidthProbe {
+    widths: Arc<Mutex<Vec<Option<u16>>>>,
+    lines: usize,
+}
+impl WidthProbe {
+    fn body(&self, width: Option<u16>, name: &str) -> RenderResult {
+        let mut s = format!("w={width:?}:{name}");
+        for i in 1..self.lines {
+            s.push_str(&format!("\nline{i}"));
+        }
+        RenderResult {
+            content: Text::raw(s),
+            notices: Vec::new(),
+            source: None,
+        }
+    }
+}
+impl ContentProvider for WidthProbe {
+    fn render(&self, path: &Path, mode: ViewMode, raw_diff: Option<&str>) -> RenderResult {
+        self.render_at_width(path, mode, raw_diff, None)
+    }
+    fn render_at_width(
+        &self,
+        path: &Path,
+        _mode: ViewMode,
+        _raw_diff: Option<&str>,
+        width: Option<u16>,
+    ) -> RenderResult {
+        self.widths.lock().unwrap().push(width);
+        let name = path.file_name().unwrap().to_string_lossy().into_owned();
+        self.body(width, &name)
+    }
+}
+
+fn key(code: KeyCode) -> KeyEvent {
+    KeyEvent::new(code, KeyModifiers::NONE)
+}
+
+/// Spin `poll()` until the content pane contains `marker` (or the deadline trips).
+fn await_contains(ctrl: &mut Controller, marker: &str) {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        ctrl.poll();
+        if flatten(ctrl.content()).contains(marker) {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "content never contained {marker:?}; was {:?}",
+            flatten(ctrl.content())
+        );
+        std::thread::sleep(Duration::from_millis(5));
+    }
+}
+
+fn width_probe_components(widths: Arc<Mutex<Vec<Option<u16>>>>, lines: usize) -> Components {
+    Components {
+        providers: Box::new(move |_resolved| RootProviders {
+            git: Arc::new(NoGit),
+            content: Box::new(WidthProbe {
+                widths: Arc::clone(&widths),
+                lines,
+            }),
+        }),
+        editor: Box::new(NoEditor),
+        clipboard: Box::new(common::RecordingClipboard::default()),
+        renderers: None,
+    }
+}
+
+/// The core of the table fix: a content-pane *width* change re-renders rendered markdown at the new
+/// pane width (so glow lays out tables to fit), while a *height*-only change does not (glow's layout
+/// does not depend on height — re-rendering would be wasted work and would flash the pane).
+#[test]
+fn a_width_change_reflows_markdown_at_the_new_width_but_a_height_change_does_not() {
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("doc.md"), "# hi\n").unwrap();
+    let widths = Arc::new(Mutex::new(Vec::new()));
+    let mut ctrl = Controller::new(
+        common::resolved(dir.path().to_path_buf(), false),
+        Baseline::Head,
+        width_probe_components(Arc::clone(&widths), 5),
+    );
+
+    // The initial render happens before any draw measured the pane → width unknown (None).
+    await_contains(&mut ctrl, "w=None:doc.md");
+
+    // A width change reflows markdown at the new pane width.
+    ctrl.set_content_viewport(50, 10);
+    await_contains(&mut ctrl, "w=Some(50):doc.md");
+    assert!(
+        widths.lock().unwrap().contains(&Some(50)),
+        "a resize must thread the new pane width into the markdown render: {:?}",
+        widths.lock().unwrap()
+    );
+
+    // A height-only change (same width) must NOT reflow — no further render is dispatched.
+    let before = widths.lock().unwrap().len();
+    ctrl.set_content_viewport(50, 14);
+    std::thread::sleep(Duration::from_millis(50)); // give any (wrong) reflow time to land
+    ctrl.poll();
+    assert_eq!(
+        widths.lock().unwrap().len(),
+        before,
+        "a height-only change must not re-render markdown"
+    );
+}
+
+/// A width reflow is not a selection change: it must preserve the user's scroll position (a
+/// split-bar drag must not yank the pane to the top) and recompute — rather than drop — a committed
+/// search (a resize must not silently clear the active highlighting).
+#[test]
+fn a_width_reflow_preserves_scroll_and_recomputes_a_committed_search() {
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("doc.md"), "# hi\n").unwrap();
+    let widths = Arc::new(Mutex::new(Vec::new()));
+    let mut ctrl = Controller::new(
+        common::resolved(dir.path().to_path_buf(), false),
+        Baseline::Head,
+        width_probe_components(Arc::clone(&widths), 50), // 50 lines → scrollable
+    );
+    await_contains(&mut ctrl, "w=None:doc.md");
+
+    // Measure the pane (width 40, height 10) and land that reflow.
+    ctrl.set_content_viewport(40, 10);
+    await_contains(&mut ctrl, "w=Some(40):doc.md");
+
+    // Commit a search for a token present in every render, then scroll away from the top.
+    ctrl.handle(Intent::OpenSearch);
+    for c in "line5".chars() {
+        ctrl.handle_prompt_key(key(KeyCode::Char(c)));
+    }
+    ctrl.handle_prompt_key(key(KeyCode::Enter));
+    assert!(
+        ctrl.search()
+            .map(|s| !s.matches.is_empty())
+            .unwrap_or(false),
+        "precondition: a committed search with matches"
+    );
+    ctrl.scroll_to_line(20);
+    let scrolled = ctrl.content_scroll();
+    assert!(scrolled > 0, "precondition: scrolled away from the top");
+
+    // Resize narrower (a width change) → reflow. Scroll and the committed search must survive.
+    ctrl.set_content_viewport(30, 10);
+    await_contains(&mut ctrl, "w=Some(30):doc.md");
+    assert_eq!(
+        ctrl.content_scroll(),
+        scrolled,
+        "a width reflow must preserve the scroll position, not reset to the top"
+    );
+    let search = ctrl
+        .search()
+        .expect("a committed search must survive a width reflow (recomputed, not dropped)");
+    assert_eq!(search.query, "line5", "the committed query is unchanged");
+    assert!(
+        !search.matches.is_empty(),
+        "the search is recomputed against the reflowed content"
+    );
+}
+
+/// A resize only reflows rendered markdown — a non-markdown view (code / plain text) is
+/// width-independent here (it h-scrolls, and its delegate manages its own width), so a width change
+/// must not re-render it.
+#[test]
+fn a_width_change_does_not_reflow_non_markdown() {
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.rs"), "fn main() {}\n").unwrap();
+    let widths = Arc::new(Mutex::new(Vec::new()));
+    let mut ctrl = Controller::new(
+        common::resolved(dir.path().to_path_buf(), false),
+        Baseline::Head,
+        width_probe_components(Arc::clone(&widths), 5),
+    );
+    await_contains(&mut ctrl, "w=None:a.rs");
+
+    let before = widths.lock().unwrap().len();
+    ctrl.set_content_viewport(50, 10); // width change, but the selection is code, not markdown
+    std::thread::sleep(Duration::from_millis(50));
+    ctrl.poll();
+    assert_eq!(
+        widths.lock().unwrap().len(),
+        before,
+        "a resize must not re-render a non-markdown view"
     );
 }

--- a/tests/render_delegate.rs
+++ b/tests/render_delegate.rs
@@ -7,6 +7,7 @@
 use herdr_file_viewer::render::{Prepared, Renderers, render};
 use herdr_file_viewer::view_policy::ViewMode;
 use ratatui::text::Text;
+use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
 fn cat() -> Renderers {
@@ -322,5 +323,84 @@ fn truncation_notice_is_preserved_through_rendering() {
     assert!(
         notice.unwrap().contains("truncated-preview"),
         "AC-13 notice survives"
+    );
+}
+
+/// Whether a real `glow` is installed — the wrap-width behavioral test below needs the actual
+/// renderer (its table layout / line padding is glow's own behavior, not something we mock), so it
+/// skips cleanly when glow is absent (e.g. a CI image without the runtime renderers).
+fn glow_available() -> bool {
+    Command::new("glow")
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// The table fix, end-to-end through the REAL markdown delegate: with glow pointed at the bundled
+/// (margin-0) style and `-w <width>`, every rendered line is `<= width`. That is the property the
+/// content pane relies on — the Presenter's `Paragraph::wrap` becomes a no-op (no line overflows to
+/// a blank "gap" row), and a table wider than the pane at natural `-w 0` layout is instead sized to
+/// fit with its borders intact rather than shattered by the re-wrap. Skips if glow is not installed.
+#[test]
+fn glow_markdown_wrapped_to_width_never_exceeds_it() {
+    if !glow_available() {
+        eprintln!("skipping glow_markdown_wrapped_to_width_never_exceeds_it: glow not installed");
+        return;
+    }
+    let style = concat!(env!("CARGO_MANIFEST_DIR"), "/assets/markdown-style.json");
+    let width: u16 = 74;
+    let renderers = Renderers {
+        // The real default markdown command shape, pinned to the bundled style and this wrap width
+        // (what `LiveContent::render_at_width` builds for a markdown render at a known pane width).
+        markdown: vec![
+            "glow".into(),
+            "-s".into(),
+            style.into(),
+            "-w".into(),
+            width.to_string(),
+            "-".into(),
+        ],
+        diff: vec!["cat".into()],
+        full_diff: vec!["cat".into()],
+        syntax: vec!["cat".into()],
+        timeout: Duration::from_secs(5),
+    };
+    // A table far wider than `width` at natural layout, plus a long prose paragraph — both must be
+    // brought within `width` by glow.
+    let md = "\
+| Model | Roles | Raised | Notes |\n\
+|---|---|---|---|\n\
+| gpt-5.5 | holistic, lens-security | 5 | The security sniper: sole catch of the grid-resize DoS, unbounded dims to OOM, nobody else saw it. |\n\
+| opus-4-8 | holistic, lens-contracts | 7 | Co-caught the scrollback HIGH; a strong advisory set spanning cold-start and snapshot perms. |\n\
+\n\
+This is a long prose paragraph that at its natural width would be wider than the pane and so must be wrapped by glow to fit within the requested width without ever overflowing it.\n";
+    let prepared = Prepared::Full { text: md.into() };
+    let (text, _) = render(
+        &renderers,
+        &prepared,
+        ViewMode::RenderedMarkdown,
+        None,
+        None,
+    );
+    for line in &text.lines {
+        assert!(
+            line.width() as u16 <= width,
+            "rendered line exceeds the wrap width {width} (would force a Presenter re-wrap / gap): \
+             width={} content={:?}",
+            line.width(),
+            line.spans
+                .iter()
+                .map(|s| s.content.as_ref())
+                .collect::<String>()
+        );
+    }
+    // A table WAS rendered (box-drawing borders survived), not degraded to bare pipes.
+    let flat = flatten(&text);
+    assert!(
+        flat.contains('│') || flat.contains('┼') || flat.contains('─'),
+        "table borders present in the rendered output: {flat:?}"
     );
 }


### PR DESCRIPTION
## What

Wide tables in the rendered-markdown view used to shatter: `glow` was invoked with `-w 0` (wrapping disabled), so a table was laid out at its natural (very wide) width and the content pane's line-wrapping then broke it apart across the border rows. This PR makes tables render correctly, and adds a way to read cells that don't fit.

Two commits:

1. **fit-to-pane (default).** Point glow's `-w` at the content pane's drawable width, so glow sizes the columns and wraps prose to fit (borders intact; over-long cells ellipsized with `…`). Because glow's output is exactly the pane width, the Presenter's re-wrap becomes a no-op. A resize or split-bar drag reflows the table to the new width, preserving scroll position and any active search.

2. **`w` = wide, horizontally-scrollable view.** Fitting truncates cells, so the hidden text was unreachable. `w` now toggles rendered markdown between the fit view and a wide view that renders the table at full natural width, where the pane scrolls sideways (`←`/`→` or the scrollbar) to reveal every cell. Previously `w` did nothing for markdown. It stays a uniform wrap on/off preference, so unwrapping a table never springs an unexpected wrap onto a code file viewed next.

## Why not "fit everything by wrapping cells"

glow cannot wrap table cells (it only ellipsizes), and no renderer we delegate to does. Fitting all content and reflowing would mean rendering tables ourselves, which cuts against the delegate-rendering principle (ADR-0001). The fit view + the `w` wide/scroll escape hatch gives both "adapts to the pane" and "read everything", with zero custom rendering.

## How it works

- `ContentProvider` gains a defaulted `render_at_width`; the render worker calls it with the pane width carried on `RenderJob`. Only the live `LiveContent` overrides it (threads the width into glow's `-w`), so the test doubles are untouched.
- `wrap_override` becomes `Option<bool>` (None = per-mode default, Some(true/false) = force on/off). `md_wrap_width` hands glow the pane width only in the fit view; in the wide view glow keeps its natural-width `-w 0` output and the existing content h-scroll takes over.
- A width change (resize) or a `w` toggle re-renders markdown through one scroll/search-preserving reflow path, distinct from the selection-change render that resets view state.

## Scope / safety

- Read-only; no new dependencies.
- Rendering logic only; no UI-string or manifest changes.

## Tests

- Width threading: hermetic (shell renderer echoing `-w`) plus a real-glow check that no rendered line exceeds the wrap width (the no-gap property).
- Resize reflow vs. height-only no-op vs. non-markdown no-op; scroll + committed search preserved across a reflow.
- `w` flips fit <-> wide (both `view_state().wrap` and the width handed to glow); unwrapping markdown does not force-wrap a code file viewed next.

Full suite green; fmt/clippy/audit clean. Verified live in herdr (fit view, `w` to wide, scroll right to read the full Notes column, `w` back to fit).
