### PR TITLE
feat: configurable mouse-wheel scroll speed (scroll_lines config key)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project are documented here. The format is based on
 - **Configurable mouse-wheel scroll speed via a `scroll_lines` key in `config.toml`.** Sets how many
   lines each wheel event advances the content pane (and how many items it moves in the file-search
   list, and lines in the `?` help overlay); the directory tree still moves one row per event.
-  Defaults to `3` (unchanged behaviour) and is clamped to a minimum of `1`. Lower it (e.g.
+  Defaults to `3` (unchanged behaviour) and is clamped to the range `1..=10`. Lower it (e.g.
   `scroll_lines = 1`) for finer, slower scrolling when reading large files or browsing search
   results. `config > default`, no environment variable; the effective value is shown in the `?`
   overlay's Settings section. (GitHub #93)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ All notable changes to this project are documented here. The format is based on
 ## [Unreleased]
 
 ### Added
+- **Configurable mouse-wheel scroll speed via a `scroll_lines` key in `config.toml`.** Sets how many
+  lines each wheel event advances the content pane (and how many items it moves in the file-search
+  list, and lines in the `?` help overlay); the directory tree still moves one row per event.
+  Defaults to `3` (unchanged behaviour) and is clamped to a minimum of `1`. Lower it (e.g.
+  `scroll_lines = 1`) for finer, slower scrolling when reading large files or browsing search
+  results. `config > default`, no environment variable; the effective value is shown in the `?`
+  overlay's Settings section. (GitHub #93)
 - **Customizable keybindings: remap any global key with a `[keys]` table in `config.toml`.** A new
   `[keys]` section keyed by intent name (`refresh`, `nav_up`, `switch_worktree`, and the rest) lets
   you replace an action's default key(s) with your own, written as a single string (`refresh = "g"`)

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -94,6 +94,10 @@ Canonical vocabulary for this repo. Glossary only: no implementation detail, no 
   into argv by the same quote-aware tokenizer used for `$EDITOR`; no shell is invoked.
 - **Settings section**: the display-only section of the help overlay that lists the
   **effective setting**s; it shows configuration, it does not edit it.
+- **scroll step**: how many content lines (or **file finder** list items, or help-overlay
+  lines) the mouse wheel advances per wheel event. Set by the `scroll_lines` **config file**
+  key (config > default; default 3, floor 1). The directory tree is unaffected: it always
+  advances one row per wheel event.
 - **keybinding registry**: the single data-driven table binding each global viewer action
   to its default key(s) and a human description; the source of truth the input dispatcher
   decodes from and the help overlay and README both derive from.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -96,8 +96,8 @@ Canonical vocabulary for this repo. Glossary only: no implementation detail, no 
   **effective setting**s; it shows configuration, it does not edit it.
 - **scroll step**: how many content lines (or **file finder** list items, or help-overlay
   lines) the mouse wheel advances per wheel event. Set by the `scroll_lines` **config file**
-  key (config > default; default 3, floor 1). The directory tree is unaffected: it always
-  advances one row per wheel event.
+  key (config > default; default 3, clamped to the range 1 to 10). The directory tree is
+  unaffected: it always advances one row per wheel event.
 - **keybinding registry**: the single data-driven table binding each global viewer action
   to its default key(s) and a human description; the source of truth the input dispatcher
   decodes from and the help overlay and README both derive from.

--- a/README.md
+++ b/README.md
@@ -328,7 +328,8 @@ normal case — every key falls back to its default.
 fallback tier below the config key and above the built-in default — `editor` (`$EDITOR`) and
 `update_check` (`$HERDR_FILE_VIEWER_NO_UPDATE_CHECK`) — giving those two a `config > env >
 default` chain. Every other key (`markdown`, `diff`, `syntax`, `open`, `reveal`,
-`hide_dotfiles`) has no applicable environment variable; for those it's `config > default` only.
+`hide_dotfiles`, `scroll_lines`) has no applicable environment variable; for those it's
+`config > default` only.
 
 ```toml
 # ~/.config/herdr-file-viewer/config.toml (or the herdr-provided path above)
@@ -344,6 +345,7 @@ reveal = "nautilus"
 
 hide_dotfiles = false       # true to hide dotfiles at startup (the `.` key still toggles)
 update_check = true         # false to disable the once-a-day update check
+scroll_lines = 3            # lines per mouse-wheel step (min 1) — content pane, file search, help
 ```
 
 Command values (`editor`, `markdown`, `diff`, `syntax`, `open`, `reveal`) are **split into

--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ reveal = "nautilus"
 
 hide_dotfiles = false       # true to hide dotfiles at startup (the `.` key still toggles)
 update_check = true         # false to disable the once-a-day update check
-scroll_lines = 3            # mouse-wheel step (content/search/help): 1 slow · 3 medium · 6 fast · 10 max
+scroll_lines = 3            # mouse-wheel step (content/search/help), a 1 to 10 scale: 1 slow · 3 medium · 6 fast · 10 max
 ```
 
 Command values (`editor`, `markdown`, `diff`, `syntax`, `open`, `reveal`) are **split into

--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ reveal = "nautilus"
 
 hide_dotfiles = false       # true to hide dotfiles at startup (the `.` key still toggles)
 update_check = true         # false to disable the once-a-day update check
-scroll_lines = 3            # lines per mouse-wheel step, 1 to 10 — content pane, file search, help
+scroll_lines = 3            # mouse-wheel step (content/search/help): 1 slow · 3 medium · 6 fast · 10 max
 ```
 
 Command values (`editor`, `markdown`, `diff`, `syntax`, `open`, `reveal`) are **split into

--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ reveal = "nautilus"
 
 hide_dotfiles = false       # true to hide dotfiles at startup (the `.` key still toggles)
 update_check = true         # false to disable the once-a-day update check
