### PR TITLE
feat: configurable tree/content layout (tree_width, tree_position, tree_max_cols)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ All notable changes to this project are documented here. The format is based on
 ## [Unreleased]
 
 ### Added
+- **Configurable tree/content layout via `tree_width`, `tree_position`, and `tree_max_cols` keys in
+  `config.toml`.** `tree_width` sets the directory tree column's share of the viewer pane (a percent
+  from `20` to `80`; the content pane takes the rest), `tree_position` puts the tree on the `"left"`
+  (default) or `"right"` of the content pane, and `tree_max_cols` caps the tree at a maximum number
+  of **columns** so it does not balloon on a very wide pane — the tree is drawn at
+  `min(tree_width% of the pane, tree_max_cols)`. These seed the **startup** split inside the viewer's
+  own pane (not the size of the herdr pane, which the host decides); you can still resize the split
+  live with the grow/shrink keys or by dragging the divider, and "grow" always widens the tree
+  whichever side it is on. `config > default`, no environment variable; an out-of-range width clamps
+  into `20..=80`, an unrecognized position falls back to `"left"`, and the column cap clamps into
+  `10..=1000` (set it high to disable). All three effective values are shown in the `?` overlay's
+  Settings section.
 - **Configurable mouse-wheel scroll speed via a `scroll_lines` key in `config.toml`.** Sets how many
   lines each wheel event advances the content pane (and how many items it moves in the file-search
   list, and lines in the `?` help overlay); the directory tree still moves one row per event.
@@ -46,6 +58,15 @@ All notable changes to this project are documented here. The format is based on
   Read-only: the pane zoom is a host layout op, never a file or git change, and it degrades to the
   in-pane zoom when the host isn't herdr. Lowercase `z` still toggles the in-pane zoom only; on a
   directory, `Z` just expands/collapses like `Enter`.
+
+### Changed
+- **The default tree/content split is now 30% tree (was 40%),** giving the content pane a little more
+  room out of the box. Set `tree_width` in `config.toml` to pick your own, or resize it live as
+  before.
+- **The tree is now capped at 30 columns by default** (`tree_max_cols`), so on a full-terminal tab or
+  a wide window it stays compact instead of growing into a mostly-blank column. Panes under ~100
+  columns are unaffected (the percentage governs), and dragging the divider or the grow/shrink keys
+  lifts the cap; raise `tree_max_cols` to disable it.
 
 ### Fixed
 - **Wide tables in the rendered-markdown view no longer shatter.** A table is now laid out to fit

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -98,6 +98,20 @@ Canonical vocabulary for this repo. Glossary only: no implementation detail, no 
   lines) the mouse wheel advances per wheel event. Set by the `scroll_lines` **config file**
   key (config > default; default 3, clamped to the range 1 to 10). The directory tree is
   unaffected: it always advances one row per wheel event.
+- **tree width**: the directory tree column's share of the viewer pane, as a percent (the
+  content pane takes the rest). Set by the `tree_width` **config file** key (config > default;
+  default 30, clamped to the range 20 to 80). Seeds the startup split; the live grow/shrink keys
+  and the divider drag still adjust it within a session. This is the split INSIDE the viewer's
+  pane, distinct from the size of the herdr **pane** itself (the host decides that).
+- **tree position**: which side of the content pane the directory tree is drawn on — `left`
+  (default, today's layout) or `right`. Set by the `tree_position` **config file** key
+  (config > default). An unrecognized value falls back to `left`.
+- **tree column cap**: the maximum tree width in character columns (not a percent). The tree is
+  drawn at `min(`**tree width**`% of the pane, tree_max_cols)`, so a wide pane (a full tab, a big
+  monitor) keeps the tree compact instead of over-allocating blank space. Set by the `tree_max_cols`
+  **config file** key (config > default; default 30, clamped to the range 10 to 1000; a large value
+  effectively disables the cap). A default ceiling only: a hand resize (divider drag or the
+  grow/shrink keys) lifts it for the session.
 - **keybinding registry**: the single data-driven table binding each global viewer action
   to its default key(s) and a human description; the source of truth the input dispatcher
   decodes from and the help overlay and README both derive from.

--- a/README.md
+++ b/README.md
@@ -328,8 +328,8 @@ normal case — every key falls back to its default.
 fallback tier below the config key and above the built-in default — `editor` (`$EDITOR`) and
 `update_check` (`$HERDR_FILE_VIEWER_NO_UPDATE_CHECK`) — giving those two a `config > env >
 default` chain. Every other key (`markdown`, `diff`, `syntax`, `open`, `reveal`,
-`hide_dotfiles`, `scroll_lines`) has no applicable environment variable; for those it's
-`config > default` only.
+`hide_dotfiles`, `scroll_lines`, `tree_width`, `tree_position`, `tree_max_cols`) has no applicable
+environment variable; for those it's `config > default` only.
 
 ```toml
 # ~/.config/herdr-file-viewer/config.toml (or the herdr-provided path above)
@@ -346,7 +346,18 @@ reveal = "nautilus"
 hide_dotfiles = false       # true to hide dotfiles at startup (the `.` key still toggles)
 update_check = true         # false to disable the once-a-day update check
 scroll_lines = 3            # mouse-wheel step (content/search/help), a 1 to 10 scale: 1 slow · 3 medium · 6 fast · 10 max
+tree_width = 30             # tree column's share of the viewer pane, percent 20-80 (content takes the rest)
+tree_position = "left"      # which side the directory tree sits on: "left" (default) or "right"
+tree_max_cols = 30          # cap the tree at this many columns so it stays compact on a wide pane
 ```
+
+`tree_width` / `tree_position` set the **startup** tree/content split inside the viewer's own pane
+(not the size of the herdr pane, which the host decides). You can still resize the split live with
+the grow/shrink keys or by dragging the divider; the config just seeds the initial value.
+`tree_max_cols` is a **column** ceiling (not a percent): the tree is drawn at
+`min(tree_width% of the pane, tree_max_cols)`, so a full-terminal tab gives the extra width to the
+content pane instead of a mostly-blank tree. It only bites past ~100 columns, and dragging the
+divider or the grow/shrink keys lifts it (an explicit resize wins); set it high to disable.
 
 Command values (`editor`, `markdown`, `diff`, `syntax`, `open`, `reveal`) are **split into
 arguments** the way a shell would for simple cases — whitespace splits, double-quotes group a
@@ -410,7 +421,7 @@ to remap it), its effective key(s), and its description, marking the ones you ha
 
 A few things on the way:
 
