### PR TITLE
test: sweep leaked temp dirs from killed test runs

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -9,9 +9,56 @@ use herdr_file_viewer::root::Resolved;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, Once};
+use std::time::{Duration, SystemTime};
 
 static COUNTER: AtomicU64 = AtomicU64::new(0);
+static SWEEP: Once = Once::new();
+
+/// Prefix every [`TempDir`] path shares, so the leak sweep can recognize its own orphans.
+const TEMP_PREFIX: &str = "herdr-fv-test-";
+
+/// Best-effort removal of `herdr-fv-test-*` dirs in `base` whose mtime predates `cutoff`.
+///
+/// Split out of [`sweep_stale_once`] with an injectable `base` + `cutoff` so it is testable
+/// without backdating a directory's mtime. Every step is best-effort: an unreadable base, a
+/// racing sweeper from a concurrent run, or a dir that vanishes mid-loop is simply skipped.
+pub fn sweep_stale_in(base: &Path, cutoff: SystemTime) {
+    let Ok(entries) = std::fs::read_dir(base) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+        if !name.starts_with(TEMP_PREFIX) {
+            continue;
+        }
+        // Only sweep dirs old enough that no live run (including a concurrent one) could own
+        // them; a dir whose mtime we can't read is left alone rather than risk a live removal.
+        let stale = entry
+            .metadata()
+            .and_then(|m| m.modified())
+            .map(|mtime| mtime < cutoff)
+            .unwrap_or(false);
+        if stale {
+            let _ = std::fs::remove_dir_all(entry.path());
+        }
+    }
+}
+
+/// One-time, best-effort sweep of temp dirs leaked by previous, *killed* test runs.
+///
+/// [`TempDir`] removes itself on `Drop`, but `Drop` never runs when a test process is killed
+/// (a timeout, `SIGKILL`, Ctrl-C, `panic = "abort"`): those orphans then pile up in the system
+/// temp dir and can exhaust a small `/tmp` tmpfs. Reclaim them once per process, at first
+/// `TempDir::new()`, taking only entries older than an hour so no live run's dirs are touched.
+fn sweep_stale_once() {
+    SWEEP.call_once(|| {
+        if let Some(cutoff) = SystemTime::now().checked_sub(Duration::from_secs(3600)) {
+            sweep_stale_in(&std::env::temp_dir(), cutoff);
+        }
+    });
+}
 
 /// A unique temporary directory removed on drop.
 pub struct TempDir {
@@ -20,13 +67,14 @@ pub struct TempDir {
 
 impl TempDir {
     pub fn new() -> Self {
+        sweep_stale_once();
         let n = COUNTER.fetch_add(1, Ordering::Relaxed);
         let nanos = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
             .as_nanos();
         let path = std::env::temp_dir().join(format!(
-            "herdr-fv-test-{}-{}-{}",
+            "{TEMP_PREFIX}{}-{}-{}",
             std::process::id(),
             nanos,
             n

--- a/tests/tempdir_sweep.rs
+++ b/tests/tempdir_sweep.rs
@@ -1,0 +1,41 @@
+//! Regression test for the leaked-temp-dir sweep in `common::sweep_stale_in`.
+//!
+//! `TempDir` cleans up on drop, but a *killed* test run (timeout, SIGKILL) skips `Drop` and
+//! leaks its temp dirs; over many killed runs they exhausted the `/tmp` tmpfs. The sweep
+//! reclaims those stale orphans on the next run while never touching a live run's dirs.
+
+mod common;
+
+use std::fs;
+use std::time::{Duration, SystemTime};
+
+#[test]
+fn sweeps_stale_prefixed_dirs_but_spares_fresh_and_foreign() {
+    // A private base (its own TempDir) so the test never races the real system temp dir.
+    let base = common::TempDir::new();
+    let base = base.path();
+
+    let stale = base.join("herdr-fv-test-1-2-3");
+    let also_stale = base.join("herdr-fv-test-4-5-6");
+    let foreign = base.join("some-other-tool-xyz"); // not our prefix
+    for d in [&stale, &also_stale, &foreign] {
+        fs::create_dir(d).unwrap();
+    }
+
+    // Cutoff in the future: every just-created dir is "older than cutoff", so the prefixed
+    // ones are eligible and the foreign one must still be spared (prefix gate).
+    common::sweep_stale_in(base, SystemTime::now() + Duration::from_secs(3600));
+    assert!(!stale.exists(), "a stale prefixed dir should be swept");
+    assert!(!also_stale.exists(), "a stale prefixed dir should be swept");
+    assert!(foreign.exists(), "a non-prefixed dir must never be touched");
+
+    // Cutoff in the past: a freshly created prefixed dir is newer than the cutoff, i.e. it
+    // looks like a live run's dir, so the age gate must spare it.
+    let live = base.join("herdr-fv-test-7-8-9");
+    fs::create_dir(&live).unwrap();
+    common::sweep_stale_in(base, SystemTime::now() - Duration::from_secs(3600));
+    assert!(
+        live.exists(),
+        "a dir newer than the cutoff (a live run's) must be spared"
+    );
+}


### PR DESCRIPTION
## Problem

The test suite's `TempDir` helper (`tests/common/mod.rs`) creates a throwaway git repo under the
system temp dir and removes it on `Drop`. That works on a normal return or a `panic!` unwind, but
`Drop` **never runs when the test process is killed** (a timeout, `SIGKILL`, Ctrl-C, or
`panic = "abort"`). Every interrupted `cargo test` run therefore orphans all of its temp dirs.

Over many killed runs these accumulate without bound: on one dev box there were **50,376** leaked
`herdr-fv-test-*` dirs, filling a 3.6 G `/tmp` tmpfs to 70% of its inodes. The visible symptom is
the perf tests failing with `Disk quota exceeded` on an otherwise-healthy checkout.

## Fix

A one-time, best-effort sweep at the first `TempDir::new()` in a process: remove sibling
`herdr-fv-test-*` dirs whose mtime is **older than an hour**, so no live run's dirs (including a
concurrent run's) are ever removed. Guarded by a `std::sync::Once` so it costs one `read_dir` per
process, not one per temp dir. The prefix is now a shared `const` so the path builder and the sweep
can't drift.

- **Dependency-free** - keeps the deliberate `tempfile`-free house style (no new crate).
- **Test-only** - the change lives entirely in `tests/`; zero runtime, binary, or user-facing
  surface (so no CHANGELOG/README/ARCHITECTURE changes apply).
- Self-healing: a killed run still leaks its own dirs, but the next run reclaims them.

## Tests

New `tests/tempdir_sweep.rs` exercises `sweep_stale_in` with an injected base + cutoff (no mtime
backdating needed):

- future cutoff -> prefixed dirs are swept, a non-prefixed sibling is spared (prefix gate);
- past cutoff -> a freshly created prefixed dir (a live run's) is spared (age gate).

Full suite green (846 passing) with fmt + clippy clean.

## Note

Separate from the in-flight `feat/settings-config` work by design - this is pure test
infrastructure and shouldn't muddy that review. Branched off `main` (`c532cff`).