-scroll_lines = 3            # lines per mouse-wheel step (min 1) — content pane, file search, help
+scroll_lines = 3            # lines per mouse-wheel step, 1 to 10 — content pane, file search, help
 ```
 
 Command values (`editor`, `markdown`, `diff`, `syntax`, `open`, `reveal`) are **split into

--- a/config.example.toml
+++ b/config.example.toml
@@ -70,9 +70,10 @@
 #update_check = true
 
 # How many lines the mouse wheel scrolls per event (also how many items it moves
-# in the file-search list, and lines in the `?` help overlay). Range 1 to 10;
-# lower it for finer, slower scrolling. Note: some terminals emit several wheel
-# events per physical notch, so the effective speed is this times that. Default:
+# in the file-search list, and lines in the `?` help overlay). Range 1 to 10:
+# 1 = slow, 3 = medium (default), 6 = fast, 10 = max speed. Note: some terminals
+# emit several wheel events per physical notch, so the effective speed is this
+# times that. Default:
 #scroll_lines = 3
 
 # --- Keybindings -------------------------------------------------------------

--- a/config.example.toml
+++ b/config.example.toml
@@ -69,6 +69,12 @@
 # $HERDR_FILE_VIEWER_NO_UPDATE_CHECK environment variable). Default:
 #update_check = true
 
+# How many lines the mouse wheel scrolls per event (also how many items it moves
+# in the file-search list, and lines in the `?` help overlay). Minimum 1; lower
+# it for finer, slower scrolling. Note: some terminals emit several wheel events
+# per physical notch, so the effective speed is this times that. Default:
+#scroll_lines = 3
+
 # --- Keybindings -------------------------------------------------------------
 #
 # Remap any global key. Key each entry by its INTENT NAME: the stable snake_case

--- a/config.example.toml
+++ b/config.example.toml
@@ -70,10 +70,10 @@
 #update_check = true
 
 # How many lines the mouse wheel scrolls per event (also how many items it moves
-# in the file-search list, and lines in the `?` help overlay). Range 1 to 10:
-# 1 = slow, 3 = medium (default), 6 = fast, 10 = max speed. Note: some terminals
-# emit several wheel events per physical notch, so the effective speed is this
-# times that. Default:
+# in the file-search list, and lines in the `?` help overlay). Can be set from 1
+# to 10 as a scale: 1 = slow, 3 = medium (default), 6 = fast, 10 = max speed.
+# Note: some terminals emit several wheel events per physical notch, so the
+# effective speed is this times that. Default:
 #scroll_lines = 3
 
 # --- Keybindings -------------------------------------------------------------

--- a/config.example.toml
+++ b/config.example.toml
@@ -70,9 +70,9 @@
 #update_check = true
 
 # How many lines the mouse wheel scrolls per event (also how many items it moves
-# in the file-search list, and lines in the `?` help overlay). Minimum 1; lower
-# it for finer, slower scrolling. Note: some terminals emit several wheel events
-# per physical notch, so the effective speed is this times that. Default:
+# in the file-search list, and lines in the `?` help overlay). Range 1 to 10;
+# lower it for finer, slower scrolling. Note: some terminals emit several wheel
+# events per physical notch, so the effective speed is this times that. Default:
 #scroll_lines = 3
 
 # --- Keybindings -------------------------------------------------------------

--- a/src/app.rs
+++ b/src/app.rs
@@ -103,6 +103,9 @@ pub fn run() -> io::Result<()> {
     // Apply the config-driven startup hide-dotfiles default (AC-9). The interactive `.` toggle
     // still flips it later.
     controller.apply_hide_dotfiles(eff.hide_dotfiles);
+    // Apply the config-driven mouse-wheel scroll step (`scroll_lines`); already clamped to >= 1 by
+    // the resolver, so the wheel always advances at least one line/item.
+    controller.apply_scroll_lines(eff.scroll_lines);
     // Format the Settings section body for the `?` overlay (AC-15, AC-18): reflects the load
     // outcome plus every effective setting, so a user can see what's actually in effect, and the
     // resolved config-file location so they know what to fix or create.

--- a/src/config.rs
+++ b/src/config.rs
@@ -688,6 +688,15 @@ mod tests {
     // --- scroll_lines: the effective scroll step (AC-1..AC-4) ---
 
     #[test]
+    fn scroll_lines_valid_value_parses() {
+        // Happy-path deserialize: a valid integer lands in `Config.scroll_lines` as `Some(n)` and
+        // the load succeeds (the malformed path is covered by `scroll_lines_non_representable_*`).
+        let (config, outcome) = parse_config("scroll_lines = 5\n");
+        assert_eq!(config.scroll_lines, Some(5));
+        assert_eq!(outcome, LoadOutcome::Loaded);
+    }
+
+    #[test]
     fn resolve_scroll_lines_config_value_wins() {
         // AC-1: a valid config value (>= 1) is the effective scroll step (config > default).
         let config = Config {

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,12 @@ use serde::Deserialize;
 /// the single source of truth for both the resolver's default and the controller's initial value.
 pub const DEFAULT_SCROLL_LINES: u16 = 3;
 
+/// The largest accepted `scroll_lines`. Past ~this many lines per event the wheel just jumps to the
+/// pane edge (the content/finder/help views clamp to their bounds), so a larger configured value is
+/// clamped down to this rather than taken literally — keeping the setting to sane line-scrolling
+/// instead of page-jumping. The effective range is therefore `1..=MAX_SCROLL_LINES`.
+pub const MAX_SCROLL_LINES: u16 = 10;
+
 /// A `[keys]` entry's value: the key(s) an intent binds to, written **either** as a single string
 /// (`refresh = "g"`) **or** as a TOML array of strings (`nav_up = ["w", "Up"]`). `#[serde(untagged)]`
 /// tries the variants in order, so `One(String)` must come first: a bare string deserializes to