-- **Themes and layout**: the [config file](#configuration) already covers the editor, renderer, and opener commands, a couple of startup toggles, and now [customizable keybindings](#keybindings); a theme and the default split/layout are still on the way.
+- **Themes and layout**: the [config file](#configuration) already covers the editor, renderer, and opener commands, a couple of startup toggles, the default tree/content split and side (`tree_width` / `tree_position`), and [customizable keybindings](#keybindings); a theme is still on the way.
 
 **Hit a bug, or want a feature?** Please [open an issue](https://github.com/smarzban/herdr-file-viewer/issues). Bug reports and feature requests are very welcome.
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -76,6 +76,27 @@
 # effective speed is this times that. Default:
 #scroll_lines = 3
 
+# --- Layout ------------------------------------------------------------------
+
+# The tree/content split INSIDE the viewer's pane (not the size of the herdr
+# pane itself, which the host decides). `tree_width` is the directory tree
+# column's share of the pane, as a percent from 20 to 80; the content pane takes
+# the rest. You can still resize the split live with the grow/shrink keys or by
+# dragging the divider — this only sets the startup value. Default:
+#tree_width = 30
+
+# Which side of the content pane the tree is drawn on: "left" (default) or
+# "right". An unrecognized value falls back to "left". Default:
+#tree_position = "left"
+
+# Maximum tree width in CHARACTER COLUMNS (not a percent). The tree is drawn at
+# min(tree_width% of the pane, tree_max_cols), so on a wide pane (a full tab, a
+# big monitor) it stays compact instead of ballooning into a mostly-blank
+# column. Bites once the pane is wider than ~100 columns; below that the
+# percentage governs. Dragging the divider or the grow/shrink keys lifts the cap
+# (an explicit resize wins). Set it high (up to 1000) to disable. Default:
+#tree_max_cols = 30
+
 # --- Keybindings -------------------------------------------------------------
 #
 # Remap any global key. Key each entry by its INTENT NAME: the stable snake_case

--- a/src/app.rs
+++ b/src/app.rs
@@ -106,6 +106,12 @@ pub fn run() -> io::Result<()> {
     // Apply the config-driven mouse-wheel scroll step (`scroll_lines`); already clamped to >= 1 by
     // the resolver, so the wheel always advances at least one line/item.
     controller.apply_scroll_lines(eff.scroll_lines);
+    // Apply the config-driven startup layout: the tree/content split ratio (`tree_width`, already
+    // clamped to the split range) and the tree side (`tree_position`). The live grow/shrink keys and
+    // divider drag still adjust the split within the session.
+    controller.apply_tree_width(eff.tree_width);
+    controller.apply_tree_position(eff.tree_position);
+    controller.apply_tree_max_cols(eff.tree_max_cols);
     // Format the Settings section body for the `?` overlay (AC-15, AC-18): reflects the load
     // outcome plus every effective setting, so a user can see what's actually in effect, and the
     // resolved config-file location so they know what to fix or create.

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,6 +18,57 @@ pub const DEFAULT_SCROLL_LINES: u16 = 3;
 /// instead of page-jumping. The effective range is therefore `1..=MAX_SCROLL_LINES`.
 pub const MAX_SCROLL_LINES: u16 = 10;
 
+/// The built-in **tree width**: the directory tree column's share of the viewer pane (percent) at
+/// startup, when the config supplies no valid `tree_width`. Also the controller's initial
+/// `split_pct`. Owner-set to 30 (was 40) so the content pane gets more room out of the box.
+pub const DEFAULT_TREE_WIDTH: u16 = 30;
+/// The narrowest accepted **tree width**, in percent — the same floor the live keyboard/drag resize
+/// enforces, so the tree column can never collapse. A configured value below this clamps up to it.
+pub const MIN_TREE_WIDTH: u16 = 20;
+/// The widest accepted **tree width**, in percent — the same ceiling the live resize enforces, so
+/// the content column can never collapse. A configured value above this clamps down to it. The
+/// effective range is therefore `MIN_TREE_WIDTH..=MAX_TREE_WIDTH`.
+pub const MAX_TREE_WIDTH: u16 = 80;
+
+/// The built-in **tree column cap**: the maximum width, in character columns, the directory tree may
+/// occupy regardless of [`DEFAULT_TREE_WIDTH`]. On a wide pane (a full tab, a big monitor)
+/// `tree_width` percent would over-allocate — a 50+-column tree that is mostly blank space after the
+/// filenames — so the tree is `min(tree_width% of the pane, tree_max_cols)`. Owner-set to 30: a
+/// compact tree that fits typical filenames, so the extra width of a wide pane goes to the content
+/// pane. Bites once the pane is wider than ~`tree_max_cols * 100 / tree_width%` columns (~100 at the
+/// defaults); below that the percentage governs. A hand resize (drag / grow key) lifts the cap.
+pub const DEFAULT_TREE_MAX_COLS: u16 = 30;
+/// The narrowest accepted **tree column cap**: a configured value below this clamps up to it, so the
+/// tree can never be capped to an unreadable sliver.
+pub const MIN_TREE_MAX_COLS: u16 = 10;
+/// The widest accepted **tree column cap**. A value this large never bites on any real terminal, so
+/// it is the escape hatch for "no cap"; larger values clamp down to it. The effective range is
+/// `MIN_TREE_MAX_COLS..=MAX_TREE_MAX_COLS`.
+pub const MAX_TREE_MAX_COLS: u16 = 1000;
+
+/// Which side of the content pane the directory tree is drawn on (`tree_position` config key). A
+/// pure display preference; the config value is a lenient `Option<String>` resolved into this by
+/// [`resolve`] (case-insensitive, trimmed), so this enum is never deserialized directly. `Left` is
+/// the default (today's layout).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum TreePosition {
+    /// Tree on the left of the content pane (the default, today's layout).
+    #[default]
+    Left,
+    /// Tree on the right of the content pane.
+    Right,
+}
+
+impl TreePosition {
+    /// The lowercase label shown in the read-only Settings overlay (`left` / `right`).
+    pub fn label(self) -> &'static str {
+        match self {
+            TreePosition::Left => "left",
+            TreePosition::Right => "right",
+        }
+    }
+}
+
 /// A `[keys]` entry's value: the key(s) an intent binds to, written **either** as a single string
 /// (`refresh = "g"`) **or** as a TOML array of strings (`nav_up = ["w", "Up"]`). `#[serde(untagged)]`
 /// tries the variants in order, so `One(String)` must come first: a bare string deserializes to
@@ -52,6 +103,22 @@ pub struct Config {
     /// number still clamps into range instead of tripping the parse; only a negative / non-integer /
     /// astronomically large value fails to parse and degrades the whole config to defaults.
     pub scroll_lines: Option<u32>,
+    /// The **tree width**: the directory tree column's share of the viewer pane, in percent, at
+    /// startup. `None` falls back to [`DEFAULT_TREE_WIDTH`]; the resolver clamps any present value
+    /// into `MIN_TREE_WIDTH..=MAX_TREE_WIDTH`. Held as `u32` (like `scroll_lines`) so an
+    /// out-of-`u16` number still clamps into range instead of tripping the parse; only a negative /
+    /// non-integer value fails to parse and degrades the whole config to defaults.
+    pub tree_width: Option<u32>,
+    /// The **tree position**: which side the directory tree is drawn on. A lenient string
+    /// (`"left"` / `"right"`, case-insensitive, trimmed) resolved into a [`TreePosition`] by
+    /// [`resolve`]; `None` or an unrecognized value falls back to [`TreePosition::Left`].
+    pub tree_position: Option<String>,
+    /// The **tree column cap**: the maximum tree width in character columns (see
+    /// [`DEFAULT_TREE_MAX_COLS`]). `None` falls back to that default; the resolver clamps any present
+    /// value into `MIN_TREE_MAX_COLS..=MAX_TREE_MAX_COLS`. Held as `u32` (like `tree_width`) so an
+    /// out-of-`u16` number clamps into range instead of tripping the parse; only a negative /
+    /// non-integer value fails to parse and degrades the whole config to defaults.
+    pub tree_max_cols: Option<u32>,
     /// The `[keys]` remapping table: **intent name -> key spec** (T-4, Slice B). `None` when the
     /// config omits `[keys]`. A `BTreeMap` keeps the entries in deterministic order. Rides the
     /// existing defensive `load_config` / `parse_config` with no wiring change: a malformed `[keys]`
@@ -167,6 +234,17 @@ pub struct EffectiveSettings {
     /// `1..=`[`MAX_SCROLL_LINES`] when present, else [`DEFAULT_SCROLL_LINES`]. No environment
     /// variable participates — this is a config-or-default UI preference.
     pub scroll_lines: u16,
+    /// The effective **tree width**: the config `tree_width` clamped to
+    /// `MIN_TREE_WIDTH..=MAX_TREE_WIDTH` when present, else [`DEFAULT_TREE_WIDTH`]. Seeds the
+    /// controller's startup split percent. Config-or-default (no env var).
+    pub tree_width: u16,
+    /// The effective **tree position**: the config `tree_position` mapped to `Left`/`Right`, else
+    /// [`TreePosition::Left`]. Config-or-default (no env var).
+    pub tree_position: TreePosition,
+    /// The effective **tree column cap**: the config `tree_max_cols` clamped to
+    /// `MIN_TREE_MAX_COLS..=MAX_TREE_MAX_COLS` when present, else [`DEFAULT_TREE_MAX_COLS`]. The tree
+    /// is drawn at `min(tree_width% of the pane, tree_max_cols)`. Config-or-default (no env var).
+    pub tree_max_cols: u16,
 }
 
 /// Pure resolver: `Config` + injected env getter -> `EffectiveSettings` (AC-3, AC-4, AC-5,
@@ -215,6 +293,37 @@ pub fn resolve(config: &Config, get_env: impl Fn(&str) -> Option<String>) -> Eff
         .map(|n| n.clamp(1, MAX_SCROLL_LINES as u32) as u16)
         .unwrap_or(DEFAULT_SCROLL_LINES);
 
+    // Config > default; no env var. Clamp to `MIN_TREE_WIDTH..=MAX_TREE_WIDTH` — the same range the
+    // live keyboard/drag resize enforces — so neither column can collapse (AC-3). A value that isn't
+    // a representable non-negative integer never reaches here: it failed the parse and arrived as
+    // `None` on a defaulted `Config` (AC-4).
+    let tree_width = config
+        .tree_width
+        .map(|n| n.clamp(MIN_TREE_WIDTH as u32, MAX_TREE_WIDTH as u32) as u16)
+        .unwrap_or(DEFAULT_TREE_WIDTH);
+
+    // Config > default; no env var. Lenient string match (trimmed, case-insensitive): only `right`
+    // selects the non-default side; anything else — absent, unrecognized, differently-typed — keeps
+    // the default `Left` so a fat-fingered value loses the customization without crashing (AC-5..7).
+    let tree_position = match config
+        .tree_position
+        .as_deref()
+        .map(|s| s.trim().to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("right") => TreePosition::Right,
+        _ => TreePosition::Left,
+    };
+
+    // Config > default; no env var. Clamp to `MIN_TREE_MAX_COLS..=MAX_TREE_MAX_COLS` so the cap can
+    // never shrink the tree to an unreadable sliver, and a huge value just becomes the effective
+    // "no cap" (it never bites on a real terminal). A non-representable value degraded the whole
+    // config to defaults and arrived as `None`.
+    let tree_max_cols = config
+        .tree_max_cols
+        .map(|n| n.clamp(MIN_TREE_MAX_COLS as u32, MAX_TREE_MAX_COLS as u32) as u16)
+        .unwrap_or(DEFAULT_TREE_MAX_COLS);
+
     EffectiveSettings {
         editor,
         markdown,
@@ -225,6 +334,9 @@ pub fn resolve(config: &Config, get_env: impl Fn(&str) -> Option<String>) -> Eff
         hide_dotfiles,
         update_check,
         scroll_lines,
+        tree_width,
+        tree_position,
+        tree_max_cols,
     }
 }
 
@@ -774,6 +886,202 @@ mod tests {
         }
         let effective = resolve(&config, |_| None);
         assert_eq!(effective.scroll_lines, 3);
+    }
+
+    #[test]
+    fn resolve_tree_width_config_value_wins() {
+        // AC-1: a valid config value (in range) is the effective tree width (config > default).
+        let config = Config {
+            tree_width: Some(25),
+            ..Default::default()
+        };
+        assert_eq!(resolve(&config, |_| None).tree_width, 25);
+    }
+
+    #[test]
+    fn resolve_tree_width_defaults_when_absent() {
+        // AC-2: omitted -> the built-in default (DEFAULT_TREE_WIDTH = 30).
+        let effective = resolve(&Config::default(), |_| None);
+        assert_eq!(effective.tree_width, DEFAULT_TREE_WIDTH);
+        assert_eq!(effective.tree_width, 30);
+    }
+
+    #[test]
+    fn resolve_tree_width_clamps_to_range() {
+        // AC-3: a value below the floor clamps up to MIN_TREE_WIDTH, above the ceiling clamps down to
+        // MAX_TREE_WIDTH — the same range the live resize enforces, so neither column can collapse.
+        // Values beyond u16 are accepted (the field is u32) and clamped, not degraded.
+        assert_eq!((MIN_TREE_WIDTH, MAX_TREE_WIDTH), (20, 80));
+        for (input, want) in [
+            (0u32, 20u16),
+            (5, 20),
+            (19, 20),
+            (81, 80),
+            (95, 80),
+            (u32::MAX, 80),
+        ] {
+            let cfg = Config {
+                tree_width: Some(input),
+                ..Default::default()
+            };
+            assert_eq!(
+                resolve(&cfg, |_| None).tree_width,
+                want,
+                "value {input} must clamp to {want}"
+            );
+        }
+        // The boundary values pass through unchanged.
+        for edge in [MIN_TREE_WIDTH, MAX_TREE_WIDTH] {
+            let cfg = Config {
+                tree_width: Some(edge as u32),
+                ..Default::default()
+            };
+            assert_eq!(resolve(&cfg, |_| None).tree_width, edge);
+        }
+    }
+
+    #[test]
+    fn tree_width_non_representable_degrades_to_default() {
+        // AC-4: a non-representable value fails the parse, so the whole config degrades to defaults
+        // (Malformed); the resolver then yields the default width (30). AC-4 names both a negative
+        // and a string, so cover both — a `u32` field rejects each (an over-large-but-representable
+        // value clamps instead — see resolve_tree_width_clamps_to_range).
+        // Each fixture also carries a VALID key (`hide_dotfiles = true`) to prove the malformed value
+        // defaults the WHOLE config, not just its own field (the valid key is dropped too).
+        for src in [
+            "tree_width = -1\nhide_dotfiles = true\n",
+            "tree_width = \"wide\"\nhide_dotfiles = true\n",
+        ] {
+            let (config, outcome) = parse_config(src);
+            assert_eq!(
+                config.tree_width, None,
+                "{src:?} must not populate tree_width"
+            );
+            assert_eq!(
+                config.hide_dotfiles, None,
+                "{src:?} must default the WHOLE config (the valid hide_dotfiles is dropped too)"
+            );
+            match outcome {
+                LoadOutcome::Malformed(_) => {}
+                other => panic!("expected Malformed for {src:?}, got {other:?}"),
+            }
+            assert_eq!(
+                resolve(&config, |_| None).tree_width,
+                30,
+                "{src:?} → default 30"
+            );
+        }
+    }
+
+    #[test]
+    fn resolve_tree_position_config_value_wins() {
+        // AC-5: "right" -> Right, "left" -> Left (config > default).
+        for (value, want) in [("right", TreePosition::Right), ("left", TreePosition::Left)] {
+            let cfg = Config {
+                tree_position: Some(value.to_string()),
+                ..Default::default()
+            };
+            assert_eq!(resolve(&cfg, |_| None).tree_position, want);
+        }
+    }
+
+    #[test]
+    fn resolve_tree_position_defaults_when_absent() {
+        // AC-6: omitted -> the default side (Left, today's layout).
+        assert_eq!(
+            resolve(&Config::default(), |_| None).tree_position,
+            TreePosition::Left
+        );
+    }
+
+    #[test]
+    fn resolve_tree_position_lenient_and_case_insensitive() {
+        // AC-7: an unrecognized value degrades to the default Left without panicking, and a valid
+        // value is matched case-insensitively after trimming.
+        for (value, want) in [
+            ("sideways", TreePosition::Left),
+            ("", TreePosition::Left),
+            (" RIGHT ", TreePosition::Right),
+            ("Left", TreePosition::Left),
+            ("RiGhT", TreePosition::Right),
+        ] {
+            let cfg = Config {
+                tree_position: Some(value.to_string()),
+                ..Default::default()
+            };
+            assert_eq!(
+                resolve(&cfg, |_| None).tree_position,
+                want,
+                "{value:?} must resolve to {want:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn resolve_tree_max_cols_config_value_wins() {
+        // A valid config value (in range) is the effective tree column cap (config > default).
+        let cfg = Config {
+            tree_max_cols: Some(60),
+            ..Default::default()
+        };
+        assert_eq!(resolve(&cfg, |_| None).tree_max_cols, 60);
+    }
+
+    #[test]
+    fn resolve_tree_max_cols_defaults_when_absent() {
+        // Omitted -> the built-in default (DEFAULT_TREE_MAX_COLS = 30).
+        let effective = resolve(&Config::default(), |_| None);
+        assert_eq!(effective.tree_max_cols, DEFAULT_TREE_MAX_COLS);
+        assert_eq!(effective.tree_max_cols, 30);
+    }
+
+    #[test]
+    fn resolve_tree_max_cols_clamps_to_range() {
+        // Below the floor clamps up (never an unreadable sliver); above the ceiling clamps down (a
+        // huge value is the "no cap" escape hatch). Values beyond u16 are accepted (u32 field) and
+        // clamped, not degraded.
+        assert_eq!((MIN_TREE_MAX_COLS, MAX_TREE_MAX_COLS), (10, 1000));
+        for (input, want) in [(0u32, 10u16), (5, 10), (1001, 1000), (u32::MAX, 1000)] {
+            let cfg = Config {
+                tree_max_cols: Some(input),
+                ..Default::default()
+            };
+            assert_eq!(
+                resolve(&cfg, |_| None).tree_max_cols,
+                want,
+                "value {input} must clamp to {want}"
+            );
+        }
+    }
+
+    #[test]
+    fn tree_max_cols_non_representable_degrades_to_default() {
+        // A non-representable value fails the parse, degrading the whole config to defaults; the
+        // resolver then yields the default cap (30).
+        // A valid key rides alongside to prove the whole config defaults, not just this field.
+        for src in [
+            "tree_max_cols = -1\nhide_dotfiles = true\n",
+            "tree_max_cols = \"wide\"\nhide_dotfiles = true\n",
+        ] {
+            let (config, outcome) = parse_config(src);
+            assert_eq!(
+                config.tree_max_cols, None,
+                "{src:?} must not populate the field"
+            );
+            assert_eq!(
+                config.hide_dotfiles, None,
+                "{src:?} must default the WHOLE config (valid hide_dotfiles dropped too)"
+            );
+            match outcome {
+                LoadOutcome::Malformed(_) => {}
+                other => panic!("expected Malformed for {src:?}, got {other:?}"),
+            }
+            assert_eq!(
+                resolve(&config, |_| None).tree_max_cols,
+                30,
+                "{src:?} → default 30"
+            );
+        }
     }
 
     // --- Settings Applier: effective_editor / effective_renderers / should_start_update_check

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -58,11 +58,21 @@ use std::time::{Duration, Instant};
 
 /// Tree-column width as a percentage of the pane: its default and the bounds the resize keys
 /// clamp to, so neither column can be squeezed to nothing.
-const SPLIT_DEFAULT: u16 = 40;
-const SPLIT_MIN: u16 = 20;
-const SPLIT_MAX: u16 = 80;
+// The split range is owned by `crate::config` (the single source of truth), so the config-value
+// clamp (`resolve`) and this live keyboard/drag-resize clamp can never drift. `SPLIT_DEFAULT` seeds
+// the initial `split_pct` before any `apply_tree_width` from the effective config.
+const SPLIT_DEFAULT: u16 = crate::config::DEFAULT_TREE_WIDTH;
+const SPLIT_MIN: u16 = crate::config::MIN_TREE_WIDTH;
+const SPLIT_MAX: u16 = crate::config::MAX_TREE_WIDTH;
 /// How many percentage points one resize keypress moves the divider.
 const SPLIT_STEP: u16 = 5;
+// The floor for an INTERACTIVE resize (grow/shrink keys, divider drag), below the config/startup
+// floor `SPLIT_MIN`. A hand resize may pull the tree narrower than the startup minimum — down to the
+// same 10% the Presenter's `columns()` renders at — so on a wide pane the tree can be shrunk below a
+// `tree_max_cols`-capped default (which can sit below `SPLIT_MIN`, leaving "shrink" nowhere to go
+// otherwise). `SPLIT_MIN` still bounds the config-seeded startup value; this only widens the
+// interactive range.
+const SPLIT_DRAG_MIN: u16 = 10;
 /// How many columns one horizontal-scroll keypress moves the content pane.
 const HSCROLL_STEP: u16 = 8;
 /// Wall-clock bound for the synchronous What's New markdown render in `open_help`. The render runs
@@ -393,8 +403,24 @@ pub struct Controller {
     /// the finder list, and the help overlay.
     wheel_step: isize,
     /// The tree column's share of the width, as a percentage (the rest is the content pane).
-    /// Adjustable from the keyboard since the viewer owns both columns (ADR-0002).
+    /// Adjustable from the keyboard since the viewer owns both columns (ADR-0002). Seeded at
+    /// startup from the effective config via [`apply_tree_width`](Self::apply_tree_width).
     split_pct: u16,
+    /// Which side of the content pane the tree is drawn on. Seeded at startup from the effective
+    /// config via [`apply_tree_position`](Self::apply_tree_position); a session preference carried
+    /// across a re-root (like `split_pct`). The Presenter reads it through the view state.
+    tree_position: crate::config::TreePosition,
+    /// The maximum tree width in character columns (`tree_max_cols`): the tree is drawn at
+    /// `min(split_pct% of the pane, tree_max_cols)` so it never over-allocates on a very wide pane.
+    /// Seeded at startup via [`apply_tree_max_cols`](Self::apply_tree_max_cols); read by the
+    /// Presenter through the view state. Carried across a re-root (like `split_pct`).
+    tree_max_cols: u16,
+    /// Whether the user has resized the split by hand this session (grow/shrink keys or a divider
+    /// drag). `tree_max_cols` caps the tree only while this is `false`; the first manual resize seeds
+    /// `split_pct` from the currently-displayed width and lifts the cap, so the resize is honoured
+    /// exactly instead of looking frozen on a wide, capped pane. Carried across a re-root (like
+    /// `split_pct`).
+    split_manual: bool,
     /// User override of the per-mode wrap default (the `w` toggle). `None` ⇒ the per-mode default
     /// applies (prose wraps, code/diffs don't); `Some(true)` ⇒ force wrap on everywhere (read long
     /// code/diff lines); `Some(false)` ⇒ force wrap off everywhere — which, for rendered markdown,
@@ -636,6 +662,9 @@ impl Controller {
             content_height: 0,
             wheel_step: crate::config::DEFAULT_SCROLL_LINES as isize,
             split_pct: SPLIT_DEFAULT,
+            tree_position: crate::config::TreePosition::Left,
+            tree_max_cols: crate::config::DEFAULT_TREE_MAX_COLS,
+            split_manual: false,
             wrap_override: None,
             zoomed: false,
             host_zoomed: false,
@@ -836,7 +865,7 @@ impl Controller {
         self.last_click = None;
 
         // PREFERENCES ARE CARRIED (AC-12) — deliberately NOT reset: show_ignored, hide_hidden,
-        // changed_only, split_pct, wrap_override, baseline keep their current values. The fresh
+        // changed_only, split_pct, tree_position, tree_max_cols, split_manual, wrap_override, baseline keep their current values. The fresh
         // TreeModel starts with default filter flags. `show_ignored` and `hide_hidden` are
         // git-independent, so apply them now. The changed-only *filter* is NOT applied here: it
         // must be applied against the REAL changed-set, which `dispatch_status_refresh` computes
@@ -1073,6 +1102,32 @@ impl Controller {
         self.wheel_step = lines.max(1) as isize;
     }
 
+    /// Seed the startup split ratio from the effective config (`tree_width`). Called once at
+    /// startup, mirroring [`apply_hide_dotfiles`](Self::apply_hide_dotfiles). The live keyboard/drag
+    /// resize adjusts `split_pct` afterward within the session; this only sets its initial value.
+    pub fn apply_tree_width(&mut self, pct: u16) {
+        // Defensive clamp at the public boundary: the resolver already clamps to
+        // `SPLIT_MIN..=SPLIT_MAX`, but guard locally so a direct/out-of-range caller can never
+        // collapse a column (matches the live-resize clamp).
+        self.split_pct = pct.clamp(SPLIT_MIN, SPLIT_MAX);
+    }
+
+    /// Seed the startup tree side from the effective config (`tree_position`). Called once at
+    /// startup, mirroring [`apply_hide_dotfiles`](Self::apply_hide_dotfiles). Pure layout state read
+    /// by the Presenter through the view state — no re-render needed (the content is unchanged).
+    pub fn apply_tree_position(&mut self, position: crate::config::TreePosition) {
+        self.tree_position = position;
+    }
+
+    /// Seed the startup tree column cap from the effective config (`tree_max_cols`). Called once at
+    /// startup, mirroring [`apply_hide_dotfiles`](Self::apply_hide_dotfiles). Pure layout state read
+    /// by the Presenter through the view state — no re-render needed (the content is unchanged).
+    pub fn apply_tree_max_cols(&mut self, cols: u16) {
+        // Defensive floor at the public boundary: the resolver already clamps to >= MIN_TREE_MAX_COLS,
+        // but guard locally so a direct/out-of-range caller can never cap the tree to nothing.
+        self.tree_max_cols = cols.max(crate::config::MIN_TREE_MAX_COLS);
+    }
+
     /// Record the content viewport `(width, height)` the Presenter last drew into, so content
     /// scrolling can be clamped to it. Called by the run loop after each draw.
     pub fn set_content_viewport(&mut self, width: u16, height: u16) {
@@ -1181,6 +1236,9 @@ impl Controller {
             wrap,
             content_pad_left,
             split_pct: self.split_pct,
+            tree_position: self.tree_position,
+            tree_max_cols: self.tree_max_cols,
+            split_manual: self.split_manual,
             zoomed: self.zoomed,
             update_banner: self.update_banner(),
             picker: self.picker_view(),
@@ -1960,9 +2018,47 @@ impl Controller {
     /// Move the tree/content divider by `delta` percentage points, clamped so neither column
     /// can collapse. Pure layout state — no re-render is needed (the content is unchanged).
     fn resize_split(&mut self, delta: i16) -> Effects {
-        let next = (self.split_pct as i16 + delta).clamp(SPLIT_MIN as i16, SPLIT_MAX as i16);
+        self.engage_manual_split();
+        let next =
+            (self.split_pct as i16 + delta).clamp(self.split_floor_pct() as i16, SPLIT_MAX as i16);
         self.split_pct = next as u16;
         Effects::redraw()
+    }
+
+    /// First-manual-resize seam: mark the split user-controlled (which lifts the `tree_max_cols`
+    /// cap) and, so the tree doesn't jump on that first keypress/drag, seed `split_pct` from the
+    /// width the tree is *currently displayed* at (which may be capped below `split_pct`%). A no-op
+    /// after the first call, and when no frame has been drawn yet (no geometry to read).
+    fn engage_manual_split(&mut self) {
+        if self.split_manual {
+            return;
+        }
+        // Convert the displayed tree column to a percentage of the drawn body width, so the resize
+        // continues from what's on screen rather than snapping to the uncapped `split_pct`%.
+        // `tree_inner` is the tree's TEXT rect: reconstruct the outer column as interior + its two
+        // block borders + the 2-cell scrollbar gutter the Presenter reserves when a tree vbar is drawn.
+        if let Some(tree) = self.geom.tree_inner
+            && self.geom.area_width > 0
+        {
+            let gutter = if self.geom.tree_vbar.is_some() { 2 } else { 0 };
+            let tree_outer = tree.width.saturating_add(2).saturating_add(gutter);
+            let pct = (tree_outer as u32 * 100 / self.geom.area_width as u32) as u16;
+            self.split_pct = pct.clamp(self.split_floor_pct(), SPLIT_MAX);
+        }
+        self.split_manual = true;
+    }
+
+    /// The lowest split percentage an interactive resize may reach on the current frame: the
+    /// pane-aware "≥ [`MIN_TREE_MAX_COLS`](crate::config::MIN_TREE_MAX_COLS) columns" floor, so a hand
+    /// resize can pull the tree as narrow as the cap allows on any pane width (a fixed percentage
+    /// floor would be far more than the cap's minimum on a very wide pane). Falls back to
+    /// [`SPLIT_DRAG_MIN`] before the first frame is drawn (no geometry width yet).
+    fn split_floor_pct(&self) -> u16 {
+        if self.geom.area_width > 0 {
+            crate::presenter::min_tree_split_pct(self.geom.area_width)
+        } else {
+            SPLIT_DRAG_MIN
+        }
     }
 
     /// Flip the content-wrap state (the `w` key): force it to the opposite of what the current

--- a/src/controller/mouse.rs
+++ b/src/controller/mouse.rs
@@ -420,14 +420,27 @@ impl Controller {
     }
 
     /// During a divider drag, set the split so the divider tracks the cursor column — clamped
-    /// like the keyboard resize so neither column can collapse.
+    /// like the keyboard resize so neither column can collapse. The tree width is measured from
+    /// whichever edge the tree hugs, so a drag toward the content pane always *grows* the tree
+    /// regardless of the side: from the left edge when the tree is on the left, and from the right
+    /// edge when it is on the right.
     fn resize_split_to_col(&mut self, col: u16) -> Effects {
         if self.geom.area_width == 0 {
             return Effects::noop();
         }
-        let tree_w = col.saturating_sub(self.geom.area_x) as i32;
-        let pct =
-            (tree_w * 100 / self.geom.area_width as i32).clamp(SPLIT_MIN as i32, SPLIT_MAX as i32);
+        // A drag is an explicit resize: lift the `tree_max_cols` cap (the drag below sets `split_pct`
+        // straight from the cursor, so there is no jump — the divider is grabbed at its drawn,
+        // possibly-capped, position).
+        self.engage_manual_split();
+        let tree_w = match self.tree_position {
+            crate::config::TreePosition::Left => col.saturating_sub(self.geom.area_x) as i32,
+            crate::config::TreePosition::Right => {
+                let right_edge = self.geom.area_x as i32 + self.geom.area_width as i32;
+                (right_edge - col as i32).max(0)
+            }
+        };
+        let pct = (tree_w * 100 / self.geom.area_width as i32)
+            .clamp(self.split_floor_pct() as i32, SPLIT_MAX as i32);
         self.split_pct = pct as u16;
         Effects::redraw()
     }

--- a/src/help.rs
+++ b/src/help.rs
@@ -249,7 +249,10 @@ pub fn settings_text(
          reveal        = {reveal}\n\
          hide_dotfiles = {hide_dotfiles}\n\
          update_check  = {update_check}\n\
-         scroll_lines  = {scroll_lines}",
+         scroll_lines  = {scroll_lines}\n\
+         tree_width    = {tree_width}\n\
+         tree_position = {tree_position}\n\
+         tree_max_cols = {tree_max_cols}",
         editor = opt_os(&eff.editor),
         markdown = opt_argv(&eff.markdown),
         diff = opt_argv(&eff.diff),
@@ -259,6 +262,9 @@ pub fn settings_text(
         hide_dotfiles = eff.hide_dotfiles,
         update_check = if eff.update_check { "on" } else { "off" },
         scroll_lines = eff.scroll_lines,
+        tree_width = eff.tree_width,
+        tree_position = eff.tree_position.label(),
+        tree_max_cols = eff.tree_max_cols,
     )
 }
 
@@ -747,6 +753,9 @@ mod tests {
             hide_dotfiles: true,
             update_check: false,
             scroll_lines: 7,
+            tree_width: 25,
+            tree_position: crate::config::TreePosition::Right,
+            tree_max_cols: 50,
         }
     }
 
@@ -770,6 +779,9 @@ mod tests {
             "hide_dotfiles",
             "update_check",
             "scroll_lines",
+            "tree_width",
+            "tree_position",
+            "tree_max_cols",
         ] {
             assert!(
                 text.contains(key),
@@ -781,6 +793,22 @@ mod tests {
             text.lines()
                 .any(|l| l.trim_start().starts_with("scroll_lines") && l.contains('7')),
             "settings_text must show the effective scroll_lines value (7):\n{text}"
+        );
+        // AC-12: the effective tree width (25) and tree position (right) each appear as their own row.
+        assert!(
+            text.lines()
+                .any(|l| l.trim_start().starts_with("tree_width") && l.contains("25")),
+            "settings_text must show the effective tree_width value (25):\n{text}"
+        );
+        assert!(
+            text.lines()
+                .any(|l| l.trim_start().starts_with("tree_position") && l.contains("right")),
+            "settings_text must show the effective tree_position (right):\n{text}"
+        );
+        assert!(
+            text.lines()
+                .any(|l| l.trim_start().starts_with("tree_max_cols") && l.contains("50")),
+            "settings_text must show the effective tree_max_cols value (50):\n{text}"
         );
         assert!(text.contains("nano"), "editor value must appear:\n{text}");
         assert!(

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -77,6 +77,18 @@ pub struct ViewState {
     /// The tree column's share of the width, as a percentage (the content pane takes the
     /// rest). Adjustable from the keyboard; used only in the wide two-column layout.
     pub split_pct: u16,
+    /// Which side of the content pane the tree is drawn on (the `tree_position` config key).
+    /// Used only in the wide two-column layout; the narrow single-column layout ignores it.
+    pub tree_position: crate::config::TreePosition,
+    /// The maximum tree width in character columns (the `tree_max_cols` config key). The tree is
+    /// drawn at `min(split_pct% of the pane, tree_max_cols)`, so on a very wide pane it stops
+    /// growing instead of over-allocating. Used only in the wide two-column layout.
+    pub tree_max_cols: u16,
+    /// Whether the user has resized the split by hand this session (a divider drag or the
+    /// grow/shrink keys). While `false`, `tree_max_cols` caps the tree; once `true` the cap is
+    /// lifted so an explicit resize is honoured exactly (otherwise the resize would look frozen on a
+    /// wide, capped pane).
+    pub split_manual: bool,
     /// Hide the tree and let the content pane fill the whole frame (the `z` zoom toggle).
     /// Overrides the split — and the narrow-layout focus rule — to draw content only.
     pub zoomed: bool,
@@ -922,6 +934,23 @@ fn draw_prompt_line(frame: &mut Frame, area: Rect, prompt: &str) {
 /// Below this pane width the viewer drops to a single, focused column (AC-21).
 const NARROW_SPLIT: u16 = 80;
 
+/// The smallest tree column the split may render, as a percentage of `pane_width` — the percentage
+/// that yields at least [`crate::config::MIN_TREE_MAX_COLS`] columns. Pane-aware on purpose: a fixed
+/// percentage floor is wrong in absolute terms on a very wide pane (10% of a 1000-column pane is 100
+/// columns), so a manually-narrowed or `tree_max_cols`-capped tree could not be represented and would
+/// jump up to that floor. Expressing the floor as "≥ N columns" lets the tree stay narrow on any pane
+/// width while never collapsing on a small one. Shared by [`columns`] (render) and the controller's
+/// interactive resize so the two agree on how narrow the tree can get.
+pub fn min_tree_split_pct(pane_width: u16) -> u16 {
+    if pane_width == 0 {
+        return crate::config::MIN_TREE_MAX_COLS;
+    }
+    let pct = (crate::config::MIN_TREE_MAX_COLS as u32 * 100).div_ceil(pane_width as u32) as u16;
+    // Never 0 (a tree needs some width); capped well below the 90% upper bound so a small pane can't
+    // force a floor that would crowd out the content pane.
+    pct.clamp(1, 40)
+}
+
 /// The column split for the current frame: `(tree_area, content_area, divider_x)`. A column
 /// is `None` when not drawn (narrow layout shows only the focused one). Shared by [`draw`] and
 /// [`geometry`] so the drawn layout and the hit-test geometry can never disagree.
@@ -937,15 +966,40 @@ fn columns(area: Rect, state: &ViewState) -> (Option<Rect>, Option<Rect>, Option
             Focus::Content => (None, Some(area), None),
         };
     }
-    let tree_pct = state.split_pct.clamp(10, 90);
-    let cols = Layout::horizontal([
-        Constraint::Percentage(tree_pct),
-        Constraint::Percentage(100 - tree_pct),
-    ])
-    .split(area);
-    // The divider is the boundary column where the tree's right border meets the content's
-    // left border (the two bordered blocks abut here).
-    (Some(cols[0]), Some(cols[1]), Some(cols[1].x))
+    let tree_pct = state.split_pct.clamp(min_tree_split_pct(area.width), 90);
+    // The tree is `min(tree_pct% of the pane, tree_max_cols)`: the percentage governs normal panes,
+    // and the column cap reins the tree in on a very wide pane (a full tab, a big monitor) so it
+    // doesn't over-allocate blank space past the filenames. The cap is a *default* ceiling only:
+    // once the user has resized the split by hand (`split_manual` — a divider drag or the grow/shrink
+    // keys), it is lifted so the tree honours exactly what they dragged to, otherwise the resize
+    // would look frozen. Only when the cap actually bites do we switch to a fixed `Length(cap)`
+    // column; otherwise keep the exact `Percentage` layout (so nothing shifts when it doesn't). The
+    // tree keeps this width whichever side it sits on; only the column ORDER flips. `cols[1]` is
+    // always the right-hand column, so the divider — the boundary where the two bordered blocks abut
+    // — is `cols[1].x` in either layout (the hit-test and drag geometry both derive from this, so
+    // neither needs to know the side).
+    let pct_cols = (area.width as u32 * tree_pct as u32 / 100) as u16;
+    let cap_bites = !state.split_manual && pct_cols > state.tree_max_cols;
+    let (tree_c, content_c) = if cap_bites {
+        // Cap bites: fix the tree at the cap and give the content pane the rest.
+        (Constraint::Length(state.tree_max_cols), Constraint::Min(0))
+    } else {
+        (
+            Constraint::Percentage(tree_pct),
+            Constraint::Percentage(100 - tree_pct),
+        )
+    };
+    match state.tree_position {
+        crate::config::TreePosition::Left => {
+            let cols = Layout::horizontal([tree_c, content_c]).split(area);
+            (Some(cols[0]), Some(cols[1]), Some(cols[1].x))
+        }
+        crate::config::TreePosition::Right => {
+            let cols = Layout::horizontal([content_c, tree_c]).split(area);
+            // content = cols[0] (left), tree = cols[1] (right); divider at their boundary.
+            (Some(cols[1]), Some(cols[0]), Some(cols[1].x))
+        }
+    }
 }
 
 /// Hit-test geometry for mouse input, derived from the same split [`draw`] renders.

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -1427,8 +1427,9 @@ fn resize_intents_move_the_tree_content_divider_and_clamp() {
     }
     let min = ctrl.view_state().split_pct;
     assert!(
-        (20..=80).contains(&min) && min < max,
-        "split clamps to a minimum ({min})"
+        min == 10 && min < max,
+        "split clamps to the interactive minimum of 10% (below the 20% startup floor so a hand \
+         resize can pull the tree narrower than a capped default) ({min})"
     );
     ctrl.handle(Intent::ShrinkTree);
     assert_eq!(
@@ -2205,6 +2206,136 @@ fn wheel_over_the_tree_moves_the_selection() {
 }
 
 #[test]
+fn apply_tree_width_seeds_the_startup_split() {
+    // AC-11: apply_tree_width sets the controller's startup split ratio (split_pct).
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.txt"), "x\n").unwrap();
+    let mut ctrl = controller_with_lines(dir.path(), 1);
+    ctrl.apply_tree_width(25);
+    assert_eq!(
+        ctrl.view_state().split_pct,
+        25,
+        "the startup split follows tree_width"
+    );
+}
+
+#[test]
+fn apply_tree_width_clamps_to_the_split_range() {
+    // AC-11 (defensive clamp, mirrors AC-3): an out-of-range value clamps so neither column can
+    // collapse — the same 20..=80 range the resolver and the live resize enforce.
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.txt"), "x\n").unwrap();
+    let mut ctrl = controller_with_lines(dir.path(), 1);
+    ctrl.apply_tree_width(5);
+    assert_eq!(
+        ctrl.view_state().split_pct,
+        20,
+        "below the floor clamps to 20"
+    );
+    ctrl.apply_tree_width(95);
+    assert_eq!(
+        ctrl.view_state().split_pct,
+        80,
+        "above the ceiling clamps to 80"
+    );
+}
+
+#[test]
+fn apply_tree_width_then_live_resize_still_adjusts() {
+    // AC-11 / NC-6: config only SEEDS the startup split; the live grow/shrink keys still adjust it
+    // within the session (the resize controls are not disabled by the applier).
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.txt"), "x\n").unwrap();
+    let mut ctrl = controller_with_lines(dir.path(), 1);
+    ctrl.apply_tree_width(50);
+    let seeded = ctrl.view_state().split_pct;
+    assert_eq!(seeded, 50);
+    ctrl.handle(Intent::GrowTree);
+    let grown = ctrl.view_state().split_pct;
+    assert!(
+        grown > seeded,
+        "GrowTree still grows the tree after the applier"
+    );
+    ctrl.handle(Intent::ShrinkTree);
+    assert!(
+        ctrl.view_state().split_pct < grown,
+        "ShrinkTree still shrinks the tree after the applier"
+    );
+}
+
+#[test]
+fn apply_tree_position_sets_the_side() {
+    // AC-11 (position half): the default side is Left; the applier sets it to Right.
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.txt"), "x\n").unwrap();
+    let mut ctrl = controller_with_lines(dir.path(), 1);
+    assert_eq!(
+        ctrl.view_state().tree_position,
+        herdr_file_viewer::config::TreePosition::Left,
+        "the default tree side is left"
+    );
+    ctrl.apply_tree_position(herdr_file_viewer::config::TreePosition::Right);
+    assert_eq!(
+        ctrl.view_state().tree_position,
+        herdr_file_viewer::config::TreePosition::Right,
+        "the applier sets the tree side to right"
+    );
+}
+
+#[test]
+fn resizing_the_split_engages_manual_mode_and_lifts_the_cap() {
+    // The tree_max_cols cap is a default ceiling only: an explicit resize (grow/shrink key or a
+    // divider drag) marks the split manual, which lifts the cap so the resize is honoured instead of
+    // looking frozen on a wide, capped pane.
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.txt"), "x\n").unwrap();
+
+    // Grow key engages manual mode.
+    let mut bykey = controller_with_lines(dir.path(), 1);
+    assert!(
+        !bykey.view_state().split_manual,
+        "starts non-manual (cap active)"
+    );
+    bykey.handle(Intent::GrowTree);
+    assert!(
+        bykey.view_state().split_manual,
+        "a grow key marks the split manual (lifts the cap)"
+    );
+
+    // A divider drag engages manual mode too.
+    let (mut bydrag, _, _) = controller(dir.path(), false, StubGit::default(), false);
+    bydrag.set_pane_geometry(wide_geometry());
+    assert!(!bydrag.view_state().split_manual);
+    bydrag.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 40, 0));
+    bydrag.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 55, 0));
+    assert!(
+        bydrag.view_state().split_manual,
+        "a divider drag marks the split manual (lifts the cap)"
+    );
+}
+
+#[test]
+fn apply_tree_max_cols_sets_and_floors_the_cap() {
+    // The applier seeds the tree column cap; a below-floor value is clamped to MIN_TREE_MAX_COLS (10)
+    // so the tree can never be capped to an unreadable sliver.
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.txt"), "x\n").unwrap();
+    let mut ctrl = controller_with_lines(dir.path(), 1);
+    ctrl.apply_tree_max_cols(60);
+    assert_eq!(
+        ctrl.view_state().tree_max_cols,
+        60,
+        "the applier sets the cap"
+    );
+    ctrl.apply_tree_max_cols(3);
+    assert_eq!(
+        ctrl.view_state().tree_max_cols,
+        10,
+        "a below-floor cap is clamped up to MIN_TREE_MAX_COLS"
+    );
+}
+
+#[test]
 fn apply_scroll_lines_sets_the_content_wheel_step() {
     // AC-5: the effective scroll step (config `scroll_lines`) is the number of lines a wheel event
     // advances the content pane. apply_scroll_lines(1) → one notch scrolls exactly 1 line (the
@@ -2370,7 +2501,11 @@ fn dragging_the_divider_resizes_the_split() {
     let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
     ctrl.set_pane_geometry(wide_geometry()); // divider at col 40, pane x=0 width=100
 
-    assert_eq!(ctrl.view_state().split_pct, 40, "default split");
+    assert_eq!(
+        ctrl.view_state().split_pct,
+        30,
+        "default split (DEFAULT_TREE_WIDTH)"
+    );
     ctrl.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 40, 0)); // grab the divider
     ctrl.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 60, 0)); // drag right
     assert_eq!(
@@ -2386,6 +2521,39 @@ fn dragging_the_divider_resizes_the_split() {
         ctrl.view_state().split_pct,
         60,
         "no drag in progress → no resize"
+    );
+}
+
+#[test]
+fn dragging_the_divider_grows_the_tree_on_each_side() {
+    // AC-10: a divider drag toward the content pane grows the TREE regardless of which side the tree
+    // sits on — measured from the left edge when the tree is on the left, from the right edge when
+    // it is on the right. The pane is x=0 width=100 with the divider fixture at col 40.
+    let dir = TempDir::new();
+
+    // Tree on the LEFT: dragging the divider right (toward content) grows the tree to 60%.
+    let (mut left, _, _) = controller(dir.path(), false, StubGit::default(), false);
+    left.set_pane_geometry(wide_geometry());
+    left.apply_tree_position(herdr_file_viewer::config::TreePosition::Left);
+    left.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 40, 0)); // grab the divider
+    left.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 60, 0)); // drag right
+    assert_eq!(
+        left.view_state().split_pct,
+        60,
+        "left tree: dragging right toward content grows the tree to 60%"
+    );
+
+    // Tree on the RIGHT: dragging the divider left (toward content) grows the tree. The width is
+    // taken from the right edge, so a drag to col 25 gives 100 - 25 = 75% tree.
+    let (mut right, _, _) = controller(dir.path(), false, StubGit::default(), false);
+    right.set_pane_geometry(wide_geometry());
+    right.apply_tree_position(herdr_file_viewer::config::TreePosition::Right);
+    right.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 40, 0)); // grab the divider
+    right.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 25, 0)); // drag left
+    assert_eq!(
+        right.view_state().split_pct,
+        75,
+        "right tree: dragging left toward content grows the tree to 75%"
     );
 }
 