@@ -40,9 +46,10 @@ pub struct Config {
     pub hide_dotfiles: Option<bool>,
     pub update_check: Option<bool>,
     /// The mouse-wheel **scroll step**: how many lines/items each wheel event advances. `None`
-    /// falls back to [`DEFAULT_SCROLL_LINES`]; a value of `0` is clamped up to `1` by the resolver
-    /// (a `0` step would freeze scrolling). A non-representable value (negative / non-integer) fails
-    /// the parse and degrades the whole config to defaults via the existing `Malformed` path.
+    /// falls back to [`DEFAULT_SCROLL_LINES`]; the resolver clamps a present value to
+    /// `1..=`[`MAX_SCROLL_LINES`] (`0` would freeze scrolling; an over-large value just page-jumps).
+    /// A non-representable value (negative / non-integer / above `u16`) fails the parse and degrades
+    /// the whole config to defaults via the existing `Malformed` path.
     pub scroll_lines: Option<u16>,
     /// The `[keys]` remapping table: **intent name -> key spec** (T-4, Slice B). `None` when the
     /// config omits `[keys]`. A `BTreeMap` keeps the entries in deterministic order. Rides the
@@ -155,9 +162,9 @@ pub struct EffectiveSettings {
     pub reveal: Option<Vec<String>>,
     pub hide_dotfiles: bool,
     pub update_check: bool,
-    /// The effective mouse-wheel **scroll step** (always ≥ 1): the config `scroll_lines` clamped to
-    /// a floor of 1 when present, else [`DEFAULT_SCROLL_LINES`]. No environment variable
-    /// participates — this is a config-or-default UI preference.
+    /// The effective mouse-wheel **scroll step**: the config `scroll_lines` clamped to
+    /// `1..=`[`MAX_SCROLL_LINES`] when present, else [`DEFAULT_SCROLL_LINES`]. No environment
+    /// variable participates — this is a config-or-default UI preference.
     pub scroll_lines: u16,
 }
 
@@ -198,12 +205,13 @@ pub fn resolve(config: &Config, get_env: impl Fn(&str) -> Option<String>) -> Eff
         None => get_env("HERDR_FILE_VIEWER_NO_UPDATE_CHECK").is_none(),
     };
 
-    // Config > default; no env var. Clamp the floor to 1 so a configured `0` can never freeze
-    // scrolling (AC-3). A non-representable value never reaches here — it failed the parse and
-    // arrived as `None` on a defaulted `Config` (AC-4).
+    // Config > default; no env var. Clamp to `1..=MAX_SCROLL_LINES`: a configured `0` can never
+    // freeze scrolling and an over-large value is capped to a sane line step rather than page-jumping
+    // (AC-3). A value that isn't a representable non-negative integer never reaches here — it failed
+    // the parse and arrived as `None` on a defaulted `Config` (AC-4).
     let scroll_lines = config
         .scroll_lines
-        .map(|n| n.max(1))
+        .map(|n| n.clamp(1, MAX_SCROLL_LINES))
         .unwrap_or(DEFAULT_SCROLL_LINES);
 
     EffectiveSettings {
@@ -724,6 +732,23 @@ mod tests {
         };
         let effective = resolve(&config, |_| None);
         assert_eq!(effective.scroll_lines, 1);
+    }
+
+    #[test]
+    fn resolve_scroll_lines_clamps_to_max() {
+        // AC-3: an over-large value is capped to MAX_SCROLL_LINES (page-jumping is pointless — the
+        // views clamp to their bounds), and the boundary value passes through unchanged.
+        let over = Config {
+            scroll_lines: Some(1000),
+            ..Default::default()
+        };
+        assert_eq!(resolve(&over, |_| None).scroll_lines, MAX_SCROLL_LINES);
+        assert_eq!(MAX_SCROLL_LINES, 10);
+        let at_max = Config {
+            scroll_lines: Some(MAX_SCROLL_LINES),
+            ..Default::default()
+        };
+        assert_eq!(resolve(&at_max, |_| None).scroll_lines, MAX_SCROLL_LINES);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,11 @@
 
 use serde::Deserialize;
 
+/// The built-in **scroll step**: how many lines (or finder list items, or help-overlay lines) the
+/// mouse wheel advances per wheel event when the config supplies no valid `scroll_lines`. This is
+/// the single source of truth for both the resolver's default and the controller's initial value.
+pub const DEFAULT_SCROLL_LINES: u16 = 3;
+
 /// A `[keys]` entry's value: the key(s) an intent binds to, written **either** as a single string
 /// (`refresh = "g"`) **or** as a TOML array of strings (`nav_up = ["w", "Up"]`). `#[serde(untagged)]`
 /// tries the variants in order, so `One(String)` must come first: a bare string deserializes to
@@ -34,6 +39,11 @@ pub struct Config {
     pub reveal: Option<String>,
     pub hide_dotfiles: Option<bool>,
     pub update_check: Option<bool>,
+    /// The mouse-wheel **scroll step**: how many lines/items each wheel event advances. `None`
+    /// falls back to [`DEFAULT_SCROLL_LINES`]; a value of `0` is clamped up to `1` by the resolver
+    /// (a `0` step would freeze scrolling). A non-representable value (negative / non-integer) fails
+    /// the parse and degrades the whole config to defaults via the existing `Malformed` path.
+    pub scroll_lines: Option<u16>,
     /// The `[keys]` remapping table: **intent name -> key spec** (T-4, Slice B). `None` when the
     /// config omits `[keys]`. A `BTreeMap` keeps the entries in deterministic order. Rides the
     /// existing defensive `load_config` / `parse_config` with no wiring change: a malformed `[keys]`
@@ -145,6 +155,10 @@ pub struct EffectiveSettings {
     pub reveal: Option<Vec<String>>,
     pub hide_dotfiles: bool,
     pub update_check: bool,
+    /// The effective mouse-wheel **scroll step** (always ≥ 1): the config `scroll_lines` clamped to
+    /// a floor of 1 when present, else [`DEFAULT_SCROLL_LINES`]. No environment variable
+    /// participates — this is a config-or-default UI preference.
+    pub scroll_lines: u16,
 }
 
 /// Pure resolver: `Config` + injected env getter -> `EffectiveSettings` (AC-3, AC-4, AC-5,
@@ -184,6 +198,14 @@ pub fn resolve(config: &Config, get_env: impl Fn(&str) -> Option<String>) -> Eff
         None => get_env("HERDR_FILE_VIEWER_NO_UPDATE_CHECK").is_none(),
     };
 
+    // Config > default; no env var. Clamp the floor to 1 so a configured `0` can never freeze
+    // scrolling (AC-3). A non-representable value never reaches here — it failed the parse and
+    // arrived as `None` on a defaulted `Config` (AC-4).
+    let scroll_lines = config
+        .scroll_lines
+        .map(|n| n.max(1))
+        .unwrap_or(DEFAULT_SCROLL_LINES);
+
     EffectiveSettings {
         editor,
         markdown,
@@ -193,6 +215,7 @@ pub fn resolve(config: &Config, get_env: impl Fn(&str) -> Option<String>) -> Eff
         reveal,
         hide_dotfiles,
         update_check,
+        scroll_lines,
     }
 }
 
@@ -319,6 +342,7 @@ mod tests {
         assert_eq!(config.reveal, None);
         assert_eq!(config.hide_dotfiles, None);
         assert_eq!(config.update_check, None);
+        assert_eq!(config.scroll_lines, None);
         assert_eq!(outcome, LoadOutcome::Loaded);
     }
 
@@ -353,6 +377,7 @@ mod tests {
         assert_eq!(config.reveal, None);
         assert_eq!(config.hide_dotfiles, None);
         assert_eq!(config.update_check, None);
+        assert_eq!(config.scroll_lines, None);
         assert_eq!(outcome, LoadOutcome::Loaded);
     }
 
@@ -594,6 +619,7 @@ mod tests {
         assert_eq!(effective.syntax, None);
         assert_eq!(effective.open, None);
         assert_eq!(effective.reveal, None);
+        assert_eq!(effective.scroll_lines, 3);
     }
 
     // --- resolve: AC-16 partial config -- unset fields fall to their own default ---
@@ -613,6 +639,7 @@ mod tests {
         assert_eq!(effective.syntax, None);
         assert_eq!(effective.open, None);
         assert_eq!(effective.reveal, None);
+        assert_eq!(effective.scroll_lines, 3);
     }
 
     // --- resolve: AC-12 tokenized argv, no shell ---
@@ -656,6 +683,52 @@ mod tests {
         };
         let effective = resolve(&config, get_env);
         assert_eq!(effective.editor, None);
+    }
+
+    // --- scroll_lines: the effective scroll step (AC-1..AC-4) ---
+
+    #[test]
+    fn resolve_scroll_lines_config_value_wins() {
+        // AC-1: a valid config value (>= 1) is the effective scroll step (config > default).
+        let config = Config {
+            scroll_lines: Some(5),
+            ..Default::default()
+        };
+        let effective = resolve(&config, |_| None);
+        assert_eq!(effective.scroll_lines, 5);
+    }
+
+    #[test]
+    fn resolve_scroll_lines_defaults_when_absent() {
+        // AC-2: omitted -> the built-in default (DEFAULT_SCROLL_LINES = 3).
+        let effective = resolve(&Config::default(), |_| None);
+        assert_eq!(effective.scroll_lines, DEFAULT_SCROLL_LINES);
+        assert_eq!(effective.scroll_lines, 3);
+    }
+
+    #[test]
+    fn resolve_scroll_lines_zero_clamps_to_one() {
+        // AC-3: 0 would freeze scrolling -> clamp to the floor of 1.
+        let config = Config {
+            scroll_lines: Some(0),
+            ..Default::default()
+        };
+        let effective = resolve(&config, |_| None);
+        assert_eq!(effective.scroll_lines, 1);
+    }
+
+    #[test]
+    fn scroll_lines_non_representable_degrades_to_default() {
+        // AC-4: a non-representable value (negative) fails the u16 parse, so the whole config
+        // degrades to defaults (Malformed); the resolver then yields the default step (3).
+        let (config, outcome) = parse_config("scroll_lines = -1\n");
+        assert_eq!(config.scroll_lines, None);
+        match outcome {
+            LoadOutcome::Malformed(_) => {}
+            other => panic!("expected Malformed, got {other:?}"),
+        }
+        let effective = resolve(&config, |_| None);
+        assert_eq!(effective.scroll_lines, 3);
     }
 
     // --- Settings Applier: effective_editor / effective_renderers / should_start_update_check