@@ -9292,6 +9460,9 @@ fn open_help_appends_settings_section_when_display_is_set() {
         hide_dotfiles: false,
         update_check: true,
         scroll_lines: 3,
+        tree_width: 30,
+        tree_position: herdr_file_viewer::config::TreePosition::Left,
+        tree_max_cols: 45,
     };
     ctrl.set_settings_display(
         &eff,

--- a/tests/docs_consistency.rs
+++ b/tests/docs_consistency.rs
@@ -40,6 +40,9 @@ fn config_example_documents_every_config_key() {
         "hide_dotfiles",
         "update_check",
         "scroll_lines",
+        "tree_width",
+        "tree_position",
+        "tree_max_cols",
     ] {
         assert!(
             has_commented_assignment(CONFIG_EXAMPLE, key),
@@ -86,6 +89,22 @@ fn readme_and_example_document_scroll_lines() {
         CONFIG_EXAMPLE.contains("scroll_lines"),
         "config.example.toml must document the `scroll_lines` config key"
     );
+}
+
+#[test]
+fn readme_and_example_document_tree_layout() {
+    // AC-13: the tree layout config keys must be documented in BOTH the README and the bundled
+    // config.example.toml, so the feature ships with discoverable, copy-pasteable settings.
+    for key in ["tree_width", "tree_position", "tree_max_cols"] {
+        assert!(
+            README.contains(key),
+            "README.md must document the `{key}` config key"
+        );
+        assert!(
+            CONFIG_EXAMPLE.contains(key),
+            "config.example.toml must document the `{key}` config key"
+        );
+    }
 }
 
 #[test]

--- a/tests/presenter.rs
+++ b/tests/presenter.rs
@@ -77,6 +77,11 @@ fn sample_state() -> ViewState {
         wrap: false,
         content_pad_left: false,
         split_pct: 40,
+        tree_position: herdr_file_viewer::config::TreePosition::Left,
+        // A high cap so the percentage governs in these fixtures (the cap only bites on very wide
+        // panes; the cap's own behaviour is covered by dedicated tests).
+        tree_max_cols: 1000,
+        split_manual: false,
         zoomed: false,
         update_banner: None,
         picker: None,
@@ -1177,6 +1182,243 @@ fn geometry_matches_the_wide_two_column_layout() {
         "a wide layout has a draggable divider"
     );
     assert_eq!((g.area_x, g.area_width), (0, 100));
+}
+
+#[test]
+fn geometry_left_position_puts_the_tree_on_the_left() {
+    // AC-8: with tree_position = Left (the default), the tree column is drawn to the left of the
+    // content column — today's layout, unchanged.
+    use herdr_file_viewer::presenter::geometry;
+    use ratatui::layout::Rect;
+    let area = Rect {
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 24,
+    };
+    let mut s = sample_state();
+    s.tree_position = herdr_file_viewer::config::TreePosition::Left;
+    let g = geometry(area, &s);
+    let t = g.tree_inner.expect("tree interior");
+    let c = g.content_inner.expect("content interior");
+    assert!(t.x < c.x, "tree is left of content ({} < {})", t.x, c.x);
+}
+
+#[test]
+fn geometry_right_position_puts_the_tree_on_the_right() {
+    // AC-9: with tree_position = Right, the tree column is drawn to the right of the content column,
+    // and the tree still occupies tree_width percent of the pane (only the side flips; the width is
+    // unchanged).
+    use herdr_file_viewer::presenter::geometry;
+    use ratatui::layout::Rect;
+    let area = Rect {
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 24,
+    };
+    let mut left = sample_state();
+    left.tree_position = herdr_file_viewer::config::TreePosition::Left;
+    left.split_pct = 30;
+    let mut right = sample_state();
+    right.tree_position = herdr_file_viewer::config::TreePosition::Right;
+    right.split_pct = 30;
+
+    let gr = geometry(area, &right);
+    let t = gr.tree_inner.expect("tree interior");
+    let c = gr.content_inner.expect("content interior");
+    assert!(t.x > c.x, "tree is right of content ({} > {})", t.x, c.x);
+    // The tree keeps the SAME width whichever side it sits on (30% of the pane here).
+    let tree_w_left = geometry(area, &left).tree_inner.unwrap().width;
+    assert_eq!(
+        t.width, tree_w_left,
+        "the tree width is unchanged by the side flip"
+    );
+    // AC-9: the tree occupies tree_width percent of the pane, within one column of rounding. The
+    // tree COLUMN is 30% of 100 = 30 cols; its interior is that minus the two block borders (~28).
+    // Asserting the absolute share (not just "narrower than content") catches a layout that used
+    // the wrong percentage on both sides.
+    let tree_outer = t.width + 2; // interior + left/right border
+    assert!(
+        tree_outer.abs_diff(30) <= 1,
+        "the right tree column is ~30% of the 100-col pane (outer width {tree_outer}, want ~30)"
+    );
+    // 30% tree vs 70% content: the tree is the narrower column.
+    assert!(
+        t.width < c.width,
+        "the 30% tree column ({}) is narrower than the content ({})",
+        t.width,
+        c.width
+    );
+}
+
+#[test]
+fn geometry_caps_the_tree_at_tree_max_cols_on_a_wide_pane() {
+    // On a very wide pane, tree_width% would over-allocate a mostly-blank tree; tree_max_cols reins
+    // it in to a fixed column count. On a normal pane where the percentage is under the cap, the
+    // percentage still governs and nothing changes.
+    use herdr_file_viewer::presenter::geometry;
+    use ratatui::layout::Rect;
+    let wide = Rect {
+        x: 0,
+        y: 0,
+        width: 200,
+        height: 24,
+    };
+    let narrow = Rect {
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 24,
+    };
+    let mut capped = sample_state();
+    capped.split_pct = 30;
+    capped.tree_max_cols = 45;
+    let mut uncapped = sample_state();
+    uncapped.split_pct = 30;
+    uncapped.tree_max_cols = 1000;
+
+    // Wide pane: 30% of 200 = 60 cols would be the tree; the cap holds it to ~45 (outer).
+    let t_capped = geometry(wide, &capped).tree_inner.unwrap().width;
+    let t_uncapped = geometry(wide, &uncapped).tree_inner.unwrap().width;
+    assert!(
+        t_capped < t_uncapped,
+        "the cap makes the wide-pane tree narrower ({t_capped} < {t_uncapped})"
+    );
+    assert!(
+        (t_capped + 2).abs_diff(45) <= 1,
+        "the capped tree column is ~45 cols (outer {})",
+        t_capped + 2
+    );
+    assert!(
+        (t_uncapped + 2).abs_diff(60) <= 1,
+        "the uncapped tree column is ~60 cols (30% of 200; outer {})",
+        t_uncapped + 2
+    );
+
+    // Normal pane: 30% of 100 = 30 cols < 45, so the cap does NOT bite — the capped and uncapped
+    // layouts are identical and the percentage governs.
+    let t_narrow_capped = geometry(narrow, &capped).tree_inner.unwrap().width;
+    let t_narrow_uncapped = geometry(narrow, &uncapped).tree_inner.unwrap().width;
+    assert_eq!(
+        t_narrow_capped, t_narrow_uncapped,
+        "on a normal pane the cap does not bite; the percentage governs"
+    );
+}
+
+#[test]
+fn geometry_ignores_the_cap_after_a_manual_resize() {
+    // The cap is a DEFAULT ceiling only: once the user has resized by hand (split_manual), the tree
+    // honours split_pct% exactly, even past tree_max_cols — otherwise a divider drag / grow key would
+    // look frozen on a wide, capped pane.
+    use herdr_file_viewer::presenter::geometry;
+    use ratatui::layout::Rect;
+    let wide = Rect {
+        x: 0,
+        y: 0,
+        width: 200,
+        height: 24,
+    };
+    let mut capped = sample_state();
+    capped.split_pct = 40;
+    capped.tree_max_cols = 45;
+    capped.split_manual = false;
+    let mut manual = sample_state();
+    manual.split_pct = 40;
+    manual.tree_max_cols = 45;
+    manual.split_manual = true;
+
+    let t_capped = geometry(wide, &capped).tree_inner.unwrap().width;
+    let t_manual = geometry(wide, &manual).tree_inner.unwrap().width;
+    assert!(
+        (t_capped + 2).abs_diff(45) <= 1,
+        "before a manual resize the tree is capped at ~45 (outer {})",
+        t_capped + 2
+    );
+    // 40% of 200 = 80 cols: after a manual resize the cap is lifted and the percentage governs.
+    assert!(
+        (t_manual + 2).abs_diff(80) <= 1,
+        "after a manual resize the tree follows split_pct% (~80 cols; outer {})",
+        t_manual + 2
+    );
+    assert!(
+        t_manual > t_capped,
+        "the manual resize widened the tree past the cap"
+    );
+}
+
+#[test]
+fn min_tree_split_pct_yields_at_least_the_min_columns() {
+    // The interactive/render floor is the % that gives >= MIN_TREE_MAX_COLS (10) columns, so it is
+    // small on a wide pane (a narrow tree is representable) and larger on a narrow one (no collapse).
+    use herdr_file_viewer::presenter::min_tree_split_pct;
+    for w in [80u16, 100, 170, 200, 1000] {
+        let pct = min_tree_split_pct(w);
+        assert!(
+            (pct as u32 * w as u32 / 100) >= 10,
+            "floor {pct}% of {w} cols must be >= 10 columns"
+        );
+    }
+    // Wider pane -> smaller floor.
+    assert!(min_tree_split_pct(1000) < min_tree_split_pct(100));
+    assert_eq!(
+        min_tree_split_pct(1000),
+        1,
+        "10 cols of a 1000-col pane is 1%"
+    );
+}
+
+#[test]
+fn geometry_allows_a_narrow_manual_tree_on_a_very_wide_pane() {
+    // Medium-fix: on an ultrawide pane the tree floor is pane-aware, so a manually-narrowed (or
+    // capped) tree is representable instead of jumping up to a fixed 10% of the pane (100 cols here).
+    use herdr_file_viewer::presenter::geometry;
+    use ratatui::layout::Rect;
+    let wide = Rect {
+        x: 0,
+        y: 0,
+        width: 1000,
+        height: 24,
+    };
+    let mut s = sample_state();
+    s.split_manual = true;
+    s.tree_max_cols = 1000; // no cap
+    s.split_pct = 3; // 3% of 1000 = ~30 cols; a fixed 10% floor would force >= 100
+    let t = geometry(wide, &s).tree_inner.unwrap().width;
+    assert!(
+        (t + 2).abs_diff(30) <= 2,
+        "a 3% tree on a 1000-col pane stays ~30 cols (outer {}), not floored to 10% (100 cols)",
+        t + 2
+    );
+}
+
+#[test]
+fn geometry_caps_the_tree_on_the_right_side_too() {
+    // The capped layout arm must also work with the tree on the RIGHT (content = Min(0), tree =
+    // Length(cap)): tree on the right, capped to ~cap columns, content takes the larger remainder.
+    use herdr_file_viewer::presenter::geometry;
+    use ratatui::layout::Rect;
+    let wide = Rect {
+        x: 0,
+        y: 0,
+        width: 200,
+        height: 24,
+    };
+    let mut s = sample_state();
+    s.tree_position = herdr_file_viewer::config::TreePosition::Right;
+    s.split_pct = 30; // 30% of 200 = 60 cols would be the tree...
+    s.tree_max_cols = 45; // ...capped to 45
+    s.split_manual = false;
+    let g = geometry(wide, &s);
+    let t = g.tree_inner.unwrap();
+    let c = g.content_inner.unwrap();
+    assert!(t.x > c.x, "tree is on the right ({} > {})", t.x, c.x);
+    assert!(
+        (t.width + 2).abs_diff(45) <= 1,
+        "the right tree is capped to ~45 cols (outer {})",
+        t.width + 2
+    );
+    assert!(c.width > t.width, "content takes the larger remainder");
 }
 
 #[test]

--- a/tests/presenter_narrow.rs
+++ b/tests/presenter_narrow.rs
@@ -41,6 +41,9 @@ fn state(width: u16, focus: Focus) -> ViewState {
         wrap: false,
         content_pad_left: false,
         split_pct: 40,
+        tree_position: herdr_file_viewer::config::TreePosition::Left,
+        tree_max_cols: 1000, // high cap: percentage governs (narrow-layout tests ignore it anyway)
+        split_manual: false,
         zoomed: false,
         update_banner: None,
         picker: None,

--- a/tests/reroot.rs
+++ b/tests/reroot.rs
@@ -186,6 +186,9 @@ fn re_root_rebuilds_at_the_new_root_carrying_prefs_and_resetting_nav() {
     ctrl.handle(Intent::ToggleHidden); // hide-hidden on (#46)
     ctrl.handle(Intent::ToggleBaseline); // baseline Head → Base
 
+    ctrl.apply_tree_position(herdr_file_viewer::config::TreePosition::Right); // tree side → Right
+    ctrl.apply_tree_max_cols(55); // tree column cap → 55 (off its default)
+
     let split_pref = ctrl.split_pct();
     assert_ne!(split_pref, split_default, "GrowTree should move the split");
     assert!(ctrl.wrap_override(), "wrap toggled on");
@@ -233,6 +236,12 @@ fn re_root_rebuilds_at_the_new_root_carrying_prefs_and_resetting_nav() {
 
     // Preferences are CARRIED (AC-12) — none reset. (Accessor-based, mode-independent.)
     assert_eq!(ctrl.split_pct(), split_pref, "split_pct carried");
+    assert_eq!(
+        ctrl.view_state().tree_position,
+        herdr_file_viewer::config::TreePosition::Right,
+        "tree_position carried"
+    );
+    assert_eq!(ctrl.view_state().tree_max_cols, 55, "tree_max_cols carried");
     assert!(ctrl.wrap_override(), "wrap_override carried");
     assert!(ctrl.changed_only(), "changed_only carried");
     assert!(ctrl.show_ignored(), "show_ignored carried");


### PR DESCRIPTION
## What

Two read-only `config.toml` keys for the tree/content layout inside the viewer's own pane, layered on the existing settings-config surface (same loader, `config > default` precedence, defensive parse, display-only Settings overlay):

- **`tree_width`** — the directory tree column's share of the viewer pane, a percent clamped to `20..=80`. Seeds the **startup** split; the live grow/shrink keys and divider drag still adjust it within a session.
- **`tree_position`** — `"left"` (default, today's layout) or `"right"`. Lenient: trimmed, case-insensitive; an unrecognized value falls back to `"left"`.

**The default tree width changes 40 → 30** (owner-decided), giving the content pane a little more room out of the box. Default side stays left.

Not in scope: the herdr-level pane split (~50%, the host decides that; `plugin pane open` exposes no ratio), and persisting the live-adjusted split (config seeds startup only, consistent with the read-only design).

## How

- `Config.tree_width: Option<u32>` + `Config.tree_position: Option<String>` → `resolve()` → `EffectiveSettings.tree_width: u16` + `.tree_position: TreePosition` (clamp + lenient map, no env var).
- Split-range constants (`DEFAULT_TREE_WIDTH=30`, `MIN=20`, `MAX=80`) move to `config.rs` as one source of truth; the controller's `SPLIT_DEFAULT/MIN/MAX` point at them so the config clamp and the live-resize clamp can't drift.
- `Controller` gains a `tree_position` field (carried across a re-root, like `split_pct`) + `apply_tree_width` / `apply_tree_position` startup appliers (mirroring `apply_hide_dotfiles` / `apply_scroll_lines`), wired in `app::run`.
- The presenter's `columns()` — the single helper both `draw()` and `geometry()` derive from — swaps the content/tree rects for the right side, so hit-testing and scrollbars follow automatically. Only `resize_split_to_col` also needs to know the side (so a drag "grows the tree" on either side).
- Effective values shown read-only in the `?` overlay's Settings section.

Zero new Cargo dependencies.

## Tests

Test-first, one atomic commit per task (T-1..T-6). Resolver clamp/lenient cases, controller appliers + re-root carry, presenter geometry for both sides, per-side divider drag, settings display row, and a docs-consistency drift guard. Full suite green; `cargo fmt --check` / `clippy -D warnings` / `cargo build --release` / `cargo audit` clean.

## Docs

README config block + precedence list + roadmap line, a Layout section in `config.example.toml`, CHANGELOG `[Unreleased]` (`Added` the two keys, `Changed` the 40→30 default), and CONTEXT.md glossary — all in this PR.