--- a/src/config.rs
+++ b/src/config.rs
@@ -46,11 +46,12 @@ pub struct Config {
     pub hide_dotfiles: Option<bool>,
     pub update_check: Option<bool>,
     /// The mouse-wheel **scroll step**: how many lines/items each wheel event advances. `None`
-    /// falls back to [`DEFAULT_SCROLL_LINES`]; the resolver clamps a present value to
-    /// `1..=`[`MAX_SCROLL_LINES`] (`0` would freeze scrolling; an over-large value just page-jumps).
-    /// A non-representable value (negative / non-integer / above `u16`) fails the parse and degrades
-    /// the whole config to defaults via the existing `Malformed` path.
-    pub scroll_lines: Option<u16>,
+    /// falls back to [`DEFAULT_SCROLL_LINES`]; the resolver clamps any present value into
+    /// `1..=`[`MAX_SCROLL_LINES`] (`0` would freeze scrolling; a larger value just page-jumps, so it
+    /// caps at the max rather than being taken literally). Held as `u32` so even an out-of-`u16`
+    /// number still clamps into range instead of tripping the parse; only a negative / non-integer /
+    /// astronomically large value fails to parse and degrades the whole config to defaults.
+    pub scroll_lines: Option<u32>,
     /// The `[keys]` remapping table: **intent name -> key spec** (T-4, Slice B). `None` when the
     /// config omits `[keys]`. A `BTreeMap` keeps the entries in deterministic order. Rides the
     /// existing defensive `load_config` / `parse_config` with no wiring change: a malformed `[keys]`
@@ -211,7 +212,7 @@ pub fn resolve(config: &Config, get_env: impl Fn(&str) -> Option<String>) -> Eff
     // the parse and arrived as `None` on a defaulted `Config` (AC-4).
     let scroll_lines = config
         .scroll_lines
-        .map(|n| n.clamp(1, MAX_SCROLL_LINES))
+        .map(|n| n.clamp(1, MAX_SCROLL_LINES as u32) as u16)
         .unwrap_or(DEFAULT_SCROLL_LINES);
 
     EffectiveSettings {
@@ -736,16 +737,24 @@ mod tests {
 
     #[test]
     fn resolve_scroll_lines_clamps_to_max() {
-        // AC-3: an over-large value is capped to MAX_SCROLL_LINES (page-jumping is pointless — the
-        // views clamp to their bounds), and the boundary value passes through unchanged.
-        let over = Config {
-            scroll_lines: Some(1000),
-            ..Default::default()
-        };
-        assert_eq!(resolve(&over, |_| None).scroll_lines, MAX_SCROLL_LINES);
+        // AC-3: any over-large value is capped to MAX_SCROLL_LINES (page-jumping is pointless — the
+        // views clamp to their bounds), INCLUDING values beyond u16, which are accepted (the field
+        // is u32) and clamped rather than degrading the whole config to defaults.
         assert_eq!(MAX_SCROLL_LINES, 10);
+        for over in [11u32, 1000, 100_000, u32::MAX] {
+            let cfg = Config {
+                scroll_lines: Some(over),
+                ..Default::default()
+            };
+            assert_eq!(
+                resolve(&cfg, |_| None).scroll_lines,
+                MAX_SCROLL_LINES,
+                "value {over} must clamp to the max"
+            );
+        }
+        // The boundary value passes through unchanged.
         let at_max = Config {
-            scroll_lines: Some(MAX_SCROLL_LINES),
+            scroll_lines: Some(MAX_SCROLL_LINES as u32),
             ..Default::default()
         };
         assert_eq!(resolve(&at_max, |_| None).scroll_lines, MAX_SCROLL_LINES);
@@ -753,8 +762,10 @@ mod tests {
 
     #[test]
     fn scroll_lines_non_representable_degrades_to_default() {
-        // AC-4: a non-representable value (negative) fails the u16 parse, so the whole config
-        // degrades to defaults (Malformed); the resolver then yields the default step (3).
+        // AC-4: a value that isn't a representable non-negative integer (here, negative) fails the
+        // parse, so the whole config degrades to defaults (Malformed); the resolver then yields the
+        // default step (3). (An over-large-but-representable value clamps instead — see
+        // resolve_scroll_lines_clamps_to_max.)
         let (config, outcome) = parse_config("scroll_lines = -1\n");
         assert_eq!(config.scroll_lines, None);
         match outcome {

--- a/src/controller/finder.rs
+++ b/src/controller/finder.rs
@@ -27,7 +27,7 @@ impl Controller {
     /// Handle a mouse event while the go-to-file finder is open (the finder is mouse-interactive;
     /// it owns all mouse while open and never leaks events to the tree/content beneath).
     ///
-    /// - `ScrollDown`/`ScrollUp` → move the finder selection by `WHEEL_STEP`, clamped.
+    /// - `ScrollDown`/`ScrollUp` → move the finder selection by `self.wheel_step`, clamped.
     ///   Position-independent (the finder is the active modal).
     /// - `Up(Left)` → click on a result row (select; double-click confirms).
     /// - `Down`/`Drag`/other → inert no-op (no drag in the finder).
@@ -39,8 +39,8 @@ impl Controller {
             return Effects::noop();
         }
         match ev.kind {
-            MouseEventKind::ScrollDown => self.finder_move_selection(WHEEL_STEP),
-            MouseEventKind::ScrollUp => self.finder_move_selection(-WHEEL_STEP),
+            MouseEventKind::ScrollDown => self.finder_move_selection(self.wheel_step),
+            MouseEventKind::ScrollUp => self.finder_move_selection(-self.wheel_step),
             // Horizontal wheel: scroll the result rows sideways, mirroring the vertical-wheel
             // handling above. Additive to the keyboard ←/→ scroll (AC-18 keyboard-first).
             MouseEventKind::ScrollRight => {

--- a/src/controller/help.rs
+++ b/src/controller/help.rs
@@ -35,7 +35,7 @@ impl Controller {
     /// open and never leaks events to the tree/content beneath (AC-21) — mirroring
     /// [`handle_finder_mouse`](Self::handle_finder_mouse).
     ///
-    /// - `ScrollDown`/`ScrollUp` → `scroll_by(±WHEEL_STEP)` on the active section (AC-8 via mouse).
+    /// - `ScrollDown`/`ScrollUp` → `scroll_by(±self.wheel_step)` on the active section (AC-8 via mouse).
     ///   No clamp here: [`set_pane_geometry`](Self::set_pane_geometry) re-clamps the stored scroll to
     ///   the live measured body height after the next draw (the same split the keyboard path uses).
     /// - `Down(Left)` whose `(col,row)` lands on a section-tab rect → `select(that index)` (AC-10).
@@ -48,8 +48,8 @@ impl Controller {
             return Effects::noop();
         }
         match ev.kind {
-            MouseEventKind::ScrollDown => self.help_scroll(WHEEL_STEP),
-            MouseEventKind::ScrollUp => self.help_scroll(-WHEEL_STEP),
+            MouseEventKind::ScrollDown => self.help_scroll(self.wheel_step),
+            MouseEventKind::ScrollUp => self.help_scroll(-self.wheel_step),
             // A left press on a section tab switches sections (AC-10). Hit-test against the tab rects
             // the Presenter fed back (`geom.help_tabs`), so the click maps to the tab actually drawn.
             MouseEventKind::Down(MouseButton::Left) => {

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -1067,7 +1067,10 @@ impl Controller {
     /// storing it as `isize` lets the wheel handlers negate it for wheel-up. Affects the content
     /// pane, the finder list, and the help overlay (not the tree, which is sign-only).
     pub fn apply_scroll_lines(&mut self, lines: u16) {
-        self.wheel_step = lines as isize;
+        // Defensive floor at the public boundary: the resolver already clamps to >= 1, but a `0`
+        // reaching here (a future caller, a direct test) would freeze wheel scrolling — guard it
+        // locally so the invariant holds regardless of how the value arrives.
+        self.wheel_step = lines.max(1) as isize;
     }
 
     /// Record the content viewport `(width, height)` the Presenter last drew into, so content

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -65,8 +65,6 @@ const SPLIT_MAX: u16 = 80;
 const SPLIT_STEP: u16 = 5;
 /// How many columns one horizontal-scroll keypress moves the content pane.
 const HSCROLL_STEP: u16 = 8;
-/// How many content lines one mouse-wheel notch scrolls (matches herdr's default).
-const WHEEL_STEP: isize = 3;
 /// Wall-clock bound for the synchronous What's New markdown render in `open_help`. The render runs
 /// on the input thread (the design settled on prerender-at-open), so it must be bounded well within
 /// the AC-22 responsiveness budget — far tighter than the shared 5s content `RENDER_TIMEOUT`, which
@@ -387,6 +385,13 @@ pub struct Controller {
     /// `content_scroll` so the user cannot scroll past the last screenful.
     content_width: u16,
     content_height: u16,
+    /// How many lines (or finder list items, or help-overlay lines) one mouse-wheel event advances
+    /// — the effective **scroll step** (config `scroll_lines`, else [`crate::config::DEFAULT_SCROLL_LINES`]).
+    /// Set once at startup via [`apply_scroll_lines`](Self::apply_scroll_lines). Held as `isize`
+    /// because the wheel handlers negate it for wheel-up. The directory tree ignores the magnitude
+    /// (it advances one row per event via the delta's sign), so this only affects the content pane,
+    /// the finder list, and the help overlay.
+    wheel_step: isize,
     /// The tree column's share of the width, as a percentage (the rest is the content pane).
     /// Adjustable from the keyboard since the viewer owns both columns (ADR-0002).
     split_pct: u16,
@@ -629,6 +634,7 @@ impl Controller {
             content_hscroll: 0,
             content_width: 0,
             content_height: 0,
+            wheel_step: crate::config::DEFAULT_SCROLL_LINES as isize,
             split_pct: SPLIT_DEFAULT,
             wrap_override: None,
             zoomed: false,
@@ -1053,6 +1059,15 @@ impl Controller {
         // selection — mirrors toggle_hidden's own post-filter re-render, and supersedes
         // `Controller::new`'s single unfiltered render dispatched just before this runs.
         self.dispatch_render();
+    }
+
+    /// Set the mouse-wheel **scroll step** from the effective config (`scroll_lines`). Called once
+    /// at startup, mirroring [`apply_hide_dotfiles`](Self::apply_hide_dotfiles). The resolver has
+    /// already clamped the value to ≥ 1, so a wheel event always advances at least one line/item;
+    /// storing it as `isize` lets the wheel handlers negate it for wheel-up. Affects the content
+    /// pane, the finder list, and the help overlay (not the tree, which is sign-only).
+    pub fn apply_scroll_lines(&mut self, lines: u16) {
+        self.wheel_step = lines as isize;
     }
 
     /// Record the content viewport `(width, height)` the Presenter last drew into, so content

--- a/src/controller/mouse.rs
+++ b/src/controller/mouse.rs
@@ -116,8 +116,8 @@ impl Controller {
         }
         let (col, row) = (ev.column, ev.row);
         match ev.kind {
-            MouseEventKind::ScrollDown => self.scroll_at(col, row, WHEEL_STEP),
-            MouseEventKind::ScrollUp => self.scroll_at(col, row, -WHEEL_STEP),
+            MouseEventKind::ScrollDown => self.scroll_at(col, row, self.wheel_step),
+            MouseEventKind::ScrollUp => self.scroll_at(col, row, -self.wheel_step),
             MouseEventKind::ScrollRight => self.hscroll_at(col, row, HSCROLL_STEP as i32),
             MouseEventKind::ScrollLeft => self.hscroll_at(col, row, -(HSCROLL_STEP as i32)),
             MouseEventKind::Down(MouseButton::Left) => {

--- a/src/help.rs
+++ b/src/help.rs
@@ -248,7 +248,8 @@ pub fn settings_text(
          open          = {open}\n\
          reveal        = {reveal}\n\
          hide_dotfiles = {hide_dotfiles}\n\
-         update_check  = {update_check}",
+         update_check  = {update_check}\n\
+         scroll_lines  = {scroll_lines}",
         editor = opt_os(&eff.editor),
         markdown = opt_argv(&eff.markdown),
         diff = opt_argv(&eff.diff),
@@ -257,6 +258,7 @@ pub fn settings_text(
         reveal = opt_argv(&eff.reveal),
         hide_dotfiles = eff.hide_dotfiles,
         update_check = if eff.update_check { "on" } else { "off" },
+        scroll_lines = eff.scroll_lines,
     )
 }
 
@@ -767,12 +769,19 @@ mod tests {
             "reveal",
             "hide_dotfiles",
             "update_check",
+            "scroll_lines",
         ] {
             assert!(
                 text.contains(key),
                 "settings_text must contain a row for '{key}':\n{text}"
             );
         }
+        // AC-9: the effective scroll step is shown as its own row with its value (7 in the fixture).
+        assert!(
+            text.lines()
+                .any(|l| l.trim_start().starts_with("scroll_lines") && l.contains('7')),
+            "settings_text must show the effective scroll_lines value (7):\n{text}"
+        );
         assert!(text.contains("nano"), "editor value must appear:\n{text}");
         assert!(
             text.contains("glow -w 80"),

--- a/src/help.rs
+++ b/src/help.rs
@@ -744,6 +744,7 @@ mod tests {
             reveal: None,
             hide_dotfiles: true,
             update_check: false,
+            scroll_lines: 7,
         }
     }
 

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -2288,6 +2288,83 @@ fn apply_scroll_lines_does_not_change_the_tree_wheel_step() {
 }
 
 #[test]
+fn config_scroll_lines_flows_through_resolve_to_the_content_wheel_step() {
+    // Integration: config text → parse → resolve → apply_scroll_lines is exactly the composition
+    // app::run performs at startup (config resolution reaching the controller). Exercise that whole
+    // chain end-to-end to a real wheel event, closing the gap between resolution and application
+    // (the literal one-line app::run call mirrors the pre-existing apply_hide_dotfiles seam and is
+    // additionally live-verified).
+    use herdr_file_viewer::config::{parse_config, resolve};
+    let (cfg, _outcome) = parse_config("scroll_lines = 2\n");
+    let eff = resolve(&cfg, |_| None);
+    assert_eq!(
+        eff.scroll_lines, 2,
+        "config value resolves to the effective step"
+    );
+
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.txt"), "x\n").unwrap();
+    let mut ctrl = controller_with_lines(dir.path(), 50);
+    await_marker(&mut ctrl, "L0");
+    ctrl.set_content_viewport(58, 10);
+    ctrl.set_pane_geometry(wide_geometry());
+    ctrl.apply_scroll_lines(eff.scroll_lines);
+
+    ctrl.handle_mouse(mouse(MouseEventKind::ScrollDown, 50, 5));
+    assert_eq!(
+        ctrl.content_scroll(),
+        2,
+        "the resolved config scroll_lines reaches the content wheel step"
+    );
+}
+
+#[test]
+fn apply_scroll_lines_zero_is_floored_to_one() {
+    // Defense-in-depth: a `0` at the public setter (a future caller / direct test) must not freeze
+    // scrolling — the step floors to 1 rather than 0.
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.txt"), "x\n").unwrap();
+    let mut ctrl = controller_with_lines(dir.path(), 50);
+    await_marker(&mut ctrl, "L0");
+    ctrl.set_content_viewport(58, 10);
+    ctrl.set_pane_geometry(wide_geometry());
+    ctrl.apply_scroll_lines(0);
+
+    ctrl.handle_mouse(mouse(MouseEventKind::ScrollDown, 50, 5));
+    assert_eq!(
+        ctrl.content_scroll(),
+        1,
+        "a 0 step is floored to 1 so the wheel never freezes"
+    );
+}
+
+#[test]
+fn apply_scroll_lines_is_symmetric_up_and_handles_large_values() {
+    // ScrollUp applies the same step (negated), and an extreme step (u16::MAX) clamps to the pane
+    // bounds without overflow or panic.
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.txt"), "x\n").unwrap();
+    let mut ctrl = controller_with_lines(dir.path(), 50);
+    await_marker(&mut ctrl, "L0");
+    ctrl.set_content_viewport(58, 10); // 50 lines, 10 visible → max scroll 40
+    ctrl.set_pane_geometry(wide_geometry());
+    ctrl.apply_scroll_lines(u16::MAX);
+
+    ctrl.handle_mouse(mouse(MouseEventKind::ScrollDown, 50, 5));
+    assert_eq!(
+        ctrl.content_scroll(),
+        40,
+        "a huge step clamps to the last screenful (no overflow)"
+    );
+    ctrl.handle_mouse(mouse(MouseEventKind::ScrollUp, 50, 5));
+    assert_eq!(
+        ctrl.content_scroll(),
+        0,
+        "wheel-up applies the step symmetrically, clamped at the top"
+    );
+}
+
+#[test]
 fn dragging_the_divider_resizes_the_split() {
     let dir = TempDir::new();
     let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -2167,7 +2167,7 @@ fn wheel_scrolls_the_pane_under_the_cursor() {
     ctrl.set_content_viewport(58, 10); // 50 lines, 10 visible → max scroll = 40
     ctrl.set_pane_geometry(wide_geometry());
 
-    // Over the content column → scrolls the content by WHEEL_STEP (3) per notch.
+    // Over the content column → scrolls the content by the default scroll step (3) per notch.
     assert_eq!(ctrl.content_scroll(), 0);
     ctrl.handle_mouse(mouse(MouseEventKind::ScrollDown, 50, 5));
     assert_eq!(
@@ -2202,6 +2202,89 @@ fn wheel_over_the_tree_moves_the_selection() {
     );
     ctrl.handle_mouse(mouse(MouseEventKind::ScrollUp, 5, 5));
     assert_eq!(ctrl.tree().cursor(), 0, "wheel-up moves it back up");
+}
+
+#[test]
+fn apply_scroll_lines_sets_the_content_wheel_step() {
+    // AC-5: the effective scroll step (config `scroll_lines`) is the number of lines a wheel event
+    // advances the content pane. apply_scroll_lines(1) → one notch scrolls exactly 1 line (the
+    // default step is 3, asserted by `wheel_scrolls_the_pane_under_the_cursor`).
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.txt"), "x\n").unwrap();
+    let mut ctrl = controller_with_lines(dir.path(), 50);
+    await_marker(&mut ctrl, "L0");
+    ctrl.set_content_viewport(58, 10);
+    ctrl.set_pane_geometry(wide_geometry());
+    ctrl.apply_scroll_lines(1);
+
+    ctrl.handle_mouse(mouse(MouseEventKind::ScrollDown, 50, 5));
+    assert_eq!(
+        ctrl.content_scroll(),
+        1,
+        "the content wheel step follows scroll_lines (1)"
+    );
+}
+
+#[test]
+fn apply_scroll_lines_sets_the_finder_wheel_step() {
+    // AC-6: the effective scroll step is the number of items a wheel event advances the finder
+    // selection. apply_scroll_lines(1) → one notch moves the selection by exactly 1 (default is 3).
+    let (_dir, mut ctrl) = finder_dir();
+    ctrl.handle_finder_key(key(KeyCode::Char('a'))); // ≥2 matches (alpha, beta, gamma)
+    let n = ctrl.finder_matches().len();
+    assert!(n >= 2, "need ≥2 matches for this test; got {n}");
+    ctrl.set_pane_geometry(finder_geometry_with_rows());
+    ctrl.apply_scroll_lines(1);
+
+    ctrl.handle_mouse(mouse(MouseEventKind::ScrollDown, 6, 3));
+    assert_eq!(
+        ctrl.finder_cursor(),
+        1,
+        "the finder wheel step follows scroll_lines (1)"
+    );
+}
+
+#[test]
+fn apply_scroll_lines_sets_the_help_wheel_step() {
+    // AC-7: the effective scroll step is the number of lines a wheel event advances the help
+    // overlay. apply_scroll_lines(2) → one notch scrolls the active section by exactly 2.
+    let mut ctrl = open_help_ctrl();
+    ctrl.apply_scroll_lines(2);
+    let raw_lines = ctrl.help_state().unwrap().active_body().lines.len() as u16;
+    let geom = PaneGeometry {
+        help_body_height: 5,
+        help_body_rows: raw_lines + 200, // plenty of room so the bottom clamp does not pin scroll
+        ..wide_geometry()
+    };
+    ctrl.set_pane_geometry(geom);
+
+    ctrl.handle_mouse(mouse(MouseEventKind::ScrollDown, 6, 3));
+    assert_eq!(
+        ctrl.help_state().unwrap().sections[0].scroll,
+        2,
+        "the help wheel step follows scroll_lines (2)"
+    );
+}
+
+#[test]
+fn apply_scroll_lines_does_not_change_the_tree_wheel_step() {
+    // AC-8: the tree advances by exactly one row per wheel event REGARDLESS of the effective scroll
+    // step — it uses the wheel delta's sign, not its magnitude.
+    let dir = TempDir::new();
+    for i in 0..20 {
+        std::fs::write(dir.path().join(format!("f{i:02}.txt")), "x").unwrap();
+    }
+    let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
+    ctrl.set_pane_geometry(wide_geometry());
+    ctrl.apply_scroll_lines(10);
+    assert_eq!(ctrl.tree().cursor(), 0);
+
+    ctrl.handle_mouse(mouse(MouseEventKind::ScrollDown, 5, 5));
+    assert_eq!(
+        ctrl.tree().cursor(),
+        1,
+        "the tree wheel is one row per event regardless of scroll_lines"
+    );
 }
 
 #[test]
@@ -4782,7 +4865,7 @@ fn mouse_is_inert_while_the_finder_is_open_outside_overlay() {
 
 #[test]
 fn finder_wheel_moves_selection() {
-    // ScrollDown/ScrollUp while the finder is open moves the finder selection by WHEEL_STEP (3),
+    // ScrollDown/ScrollUp while the finder is open moves the finder selection by the default scroll step (3),
     // clamped at both ends. Position-independent (the finder owns all wheel events while open).
     let (_dir, mut ctrl) = finder_dir();
     ctrl.handle_finder_key(key(KeyCode::Char('a'))); // produces ≥1 matches (alpha, beta, gamma)
@@ -4794,14 +4877,14 @@ fn finder_wheel_moves_selection() {
     // Starting cursor is 0.
     assert_eq!(ctrl.finder_cursor(), 0, "cursor starts at 0");
 
-    // ScrollDown → moves down by WHEEL_STEP (3) or to the last match if fewer.
+    // ScrollDown → moves down by the default scroll step (3) or to the last match if fewer.
     let fx = ctrl.handle_mouse(mouse(MouseEventKind::ScrollDown, 6, 3)); // position: tree area (irrelevant)
     assert!(fx.redraw, "ScrollDown redraws");
     let expected_after_down = 3_usize.min(n - 1);
     assert_eq!(
         ctrl.finder_cursor(),
         expected_after_down,
-        "ScrollDown moves the finder selection down by WHEEL_STEP"
+        "ScrollDown moves the finder selection down by the default scroll step"
     );
 
     // ScrollUp → moves back up.

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -9131,6 +9131,7 @@ fn open_help_appends_settings_section_when_display_is_set() {
         reveal: None,
         hide_dotfiles: false,
         update_check: true,
+        scroll_lines: 3,
     };
     ctrl.set_settings_display(
         &eff,

--- a/tests/docs_consistency.rs
+++ b/tests/docs_consistency.rs
@@ -39,6 +39,7 @@ fn config_example_documents_every_config_key() {
         "reveal",
         "hide_dotfiles",
         "update_check",
+        "scroll_lines",
     ] {
         assert!(
             has_commented_assignment(CONFIG_EXAMPLE, key),
@@ -71,6 +72,20 @@ fn config_example_documents_every_config_key() {
             n + 1
         );
     }
+}
+
+#[test]
+fn readme_and_example_document_scroll_lines() {
+    // AC-10: the mouse-wheel scroll-speed key must be documented in BOTH the README and the bundled
+    // config.example.toml, so the feature ships with a discoverable, copy-pasteable setting.
+    assert!(
+        README.contains("scroll_lines"),
+        "README.md must document the `scroll_lines` config key"
+    );
+    assert!(
+        CONFIG_EXAMPLE.contains("scroll_lines"),
+        "config.example.toml must document the `scroll_lines` config key"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## What

Adds a read-only `scroll_lines` config key that sets how many lines the mouse wheel advances per event. It resolves the long-standing "wheel scrolls too far" papercut for reading large files and browsing the file-search list.

Closes #93.

## Why

The wheel step was a single hard-coded constant (`WHEEL_STEP = 3`). Because many terminals emit several `ScrollDown` events per physical notch, the effective jump felt like ~10 lines/notch, which overshoots when reading precisely, and the file-search list skipped ~10 results per notch. There was no per-user way to slow it down.

## How

- New `scroll_lines` key in the existing `config.toml` (same loader/precedence as the settings-config feature). One knob covers the three sites that share the constant today: the **content pane**, the **file-search (finder) list**, and the **help overlay**.
- Precedence is `config > default`, no environment variable. Default stays **3** (no behaviour change without a config file). The value is clamped to a floor of **1** (a `0` would freeze scrolling), and a non-representable value degrades the whole config to defaults via the existing defensive path.
- The single `WHEEL_STEP` const becomes a per-run `wheel_step` field on the controller, set once at startup via an `apply_scroll_lines` setter (mirrors `apply_hide_dotfiles`). The effective value is shown read-only in the `?` overlay's Settings section.
- The **directory tree** is intentionally unchanged: it already advances exactly one row per wheel event (it uses the wheel delta's sign, not its magnitude).

Zero new dependencies; read-only (no file/git writes, config is input only).

## Honest limitation

The terminal, not the viewer, decides how many wheel events a physical notch emits. `scroll_lines` sets the per-event step, so the lowest setting *reduces* but cannot guarantee exactly one line per notch on every terminal.

## Testing

- Unit + integration tests for all ten acceptance criteria: resolver precedence/clamp/degrade (AC-1..4); content/finder/help wheel step following `scroll_lines` and the tree staying one-row-per-event (AC-5..8); the Settings overlay row (AC-9); and a docs-drift guard for the README + `config.example.toml` (AC-10).
- Full suite green: `cargo build --release` · `cargo test` (941 passed, 0 failed) · `cargo clippy --all-targets -- -D warnings` · `cargo fmt --check`.
- Live-verified in the real release binary: with `scroll_lines = 1` set, the `?` overlay's Settings tab shows `scroll_lines  = 1`, confirming the config → resolver → applier → display chain end to end.

## Docs

`CHANGELOG.md` (Unreleased), README config block + precedence list, `config.example.toml`, and the `CONTEXT.md` glossary are all updated in this PR.
