### PR TITLE
docs: slim README to a front door, move reference into docs/, clean up CHANGELOG + AGENTS.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,29 @@
 ---
 name: Bug report
-about: Report a problem
+about: Report a problem with the viewer
+labels: bug
 ---
 
-<!-- repo-setup:seed, skeleton awaiting real content; fill, then remove this line -->
-<placeholder: owner-decided issue template body>
+Thanks for the report! Please fill in what you can — even a partial report helps.
+
+## What happened
+
+A clear description of the bug, and what you expected instead.
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Environment
+
+- OS + version:
+- herdr version (`herdr --version`):
+- Plugin version (`?` overlay → About, or `herdr plugin list`):
+- Renderers installed (glow / delta / bat)?:
+- Terminal (and multiplexer, if any):
+
+## Logs / screenshots
+
+Any error notice shown in the viewer, terminal output, or a screenshot.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,24 @@
+---
+name: Feature request
+about: Suggest an idea or improvement
+labels: enhancement
+---
+
+## Problem / motivation
+
+What are you trying to do, and what gets in the way today?
+
+## Proposed solution
+
+What you'd like the viewer to do.
+
+## Alternatives considered
+
+Other approaches you thought about, or workarounds you're using now.
+
+## Additional context
+
+Anything else — screenshots, examples, related tools.
+
+> Note: the viewer is **read-only by design** (it never edits files or changes git state; hand-offs
+> to an editor / the OS are the exception). Requests that fit that posture are the easiest to land.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,17 @@
-<!-- repo-setup:seed, skeleton awaiting real content; fill, then remove this line -->
 ## Summary
 
-<placeholder: owner-decided PR template body>
+<!-- What does this change do, and why? -->
+
+## Changes
+
+-
 
 ## Test plan
 
-<placeholder>
+- [ ] `cargo test` is green
+- [ ] `cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, `cargo audit` pass
+- [ ] Docs updated in this PR (CHANGELOG + the relevant `docs/` page) for any user-facing change
+
+## Related
+
+<!-- e.g. Closes #123 -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,8 +135,11 @@ cargo audit
 - **The spec is the contract.** To change scope/criteria/design/stack, edit the artifact at the
   **owning stage** and **re-run the readiness check**, don't ad-hoc-edit downstream specs.
 - **Definition of done for a user-facing feature:** the feature isn't done until the docs match it,
-  IN the same PR: `CHANGELOG.md` entry, README `## Keys` table + feature list (and the Shift-keys
-  note for a capital-letter key), and `ARCHITECTURE.md`'s module table if components changed.
+  IN the same PR: `CHANGELOG.md` entry, the relevant `docs/` page (`docs/keys.md` for a key + the
+  Shift-keys note for a capital-letter key, `docs/usage.md` for the feature, `docs/configuration.md`
+  for a config key), and `ARCHITECTURE.md`'s module table if components changed. The root `README.md`
+  is a lean front door (a taste of keys + links to `docs/`), NOT the full reference: keep detail in
+  `docs/`, not the README.
 - **Verify the branch base before a PR.** Worktrees here are often branched off a feature commit,
   not `main`; always `git log main..HEAD` before committing/opening a PR, or strays get swept in.
 - Keep the deterministic tier green (fmt/clippy/`cargo audit`) and tests hermetic.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,9 @@ These shape every decision; violating one is a design error, not a style nit:
 - **Manifest** `herdr-plugin.toml`: declare the viewer as a `[[panes]]` entry with
   `placement = "split"` and `command = ["./target/release/herdr-file-viewer"]`, plus an
   `[[actions]]` to summon it; `min_herdr_version = "0.7.0"`, `platforms = ["linux","macos","windows"]`
-  (Windows is preview, with per-item launcher entries), `[[build]] command = ["cargo","build","--release"]`.
+  (Windows is preview, with per-item launcher entries), and **platform-gated `[[build]]` steps**
+  (`["/bin/sh","scripts/fetch-or-build.sh"]` on unix, `powershell … scripts/fetch-or-build.ps1` on
+  Windows) that download the verified prebuilt binary and fall back to `cargo build --release`.
   **No `[[events]]`** (AC-N4).
 - **Runtime host ops** via the herdr CLI (`$HERDR_BIN_PATH`, the `HerdrCli::run` / `run_json` seam in
   `src/herdr.rs`): read-only layout/query commands only — e.g. `pane zoom` (the `Z` full-screen), the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,11 @@ Companion docs:
 
 - **`CONTEXT.md`**: the glossary (canonical vocabulary).
 - **`constitution.md`**: the standing principles (the source for "Load-bearing constraints").
+- **`ARCHITECTURE.md`**: the committed module map (keep it current when components change).
+- **`docs/`** (index: `docs/README.md`): the user-facing docs — `keys.md` (the full key/mouse
+  reference), `configuration.md` (the `config.toml` + `[keys]` reference), `usage.md` (per-feature
+  guide), plus `install.md` / `summoning.md` / `renderers.md` / `windows.md`. The root `README.md` is
+  a lean front door that links into these; reference detail lives in `docs/`, never the README.
 
 ### What this is
 
@@ -101,10 +106,14 @@ These shape every decision; violating one is a design error, not a style nit:
   silently break it.
 - **Manifest** `herdr-plugin.toml`: declare the viewer as a `[[panes]]` entry with
   `placement = "split"` and `command = ["./target/release/herdr-file-viewer"]`, plus an
-  `[[actions]]` to summon it; `min_herdr_version = "0.7.0"`, `platforms = ["linux","macos"]`,
-  `[[build]] command = ["cargo","build","--release"]`. **No `[[events]]`** (AC-N4).
-- **Runtime** (editor hand-off): via `$HERDR_BIN_PATH`: `pane split <id> --direction right
-  --no-focus` → parse `result.pane.pane_id` from the JSON → `pane run <new_id> "<editor> <file>"`.
+  `[[actions]]` to summon it; `min_herdr_version = "0.7.0"`, `platforms = ["linux","macos","windows"]`
+  (Windows is preview, with per-item launcher entries), `[[build]] command = ["cargo","build","--release"]`.
+  **No `[[events]]`** (AC-N4).
+- **Runtime host ops** via the herdr CLI (`$HERDR_BIN_PATH`, the `HerdrCli::run` / `run_json` seam in
+  `src/herdr.rs`): read-only layout/query commands only — e.g. `pane zoom` (the `Z` full-screen), the
+  worktree picker's queries, and the tab/split launcher scripts. The **editor hand-off is NOT a herdr
+  pane**: `e` runs the editor *in-process* (the viewer suspends and resumes around `$EDITOR` / the
+  config `editor`), so the viewer never spawns a pane for it.
 - External renderers (glow/delta/bat) are **runtime, install-time** dependencies, not Cargo deps;
   the Content Renderer falls back to plain text + a notice when one is absent (AC-24/25).
 - Make external commands (renderers, editor, herdr CLI) **injected parameters** so tests stay
@@ -144,6 +153,31 @@ cargo audit
   not `main`; always `git log main..HEAD` before committing/opening a PR, or strays get swept in.
 - Keep the deterministic tier green (fmt/clippy/`cargo audit`) and tests hermetic.
 
+### Adding a keybinding or a config key (touchpoints + drift guards)
+
+Both surfaces are single-source-of-truth in code, with a build-failing test guarding the docs, so you
+never wire them in two places or let the docs drift.
+
+**A new keybinding / action.** `REGISTRY` in `src/input.rs` is the source of truth: the dispatcher,
+the `?` overlay's Keybindings section, and `[keys]` remapping all derive from it.
+1. Add the variant to the `Intent` enum in `src/intent.rs` (it lives in `Intent::ALL`, 33 today).
+2. Add a `Binding { intent, name, default_keys, description, category }` row to `REGISTRY`
+   (`category` must be one of `CATEGORY_ORDER`).
+3. Handle the intent in the session controller (`src/controller/`).
+4. **Docs (same PR):** add the key row to the `## Keys` table in **`docs/keys.md`** and the
+   intent-name row to the "Every remappable action" table in **`docs/configuration.md`**, plus a
+   `CHANGELOG.md` entry. The `?` overlay updates itself — no manual edit. Two `src/input.rs` tests
+   fail the build if you skip a doc: `keys_doc_table_documents_every_registry_action_ac21` (every
+   registry key is in `docs/keys.md`) and `configuration_doc_lists_every_remappable_intent` (every
+   registry name is in `docs/configuration.md`).
+
+**A new config key.** `src/config.rs` owns it: add the field to `Config`, resolve it in `resolve`
+into `EffectiveSettings`, and apply it at wiring time. **Docs (same PR):** document it in
+**`docs/configuration.md`**, add a commented `key = ...` line to **`config.example.toml`**, surface
+the effective value in the `?` Settings section, and add a `CHANGELOG.md` entry. The
+`config_example_documents_every_config_key` test (`tests/docs_consistency.rs`) requires a commented
+assignment for every scalar `Config` field — keep its key list in lockstep with `Config`.
+
 ### Releasing a version (owner-gated, confirm first)
 
 1. **Bump the version in ALL THREE files**: `Cargo.toml`, `Cargo.lock`, **and `herdr-plugin.toml`**:
@@ -156,9 +190,11 @@ cargo audit
 3. Protected `main` → bump via a **`release/vX.Y.Z` PR** → green CI → merge.
 4. **Tag `vX.Y.Z` AT the merge commit** (`git tag -a vX.Y.Z <merge-sha>` → push) so a bare
    `herdr plugin install`'s tagless-clone `HEAD` matches the published `COMMIT` asset. The tag push
-   triggers `release.yml` (builds 3 binaries + `SHA256SUMS` + `COMMIT`, `--generate-notes`).
+   triggers `release.yml` (builds **4 binaries** — Linux musl, macOS arm64 + x86_64, Windows `.exe` —
+   plus `SHA256SUMS` + `COMMIT`, `--generate-notes`).
 5. **Replace the auto-notes** with the approved body: `gh release edit vX.Y.Z --notes-file <f>`.
-6. **Verify**: `gh release view vX.Y.Z` shows 5 assets, not draft/prerelease.
+6. **Verify**: `gh release view vX.Y.Z` shows **6 assets** (4 binaries + `SHA256SUMS` + `COMMIT`),
+   not draft/prerelease.
 
 **Install gate (current, since PR #50):** the prebuilt binary is used by **declared version match**,
 not commit-exact; main being ahead of the tag no longer forces a source build. So features can

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,13 +186,20 @@ assignment for every scalar `Config` field — keep its key list in lockstep wit
    `herdr-plugin.toml`. Versioning: **minor per additive feature**, major only on a breaking change
    or a flagship feature.
 2. Add the `## [X.Y.Z] - DATE` `CHANGELOG.md` entry (Keep-a-Changelog `Added`/`Changed`/`Fixed`,
-   omit empty sections). Show the owner the release notes before posting.
+   omit empty sections; keep bullets terse and credit external contributors `Thanks @user (#NN)`).
+   **The CHANGELOG section IS the release notes** (single source of truth) — never author them
+   separately, or the two drift. Show the owner the section before posting.
 3. Protected `main` → bump via a **`release/vX.Y.Z` PR** → green CI → merge.
 4. **Tag `vX.Y.Z` AT the merge commit** (`git tag -a vX.Y.Z <merge-sha>` → push) so a bare
    `herdr plugin install`'s tagless-clone `HEAD` matches the published `COMMIT` asset. The tag push
    triggers `release.yml` (builds **4 binaries** — Linux musl, macOS arm64 + x86_64, Windows `.exe` —
    plus `SHA256SUMS` + `COMMIT`, `--generate-notes`).
-5. **Replace the auto-notes** with the approved body: `gh release edit vX.Y.Z --notes-file <f>`.
+5. **Set the release body FROM the CHANGELOG section** (single source of truth, so the notes can't
+   drift from the changelog): extract this tag's `## [X.Y.Z]` block, drop the trailing `→ [docs]`
+   pointers (a release note is a self-contained, pinned artifact), append a
+   `**Full changelog:** <repo>/compare/vPREV...vX.Y.Z` line, then
+   `gh release edit vX.Y.Z --notes-file <f>`. Extract with e.g.
+   `awk '/^## \[X.Y.Z\]/{f=1;next} f&&/^## \[/{exit} f' CHANGELOG.md`.
 6. **Verify**: `gh release view vX.Y.Z` shows **6 assets** (4 binaries + `SHA256SUMS` + `COMMIT`),
    not draft/prerelease.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,8 @@ All notable changes to this project are documented here. The format is based on
   out. The `?` help overlay gained a display-only **Keybindings** section that groups the actions
   into sections and, for each, shows its config-var name (the `[keys]` id you type to remap it), its
   effective key(s), and its description, marking the ones you customized. Under the hood every
-  binding now derives from one in-code registry, so the dispatcher, the overlay, and the README
-  `## Keys` table can no longer drift apart.
+  binding now derives from one in-code registry, so the dispatcher, the overlay, and the keys
+  reference table can no longer drift apart.
 - **Config file — customize the editor, renderers, openers, and a couple of startup toggles.**
   An optional read-only TOML config at `$HERDR_PLUGIN_CONFIG_DIR/config.toml` (herdr-provided) or
   `$XDG_CONFIG_HOME/herdr-file-viewer/config.toml` (standalone fallback) now lets you override the
@@ -67,6 +67,12 @@ All notable changes to this project are documented here. The format is based on
   a wide window it stays compact instead of growing into a mostly-blank column. Panes under ~100
   columns are unaffected (the percentage governs), and dragging the divider or the grow/shrink keys
   lifts the cap; raise `tree_max_cols` to disable it.
+- **Documentation reorganized around a leaner README.** The README is now a short front door (what
+  it is, a quickstart, a taste of the keys, and links); the full reference moved into focused
+  [`docs/`](docs/README.md) pages — a complete [keys & mouse](docs/keys.md) reference, a
+  [configuration](docs/configuration.md) reference, a feature-by-feature [usage guide](docs/usage.md),
+  and dedicated [summoning](docs/summoning.md) and [Windows](docs/windows.md) pages — behind a docs
+  index. Adds a `CONTRIBUTING.md` guide and GitHub issue / pull-request templates. No behavior change.
 
 ### Fixed
 - **Wide tables in the rendered-markdown view no longer shatter.** A table is now laid out to fit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,450 +2,165 @@
 
 All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
-[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html). Entries are short on purpose; follow the
+`→` links for the full detail.
 
 ## [Unreleased]
 
 ### Added
-- **Configurable tree/content layout via `tree_width`, `tree_position`, and `tree_max_cols` keys in
-  `config.toml`.** `tree_width` sets the directory tree column's share of the viewer pane (a percent
-  from `20` to `80`; the content pane takes the rest), `tree_position` puts the tree on the `"left"`
-  (default) or `"right"` of the content pane, and `tree_max_cols` caps the tree at a maximum number
-  of **columns** so it does not balloon on a very wide pane — the tree is drawn at
-  `min(tree_width% of the pane, tree_max_cols)`. These seed the **startup** split inside the viewer's
-  own pane (not the size of the herdr pane, which the host decides); you can still resize the split
-  live with the grow/shrink keys or by dragging the divider, and "grow" always widens the tree
-  whichever side it is on. `config > default`, no environment variable; an out-of-range width clamps
-  into `20..=80`, an unrecognized position falls back to `"left"`, and the column cap clamps into
-  `10..=1000` (set it high to disable). All three effective values are shown in the `?` overlay's
-  Settings section.
-- **Configurable mouse-wheel scroll speed via a `scroll_lines` key in `config.toml`.** Sets how many
-  lines each wheel event advances the content pane (and how many items it moves in the file-search
-  list, and lines in the `?` help overlay); the directory tree still moves one row per event.
-  Defaults to `3` (unchanged behaviour) and is clamped to the range `1..=10`. Lower it (e.g.
-  `scroll_lines = 1`) for finer, slower scrolling when reading large files or browsing search
-  results. `config > default`, no environment variable; the effective value is shown in the `?`
-  overlay's Settings section. (GitHub #93)
-- **Customizable keybindings: remap any global key with a `[keys]` table in `config.toml`.** A new
-  `[keys]` section keyed by intent name (`refresh`, `nav_up`, `switch_worktree`, and the rest) lets
-  you replace an action's default key(s) with your own, written as a single string (`refresh = "g"`)
-  or an array (`nav_up = ["w", "Up"]`). Only modifier-free keys are bindable: printable and shifted
-  characters, plus named keys like `Tab` / `Enter` / the arrows / `F1`..`F12`; there are no
-  `Ctrl` / `Alt` chords, so terminal combinations still pass through. A `[keys]` value overrides the
-  built-in default (`config > default`); a malformed, unknown, or duplicate entry is ignored (its
-  default kept) and never crashes, and `Esc` always closes the viewer, so a remap can never lock you
-  out. The `?` help overlay gained a display-only **Keybindings** section that groups the actions
-  into sections and, for each, shows its config-var name (the `[keys]` id you type to remap it), its
-  effective key(s), and its description, marking the ones you customized. Under the hood every
-  binding now derives from one in-code registry, so the dispatcher, the overlay, and the keys
-  reference table can no longer drift apart.
-- **Config file — customize the editor, renderers, openers, and a couple of startup toggles.**
-  An optional read-only TOML config at `$HERDR_PLUGIN_CONFIG_DIR/config.toml` (herdr-provided) or
-  `$XDG_CONFIG_HOME/herdr-file-viewer/config.toml` (standalone fallback) now lets you override the
-  `e` editor command, the `markdown` / `diff` / `syntax` renderer commands, and the `O` open-with /
-  `R` reveal-in-file-manager commands, plus set `hide_dotfiles` and `update_check` defaults at
-  startup. A config key always overrides its environment variable, which overrides the built-in
-  default (`config > env > default`); a missing or malformed file safely falls back to defaults.
-  The viewer never writes the file — it's read-only input, picked up on relaunch. The `?` help
-  overlay gained a third **Settings** section showing the currently effective values and whether
-  the config loaded, was absent, or was malformed — display-only, not an in-app editor. A
-  fully-commented **`config.example.toml`** ships in the plugin folder documenting every setting
-  (all lines commented out); copy it to your config dir, rename it to `config.toml`, and edit.
-- **`Z` (Shift+`z`) toggles a file full-screen.** The first press opens the selected file like
-  `Enter` and zooms the viewer's herdr pane to fill the whole terminal, so the file takes over the
-  entire screen instead of just the split; press `Z` again (or `Esc`/`q`, or `z`) to return to the
-  normal two-column split. Switching worktree or quitting the viewer also restores the pane.
-  Read-only: the pane zoom is a host layout op, never a file or git change, and it degrades to the
-  in-pane zoom when the host isn't herdr. Lowercase `z` still toggles the in-pane zoom only; on a
-  directory, `Z` just expands/collapses like `Enter`.
+- Configurable tree layout: `tree_width` (split %, 20–80), `tree_position` (`left`/`right`), and `tree_max_cols` (column cap). → [configuration](docs/configuration.md)
+- Configurable mouse-wheel scroll speed: `scroll_lines` (1–10). Thanks @alargoa (#93). → [configuration](docs/configuration.md)
+- Customizable keybindings: remap any global key with a `[keys]` table; the `?` overlay lists effective keys. → [keybindings](docs/configuration.md#keybindings)
+- Config file (`config.toml`): override the editor, renderer/opener commands, and startup toggles (read-only, `config > env > default`). → [configuration](docs/configuration.md)
+- `Z` full-screens the selected file (in-pane zoom + the herdr pane zoom); `z` still zooms in-pane only. → [keys](docs/keys.md)
 
 ### Changed
-- **The default tree/content split is now 30% tree (was 40%),** giving the content pane a little more
-  room out of the box. Set `tree_width` in `config.toml` to pick your own, or resize it live as
-  before.
-- **The tree is now capped at 30 columns by default** (`tree_max_cols`), so on a full-terminal tab or
-  a wide window it stays compact instead of growing into a mostly-blank column. Panes under ~100
-  columns are unaffected (the percentage governs), and dragging the divider or the grow/shrink keys
-  lifts the cap; raise `tree_max_cols` to disable it.
-- **Documentation reorganized around a leaner README.** The README is now a short front door (what
-  it is, a quickstart, a taste of the keys, and links); the full reference moved into focused
-  [`docs/`](docs/README.md) pages — a complete [keys & mouse](docs/keys.md) reference, a
-  [configuration](docs/configuration.md) reference, a feature-by-feature [usage guide](docs/usage.md),
-  and dedicated [summoning](docs/summoning.md) and [Windows](docs/windows.md) pages — behind a docs
-  index. Adds a `CONTRIBUTING.md` guide and GitHub issue / pull-request templates. No behavior change.
+- Default tree width is now 30% (was 40%), for more content room.
+- Tree is capped at 30 columns by default so it stays compact on wide panes.
+- Docs reorganized: the README is a lean front door; the full reference moved to [docs/](docs/README.md), plus a `CONTRIBUTING.md` and issue/PR templates.
 
 ### Fixed
-- **Wide tables in the rendered-markdown view no longer shatter.** A table is now laid out to fit
-  the content pane (columns sized to the pane width, over-long cells ellipsized with `…`) instead
-  of overflowing at its natural width and being broken across the border rows by the pane's
-  line-wrapping. Resizing the pane (or dragging the split bar) reflows the table, preserving your
-  scroll position and any active search. Press `w` to switch to a wide, horizontally-scrollable
-  view that renders the table at full natural width with every cell intact (`←`/`→` or the
-  scrollbar to pan); press `w` again to return. (`w` remains a uniform wrap on/off preference, so
-  it never springs an unexpected wrap on a code file.)
+- Wide markdown tables now fit the pane instead of shattering; `w` toggles a full-width scrollable view.
 
 ## [1.11.0] - 2026-07-09
 
-Mouse-driven text selection in the content pane, plus content copy in line-select mode.
-
 ### Added
-- **Ambient mouse text selection.** Click-drag anywhere in the content pane during normal
-  navigation to select text character-by-character; release to copy ("Copied selection"). Works in
-  wrapped views, and `Shift`+drag still gives the terminal's native selection. Thanks @j-pollack!
-- **Mouse text selection in line-select mode**, character-by-character with a live highlight as you
-  drag.
-- **`y`/`Y` in line-select mode copy the selected content** (byte-faithful, no line-number gutter,
-  indentation preserved), while `Enter` keeps copying the `path:line` / `path:start-end` reference.
+- Ambient mouse text selection: click-drag in the content pane to select text and copy on release; `Shift`+drag keeps the terminal's native selection. Thanks @j-pollack (#78). → [keys](docs/keys.md#mouse)
+- `y`/`Y` in line-select mode copy the selected content (no line-number gutter, indentation preserved); `Enter` still copies the `path:line` reference.
 
 ### Changed
-- **In line-select mode, a mouse press now places the selection caret** (previously a click placed
-  the line marker and a double-click copied); copying is now always an explicit `Enter`/`y`.
+- In line-select mode a mouse press now places the caret; copying is always an explicit `Enter`/`y`.
 
 ### Fixed
-- **Open-in-tab (`prefix+shift+f`) no longer jumps to a viewer in another workspace.** Invoking the
-  tab action from a different workspace now opens a fresh viewer in the current workspace instead of
-  switching you to the other workspace's tab. Within-workspace open-or-switch-or-toggle is unchanged.
-- **Left gap in the rendered-markdown and diff views.** These views now sit one column in from the
-  content pane's left border, matching the gap syntax-highlighted files already get from their
-  line-number gutter.
+- Open-in-tab (`prefix+shift+f`) no longer jumps to a viewer in another workspace.
+- Closed the left gap in the rendered-markdown and diff views (now aligned with the syntax view).
 
 ## [1.10.0] - 2026-07-07
 
 ### Added
-- **Reveal in file manager / open with default app**: new `O` (open the selected file or directory
-  with the OS default application) and `R` (reveal the selected entry in the OS file manager) keyboard
-  shortcuts, each a read-only, non-blocking hand-off to the host OS (macOS `open`/`open -R`, Linux
-  `xdg-open`, Windows `explorer`). Requested in #68.
+- Reveal in file manager (`R`) and open with the OS default app (`O`): read-only, non-blocking hand-offs. Thanks @amitav13 (#68). → [keys](docs/keys.md)
 
 ## [1.9.0] - 2026-07-06
 
 ### Added
-- **Copy a line reference: `L` line-select mode.** With the content pane focused (or zoomed),
-  `L` enters line-select mode: a marker appears on the top visible source line. `j`/`k` (or
-  `↑`/`↓`) move the marker and hold `Shift` (`J`/`K`, or Shift+`↑`/`↓`) to extend a selection;
-  `Enter`, or a double-click, copies the repo-relative reference (`src/app.rs:42` for one line,
-  `src/app.rs:42-58` for a range) to the clipboard over OSC 52, the same path as `y`/`Y`; `Esc`
-  exits. A mouse click places the marker and a double-click copies. Entering
-  from a rendered-markdown or diff view first switches that file to the line-numbered source view,
-  since line numbers only map there. `L` stays focus-gated: with the tree focused it still does the
-  tree's horizontal scroll (unchanged). Correct under the `w` wrap toggle: the marker, mouse click,
-  and copied reference map through the wrapped layout, so they land on the right source line.
+- Copy a line reference: `L` line-select mode. `Enter` copies `path:line` (or `path:start-end`) over OSC 52; `j`/`k` move the marker, `Shift` extends. → [keys](docs/keys.md)
 
 ## [1.8.0] - 2026-07-05
 
 ### Added
-- **Native Windows support (preview).** The viewer now builds and runs on `x86_64-pc-windows-msvc`,
-  alongside Linux and macOS. Install via herdr's preview channel and summon it with
-  `herdr plugin action invoke open-file-viewer-windows`; see the README's Windows section.
-  Preview is best-effort: no Windows-on-ARM and no code-signing yet.
+- Native Windows support (preview): builds and runs on `x86_64-pc-windows-msvc`; summon via the `-windows` action ids. Thanks @sanirudh17 (#58). → [Windows](docs/windows.md)
 
 ## [1.7.0] - 2026-06-30
 
+The "Optimisations" release: accessibility cues, UX papercuts, and internal hardening.
+
 ### Added
-- **Tree horizontal scroll is now keyboard-reachable (AC-18).** The tree's horizontal scroll
-  offset (for reading long or deeply-nested rows that overflow the tree column) was
-  mouse-only (drag the horizontal scrollbar or a horizontal wheel/swipe); there was no key
-  for it. New `H` (Shift+`h`) and `L` (Shift+`l`) intents scroll the tree left/right by the same
-  step the mouse wheel uses, clamped to the measured max (mirroring the content pane's `←`/`→`
-  h-scroll). Inert unless the tree is focused, so the keys never fight the content pane's own
-  horizontal scroll. The lowercase `h`/`l` stay Collapse/Expand, no collision.
-- **Discoverability: a `? help` hint on the content pane's bottom border.** A new user no
-  longer has to guess that `?` opens the help overlay: a right-aligned `? help` segment now
-  rides the content block's bottom border, visible on the default screen without opening any
-  modal. One short segment; it shares the border row (not the layout), so it never crowds the
-  content or steals a row. Sanitized + clipped like the other border titles (AC-27).
-- **Empty-state guidance for blank panes.** Selecting a directory now shows
-  `Directory: select a file to view` in the content pane (instead of a blank void), and an
-  empty / zero-match tree (no files, or a filter, changed-only / gitignore / hidden, that
-  matched nothing) shows `No files`. The copy flows through the normal content path.
+- Tree horizontal scroll is keyboard-reachable: `H`/`L` scroll the tree left/right (inert unless the tree is focused).
+- A `? help` hint on the content pane's bottom border, so the help overlay is discoverable.
+- Empty-state guidance: `Directory: select a file to view` and `No files` instead of a blank pane.
 
 ### Changed
-- **Non-color cues alongside color-only signalling.** Several key UI states were
-  conveyed by color alone, so a colorblind user or a non-default terminal theme could lose the
-  signal entirely. Each now carries a non-color cue too:
-  - **Dirty directory**: the tree's `▾ dir` row for a directory containing a git change now shows
-    a leading `●` glyph (files already had `M`/`A`/`D`/`?` letters; directories were color-only
-    LightRed). The `tree_rows_max_width` calc flows from the same `tree_row` the tree draws, so the
-    added glyph column stays aligned with the h-scroll clamp / hit-test.
-  - **Active help tab**: the active section in the help overlay now carries a leading `▶ ` marker
-    alongside the existing REVERSED+BOLD indicator (the marker is counted in `help_tab_rects` so the
-    click hit-test still tracks the drawn tab).
-  - **Current worktree**: the picker's current-worktree row now carries a trailing `(current)`
-    text label alongside the existing cyan `●` glyph.
-  - **Current search match**: `CURRENT_HIGHLIGHT` is now `REVERSED|BOLD` (theme-relative: it
-    inverts whatever the terminal palette is) instead of hardcoded `Black`-on-`Yellow`, so the
-    active match is distinguishable with color stripped; the non-current matches keep their
-    black-on-cyan `HIGHLIGHT`.
-  - **Update banner / bottom prompt**: these status bars now use `REVERSED` (theme-relative)
-    instead of hardcoded `Black`-on-`Cyan` / `Black`-on-`Gray`, so they read on any palette.
-  All labels still flow through `sanitize_label` (AC-27).
-- **Renderer fallback notices no longer leak raw OS errors.** When an external renderer
-  (glow/delta/bat) is missing, times out, or otherwise fails, the viewer's fallback notice now
-  reports a short, actionable message (naming the missing binary and pointing to
-  `docs/renderers.md` for the not-found case) instead of the raw OS error string (e.g.
-  `No such file or directory (os error 2)`, which told you nothing you could act on). AC-24/AC-25
-  plain-text-plus-notice fallback is unchanged; the raw detail is retained behind a future
-  debug/verbose path, not the default notice.
-- **Editor hand-off now distinguishes a launch failure from a non-zero editor exit.** Previously
-  any error from `open_in_editor` surfaced as `"Could not open editor: …"`, so a successful
-  launch that exited non-zero (e.g. a vim exit code) was misleadingly reported as a launch
-  failure. The `EditorHandoff` return is now an `EditorOutcome` enum: `NotLaunched(reason)` for
-  a process that never started (e.g. missing binary, no `$EDITOR`) vs `NonZeroExit(detail)` for a
-  process that ran and returned a failing status, and the controller words each case correctly:
-  a launch failure still says `"Could not open editor: {reason}"`, while a non-zero exit says
-  `"Editor exited with {detail}"` and still refreshes git state and forces a full repaint (the
-  editor did take the terminal). A new `SpawnError` enum at the `Spawner` boundary keeps
-  `LiveEditor`/`ProcessSpawner` the only place that knows about `std::process`.
-- Extracted the duplicated `wait_bounded` subprocess reaper (child wait + poll + timeout-kill)
-  from `render.rs` and `update/mod.rs` into one shared `src/proc.rs` helper. Pure dedup, no
-  behavior change; the total wall-clock timeout bound is unchanged (the audit's
-  highest-agreement finding, security-adjacent).
-- Documented `git` as a runtime requirement in `docs/install.md` (the git-aware tree + diff
-  views shell out to the system `git` CLI; without it those features degrade but the viewer
-  still opens). Also corrected the `HERDR_FILE_VIEWER_NO_UPDATE_CHECK` wording: any value (the
-  var's mere presence) disables the check, not just `=1`.
-- `docs/renderers.md`: documented the bundled `assets/markdown-style.json` palette glow is
-  pointed at when present (falling back to glow's built-in `dark` style), and corrected the
-  overclaimed `cargo` fallback: only `delta` and `bat` are cargo-installable; `glow` is Go
-  and the helper prints its manual install link instead.
-- `ARCHITECTURE.md`: noted the one on-disk exception to "ephemeral state only": the advisory
-  `update-check.json` timestamp cache (safe to delete); added the new `proc` module to the
-  component table.
-- `herdr-plugin.toml`: corrected the pane comment (the `[[actions]]` do summon the viewer at
-  runtime via launcher scripts; the old comment claimed no runtime command did).
-- `.github/workflows/release.yml`: corrected the stale prebuilt-gate comment: the install
-  step selects the prebuilt by **declared version match**, not commit exactness; the published
-  `COMMIT` marker is informational only (used to note when the checkout is ahead of the
-  released binary).
-- Swept `src/**` and `tests/**` comments clean of internal build-process references (issue
-  IDs, plan task IDs, and review notes) and corrected the stale "search keystrokes are no-ops"
-  comment in `controller.rs` (in-file search is fully implemented). No code behavior changed.
-- `CHANGELOG.md`: added the missing `[1.1.0]`–`[1.6.0]` release-tag link references (only
-  `[1.0.0]` had one).
-- **Test timing hardening:** added a `perf` cargo feature to gate the
-  absolute-stopwatch perf-budget tests (`render_perf`, `tree_perf`, the `reroot` AC-17 budget)
-  off the default PR lane: a plain `cargo test` no longer runs them (they flake on a loaded
-  shared runner for reasons unrelated to a regression); run via `cargo test --features perf`.
-  Rewrote `search_perf` and `index_perf` as **relative-scaling** asserts (`time(2N) < ~4×
-  time(N)`, with a minimum-base floor below which a small absolute bound applies, modelled on
-  the `render.rs` `mul_f32(1.5)` exemplar) so they catch an O(n²) regression without flaking on
-  a 2–3× slower machine; these run on the default lane. Replaced
-  the pty e2e tests' fixed `thread::sleep` "screen is ready" assumptions with `expectrl`
-  wait-for-content (`expect` on the prompt/overlay label the next key depends on), eliminating
-  the torn-read flake class; the deliberate Esc inter-byte gaps and terminal-resume settles are
-  kept (they prevent Alt+char decoding and have no screen-content anchor). The 2 macOS
-  `#[ignore]` e2e tests (`e2e_help`, `e2e_editor`) are retained with their existing rationale:
-  they may now pass on macOS CI after the timing fix, but that can only be confirmed on the
-  macOS CI matrix, so the ignores stay until verified.
-- **Test coverage:** strengthened `no_handled_intent_mutates_the_filesystem`
-  so it routes every `Intent::ALL` variant through the real handler (closing any modal an intent
-  opened before the next iteration, so guards don't short-circuit the dispatch) and asserts a
-  content-aware FS/git snapshot. The read-only invariant (AC-N1/N2) is now genuinely exercised.
-  Added a modal × intent cross-product guard matrix (5 modal states × every `Intent::ALL`
-  variant) driving off `Intent::ALL` so a new intent variant is auto-covered; asserts modal isolation
-  (AC-5/AC-6), no second modal opens, tree/FS unchanged. Extracted the git porcelain/diff parser
-  into testable helpers (`parse_porcelain_status`, `parse_name_status`) and added table-driven
-  unit tests for malformed/truncated input, rename/copy edge cases, unknown status codes, and
-  direct `classify`/`classify_name_status` per-code assertions. The defensive branches that were
-  previously unreachable are now exercised. Added an OSC-52 clipboard-exfiltration ingestion test
-  (AC-27 named vector) on the content-renderer path, and gated the CLI smoke test's network path
-  by setting `HERDR_FILE_VIEWER_NO_UPDATE_CHECK` so it performs no network I/O (hermetic).
+- Non-color accessibility cues alongside color: a `●` on dirty directories, a `▶` on the active help tab, a `(current)` label on the current worktree, and theme-relative `REVERSED` highlights for the current match and status banners.
+- Renderer fallback notices are now short and actionable instead of raw OS errors.
+- Editor hand-off distinguishes a launch failure from a non-zero editor exit.
+- Internal: shared the subprocess reaper, hardened test timing/coverage, and fixed doc drift across `install.md` / `renderers.md` / `ARCHITECTURE.md` and the release workflow.
 
 ### Fixed
-- **Content pane no longer shows a stale file under a new title while a render is in flight.**
-  On a slow off-thread render, the content pane used to keep displaying the PREVIOUS file's body
-  while the content title (derived from the live tree cursor) already named the NEW selection.
-  the pane briefly misrepresented what was selected. The content title is now derived from the
-  displayed content's file (`content_path`, updated only when the render result lands in `poll`),
-  so the title and body switch to the new file together; while a render is in flight the body
-  shows a `Rendering…` loading placeholder (and the title stays on the previously-displayed file,
-  or a neutral `Content` label at launch / after a re-root when no content has landed yet). The
-  existing `latest_seq`/`applied_seq` supersession already keyed stale-result dropping, so a
-  superseded render result (the user moved on) still does not overwrite the pane.
+- Content pane no longer shows a stale file under a new title while a render is in flight (shows a `Rendering…` placeholder).
 
 ## [1.6.0] - 2026-06-28
 
 ### Added
-- **Go to line (`:`).** Press `:` to open a prompt and jump the content pane to a source line by
-  number: `Enter` jumps (out-of-range clamps to the last line), `Esc` cancels. Works in every view:
-  in a rendered-markdown or diff view (where a source line has no 1:1 display row) confirming switches
-  the file to the line-numbered content view and jumps there. Read-only navigation. (The first half of
-  in-file navigation.) ([#54](https://github.com/smarzban/herdr-file-viewer/pull/54))
-- **Search in file (`/`, `n`/`N`).** Press `/` to search the open file's content: every match
-  highlights as you type and the content scrolls to the first match; `Enter` commits the search
-  (highlights persist) and `n` / `N` cycle through matches in document order, wrapping at the ends
-  with a notice. Matching is **smartcase** (a lowercase query is case-insensitive, a query with any
-  uppercase letter is case-sensitive) and **literal** (regex metacharacters match literally). Search
-  works in **every** view (code, rendered markdown, or diff), over the content **as displayed**; `Esc`
-  cancels and restores the scroll, and the search clears when the displayed content changes.
-  Read-only navigation. (The second half of in-file navigation.) ([#55](https://github.com/smarzban/herdr-file-viewer/pull/55))
-- **Go to file (`f`).** Open a fuzzy finder over every file in the tree and jump straight to one by
-  name: type to filter, `↑` / `↓` to move, `Enter` to open, `Esc` to cancel; `←` / `→` (or the
-  horizontal wheel) scroll long result rows, and the result list has a draggable scrollbar.
-  Read-only navigation; it never modifies a file. ([#51](https://github.com/smarzban/herdr-file-viewer/pull/51))
-- **Help overlay (`?`).** Press `?` (Shift+`/`) to open a view-only overlay with two sections:
-  **What's New** (the changelog rendered as markdown so you can read release notes without leaving
-  the viewer) and **About** (version, repository URL, license, and update status). Navigate with
-  `↑` / `↓` (or the mouse wheel); `Esc` or `q` closes the overlay and returns to where you were.
-  Read-only; no files are modified. ([#56](https://github.com/smarzban/herdr-file-viewer/pull/56))
-- **The tree names its root and branch.** The tree column's top border shows the root directory's
-  name and its bottom border the current git branch (omitted outside a git repo / on a detached
-  HEAD), with long names middle-ellipsized to fit, so you can always see *which* directory and
-  branch you're viewing. ([#52](https://github.com/smarzban/herdr-file-viewer/pull/52))
+- Go to line (`:`): jump the content pane to a source line by number. → [usage](docs/usage.md)
+- Search in file (`/`, `n`/`N`): smartcase, works in every view. → [usage](docs/usage.md)
+- Go to file (`f`): fuzzy-find any file in the tree. → [usage](docs/usage.md)
+- Help overlay (`?`): What's New + About.
+- The tree names its root (top border) and branch (bottom border).
 
 ### Changed
-- **Installing now reuses the latest released binary even when `main` is ahead of the tag.** The
-  install step (`scripts/fetch-or-build.sh`) matches the prebuilt by **version** rather than by exact
-  commit, so landing a PR no longer forces new users to compile while a release is pending; they get
-  the last released, SHA-256-verified binary instead. A version with no published release still falls
-  back to building from source, and when the checkout is ahead of the release it's installing, the
-  install prints a note saying the binary doesn't yet include the unreleased source.
-  ([#50](https://github.com/smarzban/herdr-file-viewer/pull/50))
+- Install reuses the latest released binary even when `main` is ahead of the tag (matches by version, not commit). → [install](docs/install.md)
 
 ### Fixed
-- **The worktree picker's `←` now responds immediately after over-scrolling right.** The picker's
-  horizontal scroll offset is clamped to the measured maximum each frame (mirroring the file
-  finder), so it can't park past the widest row and swallow the first few `←` presses. ([#52](https://github.com/smarzban/herdr-file-viewer/pull/52))
+- The worktree picker's `←` responds immediately after over-scrolling right.
 
 ## [1.5.0] - 2026-06-25
 
 ### Added
-- **Scrollbars** appear on the tree and content panes whenever there's more to see than fits: a
-  vertical bar when the list or file is taller than the pane, and a horizontal bar when a row /
-  unwrapped line is wider than the pane. They show only where there is something to scroll. The
-  bars render **inside** the pane (one cell off the text) and are **draggable with the mouse**:
-  drag a vertical bar ↕ or a horizontal bar ↔ to scroll, and pressing the track jumps to that
-  position. Dragging the tree's vertical bar scrubs the selection through the file list.
-- **The tree scrolls horizontally** so a long or deeply-nested file name can be read in full, via
-  the horizontal mouse wheel or by dragging the tree's horizontal scrollbar (the `←`/`→` keys stay
-  expand/collapse in the tree).
-- **Hide hidden files (`.`).** A toggle that drops dot-prefixed files and folders from the tree,
-  handy when you open a directory (like `$HOME`) that's flooded with them. It's independent of the
-  gitignore toggle (`i`) and off by default, so `.gitignore` / `.github` stay visible until you ask
-  to hide them. ([#46](https://github.com/smarzban/herdr-file-viewer/issues/46))
+- Scrollbars on the tree and content panes (draggable; press the track to jump).
+- The tree scrolls horizontally (horizontal wheel or scrollbar drag) to read long names.
+- Hide hidden files (`.`): drop dot-prefixed entries, independent of the gitignore toggle. Thanks @julianduque (#46).
 
 ### Fixed
-- **The tree now scrolls to follow the selection.** On a long file list the tree stayed pinned to
-  the top, so moving the cursor past the last visible row selected files you couldn't see. The tree
-  now scrolls to keep the selected row in view (mouse clicks still map to the right row when
-  scrolled). ([#45](https://github.com/smarzban/herdr-file-viewer/issues/45))
+- The tree scrolls to follow the selection on long file lists. Thanks @julianduque (#45).
 
 ## [1.4.0] - 2026-06-25
 
 ### Added
-- **Switch worktree (`W`).** Press `W` to open a picker of the repository's git worktrees and
-  select one to re-root the viewer in place: the tree, git status, and content pane all rebuild
-  around the chosen worktree without relaunching the plugin. Your view preferences carry over and
-  navigation resets to the new root. It is purely a change of *where you're looking*: read-only, no
-  branch is checked out, and nothing on disk is modified.
-- The picker marks the worktree you're currently viewing and pre-selects the one where a herdr
-  agent is active, so you can jump straight to what an agent is working on.
-- Each picker row shows the worktree's branch (or a detached-HEAD marker) and, when herdr reports
-  it, the live status of the agent running there.
+- Switch worktree (`W`): re-root the viewer at another git worktree in place (read-only, no checkout). The picker marks the current worktree, pre-selects the one with an active herdr agent, and shows each branch + agent status. Thanks @mitralone (#40). → [usage](docs/usage.md)
 
 ### Changed
-- All notices shown in the viewer's notice strip are now stripped of control characters at the
-  render sink (previously only the copied-path confirmation was), so any filesystem-derived string
-  surfaced in a notice, such as a worktree path, cannot emit a terminal escape or paste-inject.
+- All notice-strip messages are now stripped of control characters at the render sink.
 
 ## [1.3.0] - 2026-06-24
 
 ### Added
-- **Copy a file's path to the clipboard.** `y` copies the selected file's repo-relative path
-  (e.g. `src/app.rs`); `Y` copies its absolute path. The copy uses the terminal's OSC 52
-  clipboard escape, so it travels through herdr and SSH to your real clipboard with no extra
-  tooling, and a confirmation shows in the notices strip. Read-only. Like every other key, it
-  never touches the file's contents.
+- Copy a file's path: `y` (repo-relative) / `Y` (absolute), over OSC 52. Thanks @riclib (#37, #38). → [keys](docs/keys.md)
 
 ### Security
-- The copied path and its confirmation notice are stripped of control characters, so a
-  maliciously-named file (e.g. one with an embedded newline or escape byte) can't paste-inject
-  into a shell or emit a terminal escape when its path is copied, consistent with how the viewer
-  already sanitizes other filesystem-derived strings it displays.
+- The copied path and its notice are stripped of control characters, so a maliciously-named file can't paste-inject or emit a terminal escape.
 
 ## [1.2.2] - 2026-06-23
 
-### Docs
-- Slimmed the README to the essentials (pitch, quick start, keys, links) and moved the longer
-  guides into dedicated files: `docs/install.md` (install & updating), `docs/renderers.md`
-  (the optional `glow`/`delta`/`bat` integrations), and `docs/usage.md` (summoning & keybindings).
-- Added a **Roadmap** section (in-app help overlay, settings, go-to-file) and an invitation to
-  open issues for bugs and feature requests.
-- Documented `$EDITOR` setup for the `e` key: the editor is read from the herdr **server's**
-  environment, so export it in the right shell startup file and restart the server
-  (`herdr server stop` + relaunch). `reload-config` and quitting the client are not enough.
-- Added a rendered-markdown screenshot to the README; trimmed `SECURITY.md` to the GitHub private
-  advisory channel.
-
-This is a docs-only release; the binary is unchanged from 1.2.1 in behavior. It is re-tagged so a
-normal `herdr plugin install` uses the prebuilt fast path again instead of building from source.
+### Changed
+- Docs-only re-tag (binary unchanged from 1.2.1): slimmed the README and moved the longer guides into `docs/`, documented `$EDITOR` setup for `e`, added a rendered-markdown screenshot, and trimmed `SECURITY.md`.
 
 ## [1.2.1] - 2026-06-23
 
 ### Fixed
-- Prebuilt install path now works for a normal `herdr plugin install`. v1.2.0 gated the prebuilt on
-  a local `v<version>` tag ref, but herdr's install checkout clones the commit *without* tags, so the
-  gate always fell back to a source build (failing when Rust was absent). The gate now compares the
-  checkout's `HEAD` to a `COMMIT` marker published in the release, so the prebuilt is used whenever
-  the source is exactly the released commit, while a `main` ahead of the tag still builds from source.
+- Prebuilt install path now works for a normal `herdr plugin install`: the gate compares `HEAD` to a published `COMMIT` marker instead of a local tag (which the install checkout lacks).
 
 ## [1.2.0] - 2026-06-23
 
 ### Added
-- Prebuilt-binary install path: tagged releases now ship SHA-256-verified binaries for macOS
-  (arm64 + x86_64) and Linux x86_64 (static/musl). The install step downloads the binary matching
-  the source's version + platform and falls back to a `cargo` source build on any miss, so no Rust
-  toolchain is needed for supported platforms. The install command is unchanged.
+- Prebuilt-binary install: tagged releases ship SHA-256-verified binaries for macOS (arm64 + x86_64) and Linux x86_64, so no Rust toolchain is needed on supported platforms (source build on any miss). → [install](docs/install.md)
 
 ## [1.1.0] - 2026-06-22
 
 ### Added
-- **Update-available notification**: the viewer checks for a newer release (at most once per
-  day, off the UI thread, over a read-only `git ls-remote`) and, when you're behind, shows a
-  dismissable bottom status-line banner with the one-line update command. Press `u` to dismiss
-  it for the session. Opt out entirely with `HERDR_FILE_VIEWER_NO_UPDATE_CHECK=1`. No new
-  dependencies, no telemetry.
+- Update-available notification: a once-a-day check (read-only `git ls-remote`, off the UI thread) shows a dismissable banner when you're behind; `u` dismisses it, `HERDR_FILE_VIEWER_NO_UPDATE_CHECK` opts out. → [install](docs/install.md)
 
-### Docs
-- Clarified updating: re-running `herdr plugin install …` pulls the latest; `--ref` only pins a
-  specific version and is no longer presented as part of the normal install.
+### Changed
+- Clarified updating: re-running `herdr plugin install …` pulls the latest; `--ref` only pins a version.
 
 ## [1.0.0] - 2026-06-22
 
 First public release: a git-aware, read-only file viewer that runs as a herdr plugin pane.
 
 ### Added
-- **Tree, scoped to your work**: rooted at the git worktree top-level (else the launch
-  directory), honoring `.gitignore` with a toggle to reveal ignored files.
-- **Git woven in**: per-file status markers (`M`/`A`/`D`/`?`) with color, a changed-files-only
-  filter, and a baseline you can toggle between your branch's merge-base and `HEAD`.
-- **The right view per file**: a changed file shows its diff; markdown renders; everything else
-  is syntax-highlighted with line numbers. Cycle the view (`v`), including a **full-file diff**
-  (whole file + line numbers + inline change).
-- **Navigable content**: scroll all four directions, toggle line wrapping (`w`), resize the
-  split (`<` / `>`), and **zoom** (`z`) to hide the tree for a full-screen read.
-- **Activate** (`Enter` / double-click): expand a folder, or open a file in zoom mode.
-- **Open in `$EDITOR`** (`e`): a read-only hand-off; the viewer never edits the file itself.
-- **Keyboard-first**, with additive mouse support (click, double-click, wheel, divider drag).
-- **Two ways to summon it**: a split-pane action and an idempotent tab action
-  (open-or-switch-or-toggle).
-- **Delegated rendering** to `glow` / `delta` / `bat`, each optional with graceful plain-text
-  fallback and a notice when a renderer is absent.
-- **Refresh** (`r`) and automatic git re-read on focus-gain, so external changes (a merge, pull,
-  or commit elsewhere) show up.
+- Tree scoped to your work: rooted at the git worktree top-level (else the launch dir), `.gitignore`-aware with a reveal toggle.
+- Git woven in: per-file `M`/`A`/`D`/`?` status markers, a changed-files-only filter, and a baseline toggle (merge-base ⇄ `HEAD`).
+- The right view per file: diff for a changed file, rendered markdown, else syntax-highlighted content; cycle with `v` (incl. a full-file diff).
+- Navigable content: scroll all directions, wrap (`w`), resize the split (`<`/`>`), zoom (`z`).
+- Open in `$EDITOR` (`e`): a read-only hand-off.
+- Two ways to summon it: a split action and an idempotent tab action. → [summoning](docs/summoning.md)
+- Delegated rendering to `glow` / `delta` / `bat`, each optional with a plain-text fallback. → [renderers](docs/renderers.md)
+- Refresh (`r`) and automatic git re-read on focus-gain.
 
 ### Security
-- Read-only by construction; untrusted file content is escape-neutralized and fed to renderers
-  on stdin; every `git` invocation is hardened for untrusted repositories. See
-  [SECURITY.md](SECURITY.md).
+- Read-only by construction; untrusted content is escape-neutralized and fed to renderers on stdin; every `git` invocation is hardened for untrusted repos. See [SECURITY.md](SECURITY.md).
 
-[1.0.0]: https://github.com/smarzban/herdr-file-viewer/releases/tag/v1.0.0
-[1.1.0]: https://github.com/smarzban/herdr-file-viewer/releases/tag/v1.1.0
-[1.2.0]: https://github.com/smarzban/herdr-file-viewer/releases/tag/v1.2.0
-[1.2.1]: https://github.com/smarzban/herdr-file-viewer/releases/tag/v1.2.1
-[1.2.2]: https://github.com/smarzban/herdr-file-viewer/releases/tag/v1.2.2
-[1.3.0]: https://github.com/smarzban/herdr-file-viewer/releases/tag/v1.3.0
-[1.4.0]: https://github.com/smarzban/herdr-file-viewer/releases/tag/v1.4.0
-[1.5.0]: https://github.com/smarzban/herdr-file-viewer/releases/tag/v1.5.0
-[1.6.0]: https://github.com/smarzban/herdr-file-viewer/releases/tag/v1.6.0
+[Unreleased]: https://github.com/smarzban/herdr-file-viewer/compare/v1.11.0...HEAD
+[1.11.0]: https://github.com/smarzban/herdr-file-viewer/releases/tag/v1.11.0
+[1.10.0]: https://github.com/smarzban/herdr-file-viewer/releases/tag/v1.10.0
+[1.9.0]: https://github.com/smarzban/herdr-file-viewer/releases/tag/v1.9.0
+[1.8.0]: https://github.com/smarzban/herdr-file-viewer/releases/tag/v1.8.0
 [1.7.0]: https://github.com/smarzban/herdr-file-viewer/releases/tag/v1.7.0
+[1.6.0]: https://github.com/smarzban/herdr-file-viewer/releases/tag/v1.6.0
+[1.5.0]: https://github.com/smarzban/herdr-file-viewer/releases/tag/v1.5.0
+[1.4.0]: https://github.com/smarzban/herdr-file-viewer/releases/tag/v1.4.0
+[1.3.0]: https://github.com/smarzban/herdr-file-viewer/releases/tag/v1.3.0
+[1.2.2]: https://github.com/smarzban/herdr-file-viewer/releases/tag/v1.2.2
+[1.2.1]: https://github.com/smarzban/herdr-file-viewer/releases/tag/v1.2.1
+[1.2.0]: https://github.com/smarzban/herdr-file-viewer/releases/tag/v1.2.0
+[1.1.0]: https://github.com/smarzban/herdr-file-viewer/releases/tag/v1.1.0
+[1.0.0]: https://github.com/smarzban/herdr-file-viewer/releases/tag/v1.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,49 @@
+# Contributing
+
+Thanks for your interest in herdr-file-viewer! Bug reports, feature requests, and pull requests are
+all welcome.
+
+## Reporting bugs & requesting features
+
+[Open an issue](https://github.com/smarzban/herdr-file-viewer/issues) — there are templates for a
+**bug report** and a **feature request**. For a bug, the plugin version (`?` overlay → About) and
+your herdr version help a lot.
+
+## Development setup
+
+Requirements: **Rust 1.96+** (edition 2024) and **git** on `PATH`. The renderers (`glow` / `delta` /
+`bat`) are optional at runtime and not needed to build or test.
+
+```bash
+cargo test                 # unit + integration + e2e (pty) tests
+cargo build --release      # what herdr's [[build]] step runs at install time
+cargo run                  # run the viewer locally, outside herdr
+```
+
+Keep the deterministic tier green — CI enforces it:
+
+```bash
+cargo fmt --all --check
+cargo clippy --all-targets -- -D warnings
+cargo audit
+```
+
+The e2e tests drive the real binary over a pseudo-terminal; they stub the editor via `$EDITOR` and
+run in temporary directories, so they need neither glow/delta/bat nor a live herdr.
+
+## Making a change
+
+- **`main` is protected.** Open a PR; CI must be green (rustfmt + clippy, the test matrix on
+  Ubuntu/macOS × Rust 1.96/stable, and `cargo audit`). PRs are squash-merged.
+- **Commit convention: [Conventional Commits](https://www.conventionalcommits.org/)** — `feat:`,
+  `fix:`, `chore:`, `test:`, `docs:`, as in the git log.
+- **Docs are part of done.** A user-facing change updates the docs in the *same* PR: a `CHANGELOG.md`
+  entry, plus the relevant page(s) — the [keys reference](docs/keys.md), the
+  [usage guide](docs/usage.md), or [configuration](docs/configuration.md).
+- **Read-only by design.** The viewer never mutates files or git state (see `constitution.md`); any
+  write capability is an explicit, opt-in exception, never a default.
+
+## More
+
+`AGENTS.md` is the full cross-agent contributor guide (build/test/verify workflow, conventions, and
+the release process). The [`docs/`](docs/README.md) tree holds the user-facing documentation.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ A taste of what the keys do — the [full key & mouse reference](docs/keys.md) h
 | `W` | Switch to another git worktree, in place |
 | `L` | Copy a `path:line` reference (or the selected lines) to your clipboard |
 | `Z` | Full-screen the current file |
-| `e` / `O` / `R` | Hand off: open in `$EDITOR` / the OS default app / the file manager |
+| `e` / `O` / `R` | Hand off: open in your editor / the OS default app / the file manager |
 | `?` | Help overlay: keys, what's new, settings, about |
 
 ## Quick start

--- a/README.md
+++ b/README.md
@@ -18,19 +18,13 @@ right into the tree. It opens beside whatever you're doing and never touches you
 
 ![herdr-file-viewer rendering a markdown file: colored headings and styled inline code on the right, the git-status tree on the left](assets/Markdown-view.png)
 
-*…and running full-screen, the same tree + content, filling the terminal:*
-
-![herdr-file-viewer running full-screen](assets/File-Viewer-FS.png)
-
-<!-- TODO: swap these stills for a short GIF (open → arrow to a changed file (diff) → `v` rendered markdown → `z` zoom). asciinema + agg → gif. -->
-
 ## Why you'd want it
 
 - **The right view, automatically.** Stop `cat`-ing files and squinting at raw diffs. A changed
   file shows its diff; a README renders; code is highlighted: no mode-switching, no commands.
-- **Git at a glance.** `M`/`A`/`D`/`?` markers, colored so changes pop, a changed-files-only
-  filter, and a baseline you can flip between your branch's merge-base and `HEAD`, all in the
-  tree, not a separate mode.
+- **Git at a glance.** `M`/`A`/`D`/`?` markers (colored, with the glyph as a non-color cue), a
+  changed-files-only filter, and a baseline you can flip between your branch's merge-base and
+  `HEAD` — all in the tree, not a separate mode.
 - **It sits beside your work.** Opens in a herdr split (or its own tab) with one keypress, and
   toggles away just as fast. Great next to an agent, a build, or an editor.
 - **Safe on anything.** Read-only by construction and hardened to open *untrusted* repos (an
@@ -39,52 +33,21 @@ right into the tree. It opens beside whatever you're doing and never touches you
 - **Keyboard-first**, mouse-optional, and it never reinvents rendering: it delegates to
   `glow` / `delta` / `bat` and degrades gracefully when they're absent.
 
-## What it does
+## Highlights
 
-- **Tree, scoped to your work**: rooted at the worktree root inside a git repo, else the
-  launch directory. Honors `.gitignore` (toggle to reveal ignored files), and a separate toggle
-  (`.`) hides dot-prefixed "hidden" files when a directory is full of them. The tree's top border
-  names the root directory and its bottom border shows the current branch, so you always know
-  *where* and *on what branch* you're looking.
-- **Jump to any file**: press `f` to open a fuzzy finder over every file in the tree
-  (`.gitignore`-aware); type to filter, `↑` / `↓` to move, and `Enter` to open, far faster than
-  scrolling the tree in a large repo.
-- **Go to a line**: press `:` and type a line number to jump the content pane straight there;
-  in a rendered-markdown or diff view it switches to the line-numbered content view to make the
-  jump. Out-of-range clamps to the last line.
-- **Search in a file**: press `/` to search the open file's content: every match highlights as
-  you type, `Enter` commits, and `n` / `N` cycle through matches (wrapping at the ends). Smartcase (
-  a lowercase query matches any case, add a capital to go case-sensitive) and it works in every
-  view (code, markdown, or diff); `Esc` clears it.
-- **Switch worktree on the fly**: press `W` to re-root the viewer at another git worktree of
-  the repo without relaunching; it pre-selects the worktree a herdr agent is working in, so you
-  can jump straight to it. Read-only: it changes only *what you're viewing*, never the branch
-  or any files.
-- **In-app help**: press `?` to open a view-only help overlay showing What's New (the latest
-  changelog entries, rendered as markdown) and About (version, repo, license, and update status).
-  Keyboard and mouse; `Esc` or `q` closes it. A `? help` hint rides the content pane's bottom
-  border so the overlay is discoverable without already knowing the key.
-- **Make the keys yours**: remap any global key with a `[keys]` table in the
-  [config file](#configuration), keyed by intent name (a single key or a list); the `?` overlay's
-  **Keybindings** section is a live reference of every action's effective keys. `Esc` always
-  closes, so a remap can never lock you out.
-- **Git woven in**: per-file status markers (`M`/`A`/`D`/`?`), and a `●` on a directory that
-  contains any change; **colored** so changes read at a glance (changed files and dirty folders
-  are red, new files green), with the glyph as a non-color cue so it survives a colorblind palette
-  or a non-default theme. A changed-files-only filter; and a baseline you can switch between the
-  merge-base of your branch and `HEAD`.
-- **The right view per file**: a changed file shows its **diff**; a markdown file renders;
-  anything else is shown as syntax-highlighted content with line numbers. Cycle the view
-  (`v`) to override. A changed file can also show a **full-file diff**: the whole file with
-  line numbers and the diff shown inline.
-- **Navigable content**: scroll the content pane in all four directions, toggle line
-  wrapping, resize the tree/content split, or zoom (`z`) to hide the tree and read a file
-  full-screen; the layout reflows when the pane is resized. The tree scrolls to keep the
-  selection in view (and sideways, for long names), and a scrollbar appears on the tree or
-  content pane whenever there is more to see than fits. Drag it with the mouse to scroll.
-- **Keyboard-first**: every function has a key; no mouse required. The tree's horizontal
-  scroll (for long / deeply-nested rows) is reachable with `H` / `L`, the same way the content
-  pane scrolls with `←` / `→` when focused.
+A taste of what the keys do — the [full key & mouse reference](docs/keys.md) has them all, and the
+[usage guide](docs/usage.md) walks through each feature:
+
+| Key | Does |
+| --- | --- |
+| `f` | Fuzzy-find any file in the tree |
+| `v` | Cycle the view (diff ⇄ rendered ⇄ syntax) |
+| `b` | Flip the diff baseline: your branch's merge-base ⇄ `HEAD` |
+| `W` | Switch to another git worktree, in place |
+| `L` | Copy a `path:line` reference (or the selected lines) to your clipboard |
+| `Z` | Full-screen the current file |
+| `e` / `O` / `R` | Hand off: open in `$EDITOR` / the OS default app / the file manager |
+| `?` | Help overlay: keys, what's new, settings, about |
 
 ## Quick start
 
@@ -113,332 +76,48 @@ command = "herdr plugin action invoke open-file-viewer-tab --plugin herdr-file-v
 
 Run `herdr server reload-config`, then press your key. That's the whole setup: the split-pane
 viewer and its open actions ship **inside** the plugin and register automatically on install, so
-you only add the keybinding. The [keys](#keys) are below; deeper detail lives in the docs:
-[install & updating](docs/install.md), [external renderers](docs/renderers.md), and
-[summoning & keybindings](docs/usage.md).
+you only add the keybinding.
 
-## Windows (preview)
-
-Native Windows (`x86_64-pc-windows-msvc`) is supported as a **preview**, mirroring herdr's own
-posture there: the crate builds, the test suite runs (advisory) on `windows-latest` CI, and
-install works the same way as Linux/macOS: `herdr plugin install` downloads a SHA-256-verified
-prebuilt binary (via `scripts/fetch-or-build.ps1`) or falls back to `cargo build --release`, no
-extra tooling required beyond the in-box Windows PowerShell 5.1. The open/toggle actions work via
-PowerShell launcher scripts.
-
-- **On Windows, bind the `-windows` action ids.** herdr requires every action id to be unique, so
-  the Windows launchers register as **`open-file-viewer-windows`** and
-  **`open-file-viewer-tab-windows`** (the unqualified `open-file-viewer` / `open-file-viewer-tab`
-  ids are the Linux/macOS variants). Point your herdr keybinding at the `-windows` id:
-  `command = "herdr plugin action invoke open-file-viewer-windows --plugin herdr-file-viewer"`.
-- **A `prefix+f` keybinding needs herdr v0.7.2 or newer.** herdr runs custom-command
-  (`[[keys.command]]`) keybindings through the platform shell; before v0.7.2 that was `/bin/sh`,
-  absent on Windows, so the binding silently did nothing there. herdr **v0.7.2** runs them through
-  `cmd.exe /d /c`, so the `prefix+f` binding above fires normally. On older herdr, summon the viewer
-  by invoking the action **directly** (`herdr plugin action invoke open-file-viewer-windows
-  --plugin herdr-file-viewer` from a shell, or via herdr's action menu) rather than through a
-  keybinding.
-- **Requires herdr's preview channel.** Windows herdr binaries ship only on herdr's pre-release
-  update channel, so you need to be on it before installing this plugin on Windows.
-- **Preview means best-effort, not a parity guarantee.** There's no Windows host in this
-  project's CI gate (the `windows-latest` job is advisory, not required), so a Windows-specific
-  regression can land between releases. Full feature parity with Linux/macOS is the goal, not a
-  promise. Please [open an issue](https://github.com/smarzban/herdr-file-viewer/issues) if you
-  hit a Windows-specific problem.
-- **WSL works today, with zero extra setup.** If you'd rather not wait on native-Windows preview
-  maturity, the existing Linux (`x86_64-unknown-linux-musl`) binary already runs unmodified
-  inside WSL. Install herdr and this plugin from within your WSL distro exactly as you would on
-  native Linux.
-
-## Keys
-
-| Key | Action |
-| --- | --- |
-| `↑` / `k`, `↓` / `j` | Move the tree cursor, or **scroll the content pane** vertically when it is focused |
-| `→` / `l` | Expand the selected directory, or **scroll the content pane right** when it is focused |
-| `←` / `h` | Collapse the selected directory, or **scroll the content pane left** when it is focused |
-| `H` (Shift+`h`) | Scroll the **tree** pane left (long / deeply-nested rows), inert unless the tree is focused |
-| `L` (Shift+`l`) | Focus-gated: with the **tree** focused, scroll it right (long / deeply-nested rows); with the **content pane** focused (or zoomed), enter **line-select mode** to select lines and copy either a `file:line` reference or the content itself (see below) |
-| _line-select mode_ | `j`/`k` (or `↑`/`↓`) move the marker, `Shift`+move (`J`/`K`, Shift+`↑`/`↓`) extends a line selection; **click-drag** with the mouse selects **text** (character-granular); `Enter` copies the `path:line` / `path:start-end` **reference**, `y`/`Y` copies the selected **content**, `Esc` exits |
-| `Enter` | Activate the selection: expand/collapse a directory, or open a file in **zoom mode** (content full-screen) |
-| `i` | Toggle gitignored files |
-| `.` | Toggle hidden (dot-prefixed) files and folders |
-| `c` | Toggle changed-files-only |
-| `b` | Toggle the diff baseline (base branch ⇄ `HEAD`) |
-| `v` | Cycle the content view mode |
-| `e` | Open the selected file in `$EDITOR` |
-| `O` (Shift+`o`) | **Open with default app**: hand the selected file or directory to the OS default application (e.g. an image opens in the system viewer). Read-only hand-off; non-blocking (the viewer keeps running) |
-| `R` (Shift+`r`) | **Reveal in file manager**: open the OS file manager (Finder / Explorer / a Linux file manager) with the selected entry highlighted where supported, so you can drag it out (e.g. into Slack). Read-only hand-off |
-| `f` | **Go to file**: open a fuzzy finder over every file in the tree; type to filter, `↑` / `↓` move, `Enter` opens the selected file, `Esc` cancels (`←` / `→` scroll long paths) |
-| `:` | **Go to line**: open a prompt and jump the content pane to a source line by number (`Enter` jumps, `Esc` cancels; out-of-range clamps to the last line). Works in any view; in a rendered-markdown or diff view, confirming switches to the line-numbered content view and jumps there |
-| `/` | **Search in file**: open a prompt and highlight every match in the content pane as you type; `Enter` commits the search (highlights persist), `Esc` clears it and restores the scroll. Smartcase (a lowercase query is case-insensitive; a capital makes it case-sensitive). Works in any view |
-| `n` / `N` (Shift+`n`) | After a committed search, jump to the **next** / **previous** match and scroll it into view, wrapping at the ends with a notice |
-| `y` | Copy the selected file's **repo-relative** path to the clipboard (e.g. `src/app.rs`) |
-| `Y` | Copy the selected file's **absolute** path to the clipboard |
-| `Tab` | Move focus between the tree and content columns |
-| `<` / `>` | Narrow / widen the tree column (move the divider) |
-| `w` | Toggle line wrapping for the content pane. For rendered markdown this switches between the fit-to-pane view (wide tables sized to fit, over-long cells shown as `…`) and a wide view that renders tables at full width and scrolls horizontally (`←`/`→`) so you can read every cell |
-| `z` | Zoom: hide the tree so the content pane fills the frame; press again (or `q`/`Esc`) to restore the two-column layout |
-| `Z` (Shift+`z`) | **Full-screen a file** (toggle): open the selected file like `Enter` _and_ zoom the viewer's herdr pane to fill the whole terminal, so the file takes over the entire screen instead of just the split. Press `Z` again (or `Esc`/`q`, or `z`) to return to the normal two-column split; switching worktree or quitting also restores the pane. On a directory it just expands/collapses like `Enter`; falls back to the in-pane zoom when the host isn't herdr |
-| `r` | Refresh git state: pick up changes made outside the viewer (a merge / pull / commit elsewhere) |
-| `W` (Shift+`w`) | **Switch worktree**: open a picker of the repo's git worktrees and re-root the viewer to the one you pick (read-only; no branch checkout). Marks the current worktree and pre-selects the one with an active herdr agent; `↑`/`↓` move, `←`/`→` scroll long paths, `Enter` switches, `Esc` cancels |
-| `?` (Shift+`/`) | Open the **help overlay**: What's New (latest changelog, rendered markdown) + About (version, repo, license, update status); `Esc` / `q` closes it |
-| `u` | Dismiss the "update available" banner for this session |
-| `q` / `Esc` | Back out of zoom if zoomed; otherwise close the viewer and return to the prior pane |
-
-These are the **default** keys. Remap any of them with a `[keys]` table in the
-[config file](#configuration) (see [Keybindings](#keybindings) below).
-
-`Tab` to the content pane, then the arrow keys (or `h`/`j`/`k`/`l`) scroll it in all four
-directions; `Tab` back to the tree to move between files. Long lines wrap in prose (markdown /
-plain text); diffs and code keep their original lines so columns stay aligned. Scroll
-sideways with `←`/`→`, or press `w` to wrap them instead. Rendered markdown fits the pane by
-default (wide tables sized to fit, over-long cells shown as `…`); press `w` for a wide view that
-renders tables at full width and scrolls sideways so you can read every cell. The layout reflows
-automatically when the pane is resized.
-
-**Git state stays current.** The viewer re-reads git status when the pane **regains focus**, so
-changes you make outside it (a merge, pull, or commit in another pane) show up automatically; `r`
-forces a full refresh on demand. (Focus-refresh updates the tree's status without disturbing your
-content scroll.)
-
-Character keys act only when no control chord is held (so terminal chords like `Ctrl+C` are
-never intercepted); `Shift` is permitted, for keys such as `<` and `>` (and `y`/`Y`, `W`, `N`,
-`O`, `R`, `Z`, `?`, `H`/`L`, and `J`/`K` in line-select mode).
-
-**Copy a path (`y` / `Y`).** `y` copies the selected file's repo-relative path; `Y` copies its
-absolute path, handy for pasting into a prompt, a command, or an agent. The copy uses the
-terminal's **OSC 52** clipboard escape, so it travels through herdr (and SSH) to your real
-clipboard with no extra tooling. A confirmation appears in the notices strip. If nothing lands
-on your clipboard, your terminal likely needs OSC 52 / clipboard-write enabled (e.g. in tmux,
-`set -g set-clipboard on`).
-
-**Copy a line reference or line content (`L`).** With the content pane focused (or zoomed), `L`
-enters **line-select mode**: a marker lands on the top visible line, `j`/`k` (or `↑`/`↓`) move it,
-and holding `Shift` (`J`/`K`, or Shift+`↑`/`↓`) extends a whole-line selection. Or **click-drag
-with the mouse** to select **text** character-by-character: press where the selection starts,
-drag to where it ends (the pane scrolls if you drag past an edge), release; the selected
-characters are highlighted as you go. One selection, two products:
-
-- **`Enter` copies a repo-relative reference**: `src/app.rs:42` for a single line,
-  `src/app.rs:42-58` for a range (a mouse selection references the lines it spans), ready to
-  paste into an agent chat or an issue to point at exact lines.
-- **`y` / `Y` copy the content itself**: for a line selection, the lines joined by newlines; for
-  a mouse text selection, exactly the characters you dragged over. The syntax view's line-number
-  gutter is stripped and indentation is preserved, so it pastes as real code.
-
-A confirmation notice names what was copied. Both copies use the same **OSC 52** path as the
-tree's `y`/`Y`. `Esc` leaves the mode.
-
-`Shift`+mouse is deliberately left alone so your terminal's own native selection/copy still works:
-most terminals reserve `Shift`+drag for exactly that. Selection works in wrapped views too (the
-`w` toggle): the click maps through the same wrapping the pane draws with, so the caret lands on
-the character under the cursor. Because selection only maps onto the source, entering line-select
-from a rendered-markdown or diff view first switches that file to the line-numbered content view. With the **tree** focused, `L` keeps its tree horizontal-scroll
-behavior instead. The mode is gated on which pane has focus.
-
-### Mouse
-
-The viewer is keyboard-first; the mouse is additive and on by default:
-
-| Gesture | Action |
-| --- | --- |
-| **Click** a tree row | Select it (focus the tree) |
-| **Double-click** a folder | Expand / collapse it (same as `Enter`) |
-| **Double-click** a file | Open it in **zoom mode**: content full-screen (same as `Enter`); the editor is the `e` key |
-| **Wheel** over the content pane | Scroll it vertically; over the tree, move the selection |
-| **Horizontal wheel / swipe** | Scroll the content, or the tree, sideways (terminal-dependent, see below) |
-| **Drag** a scrollbar | Scroll that pane: drag ↕ on a vertical bar, ↔ on a horizontal bar; pressing the track jumps there |
-| **Drag** the divider | Resize the tree / content split |
-| **Drag** over the content text | **Select and copy text**: the selection highlights character-by-character as you drag (auto-scrolling past an edge) and is copied to the clipboard on release; no mode needed. Works in wrapped views (prose/markdown) too. `Esc`, a click elsewhere, or switching files clears the highlight |
-
-**`Shift`+drag is left to your terminal**, so its native select-and-copy still works while the
-viewer owns ordinary clicks: herdr reserves `Shift`+mouse for exactly this. (herdr forwards
-mouse events to the pane because the viewer requests capture.)
-
-**Horizontal mouse scroll is terminal-dependent**: it works only where your terminal emits
-horizontal-scroll events (`ScrollLeft` / `ScrollRight`); many terminals send nothing for a
-sideways trackpad swipe. The `←` / `→` keys always scroll the content sideways, and `H` / `L`
-always scroll the tree sideways, regardless of terminal.
-
-### Opening in an editor
-
-`e` hands the selected file to the editor named by the **`$EDITOR`** environment variable
-(e.g. `vim`, or `"code --wait"` for editors that fork). The viewer suspends, runs the editor,
-and resumes when it exits. If `$EDITOR` is unset, a notice is shown. The viewer never edits a
-file itself.
-
-**`e` does nothing, or says "no editor configured"?** The viewer reads `$EDITOR` from the
-**herdr server's** environment (the server spawns every pane), *not* from the shell you happen to
-be attached from. So if `$EDITOR` is set in your interactive shell but the server was started
-without it (common with `mosh`, `systemd`, or any login manager that doesn't source your shell
-startup files), the viewer won't see it. To fix it:
-
-1. **Export `$EDITOR` in the startup file your server's launch actually reads.** Pick the line(s)
-   that match how herdr starts on your machine:
-
-   ```bash
-   # zsh: interactive shells read ~/.zshrc; ~/.zshenv is read by *every* zsh invocation
-   echo 'export EDITOR=vim' >> ~/.zshrc
-
-   # bash: add to both, so interactive and login shells agree
-   echo 'export EDITOR=vim' >> ~/.bashrc
-   echo 'export EDITOR=vim' >> ~/.profile
-
-   # mosh / `sh -lc` / any POSIX login-shell launch (e.g. herdr started over SSH+mosh)
-   echo 'export EDITOR=vim' >> ~/.profile
-   ```
-
-   If you're unsure which applies, adding it to **`~/.profile`** covers the login-shell launch
-   paths; keep it in your shell's rc too for interactive use.
-
-2. **Restart the herdr server** so it re-reads the environment: `reload-config` and `prefix+q`
-   are **not** enough (the first doesn't re-read env; the second only quits the client and leaves
-   the detached server running with its old environment):
-
-   ```bash
-   herdr server stop   # stops the background daemon: ends all panes, so finish in-flight work first
-   herdr               # relaunch from a shell where `echo $EDITOR` already prints your editor
-   ```
-
-3. **Verify:** open any shell pane *inside* herdr and run `echo $EDITOR`. Once that prints your
-   editor (it was empty before), `e` will open it. (Or set `editor` directly in the
-   [config file](#configuration), which overrides `$EDITOR` — no server env fiddling needed.)
+Deeper detail lives in the docs: [install & updating](docs/install.md),
+[summoning the viewer](docs/summoning.md) (split vs. tab, the launcher, `--remote`),
+[external renderers](docs/renderers.md), and the [keys reference](docs/keys.md).
 
 ## Configuration
 
-An optional TOML config file lets you override the editor, the renderer/opener commands, and a
-couple of startup toggles. **Read-only input** — the viewer never writes this file; edit it in
-your own editor and relaunch to pick up changes (there is no in-app settings editor). You can see
-what's currently in effect any time in the `?` help overlay's **Settings** section.
+An optional, **read-only** TOML config file lets you override the editor, the renderer/opener
+commands, a couple of startup toggles, the tree layout, and the keybindings. A fully-commented
+[`config.example.toml`](config.example.toml) ships in the plugin folder — copy it to the config
+path, rename it to `config.toml`, and uncomment what you want.
 
-**Quick start:** a fully-commented [`config.example.toml`](config.example.toml) ships in the plugin
-folder documenting every setting. Copy it to the config path below, **rename it to `config.toml`**,
-uncomment the lines you want, and relaunch — copying it as-is changes nothing (every line is
-commented out).
+The full reference — file location, precedence, every key, and `[keys]` remapping — is in
+**[docs/configuration.md](docs/configuration.md)**. See your effective settings any time in the `?`
+help overlay's **Settings** section.
 
-**File location:** when run under herdr, the config lives at
-`$HERDR_PLUGIN_CONFIG_DIR/config.toml` — herdr provides that directory (on Linux it resolves to
-`~/.config/herdr/plugins/config/herdr-file-viewer/config.toml`). Run standalone (outside herdr),
-it falls back to `$XDG_CONFIG_HOME/herdr-file-viewer/config.toml`, defaulting to
-`~/.config/herdr-file-viewer/config.toml` when `XDG_CONFIG_HOME` isn't set. A missing file is the
-normal case — every key falls back to its default.
+## Windows
 
-**Precedence:** a config key always wins. Only two keys also have an environment-variable
-fallback tier below the config key and above the built-in default — `editor` (`$EDITOR`) and
-`update_check` (`$HERDR_FILE_VIEWER_NO_UPDATE_CHECK`) — giving those two a `config > env >
-default` chain. Every other key (`markdown`, `diff`, `syntax`, `open`, `reveal`,
-`hide_dotfiles`, `scroll_lines`, `tree_width`, `tree_position`, `tree_max_cols`) has no applicable
-environment variable; for those it's `config > default` only.
-
-```toml
-# ~/.config/herdr-file-viewer/config.toml (or the herdr-provided path above)
-
-editor = "code --wait"      # command to open a file with `e` (overrides $EDITOR)
-
-markdown = "glow -s dark -w 0 -"   # override the markdown / diff / syntax renderers
-diff = "delta"                     # (defaults: glow / delta / bat)
-syntax = "bat --color=always --style=numbers --paging=never --file-name={name} -"
-
-open = "xdg-open"           # override the `O` open-with / `R` reveal-in-file-manager commands
-reveal = "nautilus"
-
-hide_dotfiles = false       # true to hide dotfiles at startup (the `.` key still toggles)
-update_check = true         # false to disable the once-a-day update check
-scroll_lines = 3            # mouse-wheel step (content/search/help), a 1 to 10 scale: 1 slow · 3 medium · 6 fast · 10 max
-tree_width = 30             # tree column's share of the viewer pane, percent 20-80 (content takes the rest)
-tree_position = "left"      # which side the directory tree sits on: "left" (default) or "right"
-tree_max_cols = 30          # cap the tree at this many columns so it stays compact on a wide pane
-```
-
-`tree_width` / `tree_position` set the **startup** tree/content split inside the viewer's own pane
-(not the size of the herdr pane, which the host decides). You can still resize the split live with
-the grow/shrink keys or by dragging the divider; the config just seeds the initial value.
-`tree_max_cols` is a **column** ceiling (not a percent): the tree is drawn at
-`min(tree_width% of the pane, tree_max_cols)`, so a full-terminal tab gives the extra width to the
-content pane instead of a mostly-blank tree. It only bites past ~100 columns, and dragging the
-divider or the grow/shrink keys lifts it (an explicit resize wins); set it high to disable.
-
-Command values (`editor`, `markdown`, `diff`, `syntax`, `open`, `reveal`) are **split into
-arguments** the way a shell would for simple cases — whitespace splits, double-quotes group a
-path with spaces — but **no shell is invoked**. `editor` / `open` / `reveal` get the target
-**path** appended as the final argument; the **renderers** (`markdown` / `diff` / `syntax`)
-instead get the file **content on stdin** and your value **replaces** the whole default command
-(flags aren't merged), so a custom renderer must read stdin (glow and bat need a trailing `-`)
-and set its own flags — the token `{name}` is substituted with the file name.
-
-**Known limitation:** the full-file-diff view derives its line-numbered gutter from the `diff`
-command by appending delta's `--line-numbers` flag; if you point `diff` at a tool that rejects
-that flag (nonzero exit or spawn failure), the full-file-diff view falls all the way back to
-plain, unrendered diff text (with a notice), not just a missing gutter. Renderer timeouts and
-other limits aren't configurable.
-
-### Keybindings
-
-A `[keys]` table remaps the viewer's global keys, keyed by **intent name** (the stable snake_case
-id of an action, e.g. `refresh`, `nav_up`, `switch_worktree`). Each value is a **key spec**: a
-single string, or an array of strings, naming the key(s) that action should answer to. An entry
-**replaces** that action's default key set, so list every key you want it to keep.
-
-```toml
-[keys]
-refresh = "g"               # a single key: `g` refreshes, and the default `r` no longer does
-nav_up = ["w", "Up"]        # an array: bind several keys at once (the default `k` is dropped)
-switch_worktree = "F2"      # a named key
-```
-
-**Bindable keys** are the modifier-free surface the viewer already uses: any printable or shifted
-character (`g`, `<`, `?`, and capitals such as `W` are each their own key), plus the named keys
-`Tab`, `Enter`, `Esc`, the four arrows, `Home`, `End`, `PageUp`, `PageDown`, `Space`, `Backspace`,
-`Delete`, `Insert`, and `F1` through `F12` (named keys are matched case-insensitively). There are
-**no `Ctrl` / `Alt` chords**: a chord never fires a viewer action, so terminal combinations like
-`Ctrl+C` always pass straight through.
-
-**Precedence is `config > default`:** a `[keys]` value replaces the action's built-in keys, and any
-action you don't list keeps its defaults. The load is defensive and never crashes the viewer: an
-unknown intent name, an unbindable key, or two actions claiming the same key is ignored for those
-entries only (their defaults are kept). Invalid TOML in the config (a syntax error, or a wrong-typed
-value such as `refresh = 42`) is the same whole-file fallback the rest of the config uses: the viewer
-ignores the entire file and falls back to built-in defaults, and the `?` overlay flags that the
-config was malformed. Whatever you configure, **`Esc` always closes** the viewer: that floor cannot be rebound away, so
-you can never strand yourself (you may still move the `q` Close key or any other action). Only the
-global keys are remappable; keys handled inside a modal (the finder query, the `:` / `/` prompt,
-line-select mode) keep their own keys.
-
-See your bindings in effect any time in the `?` help overlay's new **Keybindings** section. It
-groups the actions into sections and shows, for each, its config-var name (the `[keys]` id you type
-to remap it), its effective key(s), and its description, marking the ones you have customized.
+Native Windows is supported as a **preview** (install works the same way; the open actions use
+`-windows` action ids and a `prefix+f` keybinding needs herdr v0.7.2+). WSL works today with zero
+extra setup. See [docs/windows.md](docs/windows.md).
 
 ## Documentation
 
-- **[Install & updating](docs/install.md)**: prebuilt vs. source, pinning a version, local-dev linking, and how updates surface (the in-app "update available" banner).
-- **[External renderers](docs/renderers.md)**: the optional `glow` / `delta` / `bat` integrations and the plain-text fallback when they're absent.
-- **[Summoning & keybindings](docs/usage.md)**: the open actions, the idempotent launcher, split vs. tab, and the `--remote` caveat.
-- **[Architecture](ARCHITECTURE.md)**: one in-process TUI owning both columns, the component map, off-thread rendering, and the load-bearing decisions (read-only, delegate rendering, git-first).
-- **[Security](SECURITY.md)**: the threat model and mitigations for opening untrusted content, and how to report a vulnerability.
+Full docs live in **[docs/](docs/README.md)**:
 
-## Roadmap
+- **[Install & updating](docs/install.md)** — prebuilt vs. source, pinning a version, local-dev linking, and the in-app update banner.
+- **[Summoning the viewer](docs/summoning.md)** — the open actions, the idempotent launcher, split vs. tab, and the `--remote` caveat.
+- **[Usage guide](docs/usage.md)** — a feature-by-feature tour of the whole viewer.
+- **[Keys & mouse](docs/keys.md)** — the complete key table, mouse gestures, and editor hand-off.
+- **[Configuration](docs/configuration.md)** — the full `config.toml` reference and `[keys]` remapping.
+- **[External renderers](docs/renderers.md)** — the optional `glow` / `delta` / `bat` integrations and the plain-text fallback.
+- **[Windows (preview)](docs/windows.md)** — native-Windows specifics and WSL.
+- **[Architecture](ARCHITECTURE.md)** — one in-process TUI owning both columns, the component map, and the load-bearing decisions.
+- **[Security](SECURITY.md)** — the threat model for opening untrusted content, and how to report a vulnerability.
 
-A few things on the way:
+## Contributing
 
-- **Themes and layout**: the [config file](#configuration) already covers the editor, renderer, and opener commands, a couple of startup toggles, the default tree/content split and side (`tree_width` / `tree_position`), and [customizable keybindings](#keybindings); a theme is still on the way.
-
-**Hit a bug, or want a feature?** Please [open an issue](https://github.com/smarzban/herdr-file-viewer/issues). Bug reports and feature requests are very welcome.
-
-## Development
-
-This crate is a library (`src/lib.rs` + modules) plus a thin binary (`src/main.rs` →
-`run()`), so the components are unit-testable.
-
-```bash
-cargo test                 # unit + integration + e2e (pty) tests
-cargo build --release      # what herdr's [[build]] step runs
-cargo run                  # run the viewer locally, outside herdr
-```
-
-The e2e tests drive the real binary over a pseudo-terminal; they stub the editor via
-`$EDITOR` and run in temporary directories, so they need neither glow/delta/bat nor a live
-herdr.
+Bug reports and feature requests are very welcome — please
+[open an issue](https://github.com/smarzban/herdr-file-viewer/issues). To build, test, and send a
+change, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -103,7 +103,9 @@
 # id of an action, shown next to every action in the `?` help overlay's
 # Keybindings tab (e.g. refresh, nav_up, switch_worktree). A value is a KEY SPEC:
 # a single string, or an array of strings. An entry REPLACES that action's
-# default key(s), so list every key you want it to answer to.
+# default key(s), so list every key you want it to answer to. The full list of
+# intent names (all 33 actions) is in docs/configuration.md (Keybindings) and the
+# `?` overlay's Keybindings tab.
 #
 # Bindable keys: any single printable or shifted character (`g`, `<`, `?`, and
 # capitals such as `W` are each their own key), plus the named keys Tab, Enter,

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,33 @@
+# Documentation
+
+The full docs for **herdr-file-viewer** — a git-aware, read-only file viewer that runs as a herdr
+TUI pane. New here? Start with the [README](../README.md) for what it is and a quickstart.
+
+## Where to start
+
+- **Just installed it?** → [Summoning the viewer](summoning.md) to bind a key and open it, then the
+  [Usage guide](usage.md).
+- **Want to know a key?** → [Keys & mouse](keys.md).
+- **Customizing it?** → [Configuration](configuration.md).
+- **On Windows?** → [Windows (preview)](windows.md).
+- **Contributing?** → [CONTRIBUTING](../CONTRIBUTING.md).
+
+## Pages
+
+| Page | What's in it |
+| --- | --- |
+| [Install & updating](install.md) | Prebuilt vs. source, pinning a version, local-dev linking, and how updates surface (the in-app "update available" banner). |
+| [Summoning the viewer](summoning.md) | The open actions, the idempotent launcher, split vs. tab, and the `--remote` caveat. |
+| [Usage guide](usage.md) | A feature-by-feature tour: the tree, view modes, git awareness, find/search, copying, hand-offs, worktrees, help. |
+| [Keys & mouse](keys.md) | The complete key table, mouse gestures, and the editor hand-off (`$EDITOR` troubleshooting). |
+| [Configuration](configuration.md) | The full `config.toml` reference — editor/renderer/opener commands, startup toggles, tree layout, and `[keys]` remapping. |
+| [External renderers](renderers.md) | The optional `glow` / `delta` / `bat` integrations and the plain-text fallback when they're absent. |
+| [Windows (preview)](windows.md) | Native-Windows specifics: the `-windows` action ids, the herdr v0.7.2 keybinding requirement, and WSL. |
+
+## Beyond the essentials
+
+- [Architecture](../ARCHITECTURE.md) — one in-process TUI owning both columns, the component map,
+  off-thread rendering, and the load-bearing decisions (read-only, delegate rendering, git-first).
+- [Security](../SECURITY.md) — the threat model and mitigations for opening untrusted content, and
+  how to report a vulnerability.
+- [Changelog](../CHANGELOG.md) — the release history (also viewable in-app under `?` → What's New).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,113 @@
+# Configuration
+
+An optional TOML config file lets you override the editor, the renderer/opener commands, a couple
+of startup toggles, the tree layout, and the keybindings. **Read-only input** — the viewer never
+writes this file; edit it in your own editor and relaunch to pick up changes (there is no in-app
+settings editor). You can see what's currently in effect any time in the `?` help overlay's
+**Settings** section.
+
+**Quick start:** a fully-commented [`config.example.toml`](../config.example.toml) ships in the
+plugin folder documenting every setting. Copy it to the config path below, **rename it to
+`config.toml`**, uncomment the lines you want, and relaunch — copying it as-is changes nothing
+(every line is commented out).
+
+## File location
+
+When run under herdr, the config lives at `$HERDR_PLUGIN_CONFIG_DIR/config.toml` — herdr provides
+that directory (on Linux it resolves to
+`~/.config/herdr/plugins/config/herdr-file-viewer/config.toml`). Run standalone (outside herdr), it
+falls back to `$XDG_CONFIG_HOME/herdr-file-viewer/config.toml`, defaulting to
+`~/.config/herdr-file-viewer/config.toml` when `XDG_CONFIG_HOME` isn't set. A missing file is the
+normal case — every key falls back to its default.
+
+## Precedence
+
+A config key always wins. Only two keys also have an environment-variable fallback tier below the
+config key and above the built-in default — `editor` (`$EDITOR`) and `update_check`
+(`$HERDR_FILE_VIEWER_NO_UPDATE_CHECK`) — giving those two a `config > env > default` chain. Every
+other key (`markdown`, `diff`, `syntax`, `open`, `reveal`, `hide_dotfiles`, `scroll_lines`,
+`tree_width`, `tree_position`, `tree_max_cols`) has no applicable environment variable; for those
+it's `config > default` only.
+
+## Keys
+
+```toml
+# ~/.config/herdr-file-viewer/config.toml (or the herdr-provided path above)
+
+editor = "code --wait"      # command to open a file with `e` (overrides $EDITOR)
+
+markdown = "glow -s dark -w 0 -"   # override the markdown / diff / syntax renderers
+diff = "delta"                     # (defaults: glow / delta / bat)
+syntax = "bat --color=always --style=numbers --paging=never --file-name={name} -"
+
+open = "xdg-open"           # override the `O` open-with / `R` reveal-in-file-manager commands
+reveal = "nautilus"
+
+hide_dotfiles = false       # true to hide dotfiles at startup (the `.` key still toggles)
+update_check = true         # false to disable the once-a-day update check
+scroll_lines = 3            # mouse-wheel step (content/search/help), a 1 to 10 scale: 1 slow · 3 medium · 6 fast · 10 max
+tree_width = 30             # tree column's share of the viewer pane, percent 20-80 (content takes the rest)
+tree_position = "left"      # which side the directory tree sits on: "left" (default) or "right"
+tree_max_cols = 30          # cap the tree at this many columns so it stays compact on a wide pane
+```
+
+`tree_width` / `tree_position` set the **startup** tree/content split inside the viewer's own pane
+(not the size of the herdr pane, which the host decides). You can still resize the split live with
+the grow/shrink keys or by dragging the divider; the config just seeds the initial value.
+`tree_max_cols` is a **column** ceiling (not a percent): the tree is drawn at
+`min(tree_width% of the pane, tree_max_cols)`, so a full-terminal tab gives the extra width to the
+content pane instead of a mostly-blank tree. It only bites past ~100 columns, and dragging the
+divider or the grow/shrink keys lifts it (an explicit resize wins); set it high to disable.
+
+## Command values
+
+Command values (`editor`, `markdown`, `diff`, `syntax`, `open`, `reveal`) are **split into
+arguments** the way a shell would for simple cases — whitespace splits, double-quotes group a
+path with spaces — but **no shell is invoked**. `editor` / `open` / `reveal` get the target
+**path** appended as the final argument; the **renderers** (`markdown` / `diff` / `syntax`)
+instead get the file **content on stdin** and your value **replaces** the whole default command
+(flags aren't merged), so a custom renderer must read stdin (glow and bat need a trailing `-`)
+and set its own flags — the token `{name}` is substituted with the file name.
+
+**Known limitation:** the full-file-diff view derives its line-numbered gutter from the `diff`
+command by appending delta's `--line-numbers` flag; if you point `diff` at a tool that rejects
+that flag (nonzero exit or spawn failure), the full-file-diff view falls all the way back to
+plain, unrendered diff text (with a notice), not just a missing gutter. Renderer timeouts and
+other limits aren't configurable.
+
+## Keybindings
+
+A `[keys]` table remaps the viewer's global keys, keyed by **intent name** (the stable snake_case
+id of an action, e.g. `refresh`, `nav_up`, `switch_worktree`). Each value is a **key spec**: a
+single string, or an array of strings, naming the key(s) that action should answer to. An entry
+**replaces** that action's default key set, so list every key you want it to keep.
+
+```toml
+[keys]
+refresh = "g"               # a single key: `g` refreshes, and the default `r` no longer does
+nav_up = ["w", "Up"]        # an array: bind several keys at once (the default `k` is dropped)
+switch_worktree = "F2"      # a named key
+```
+
+**Bindable keys** are the modifier-free surface the viewer already uses: any printable or shifted
+character (`g`, `<`, `?`, and capitals such as `W` are each their own key), plus the named keys
+`Tab`, `Enter`, `Esc`, the four arrows, `Home`, `End`, `PageUp`, `PageDown`, `Space`, `Backspace`,
+`Delete`, `Insert`, and `F1` through `F12` (named keys are matched case-insensitively). There are
+**no `Ctrl` / `Alt` chords**: a chord never fires a viewer action, so terminal combinations like
+`Ctrl+C` always pass straight through.
+
+**Precedence is `config > default`:** a `[keys]` value replaces the action's built-in keys, and any
+action you don't list keeps its defaults. The load is defensive and never crashes the viewer: an
+unknown intent name, an unbindable key, or two actions claiming the same key is ignored for those
+entries only (their defaults are kept). Invalid TOML in the config (a syntax error, or a wrong-typed
+value such as `refresh = 42`) is the same whole-file fallback the rest of the config uses: the viewer
+ignores the entire file and falls back to built-in defaults, and the `?` overlay flags that the
+config was malformed. Whatever you configure, **`Esc` always closes** the viewer: that floor cannot be
+rebound away, so you can never strand yourself (you may still move the `q` Close key or any other
+action). Only the global keys are remappable; keys handled inside a modal (the finder query, the
+`:` / `/` prompt, line-select mode) keep their own keys.
+
+See your bindings in effect any time in the `?` help overlay's **Keybindings** section. It groups
+the actions into sections and shows, for each, its config-var name (the `[keys]` id you type to
+remap it), its effective key(s), and its description, marking the ones you have customized. The full
+default key list lives in the [keys reference](keys.md).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -89,6 +89,52 @@ nav_up = ["w", "Up"]        # an array: bind several keys at once (the default `
 switch_worktree = "F2"      # a named key
 ```
 
+### Every remappable action
+
+These are all the actions you can put in `[keys]`, keyed by intent name, with their default key(s).
+The `?` help overlay's **Keybindings** section shows the same list live (and marks the ones you have
+customized).
+
+| Group | Intent name (`[keys]` id) | Default key(s) | Action |
+| --- | --- | --- | --- |
+| **Navigation** | `nav_up` | `Up`, `k` | Move the tree cursor up one row |
+| | `nav_down` | `Down`, `j` | Move the tree cursor down one row |
+| | `expand` | `Right`, `l` | Expand the selected directory |
+| | `collapse` | `Left`, `h` | Collapse the selected directory |
+| | `activate` | `Enter` | Activate the selection: expand/collapse a directory, or open a file |
+| **View & layout** | `open_fullscreen` | `Z` | Toggle full-screen reading of the selected file |
+| | `cycle_view` | `v` | Cycle the content pane's view mode |
+| | `toggle_focus` | `Tab` | Move focus between the tree and content columns |
+| | `shrink_tree` | `<` | Narrow the tree column |
+| | `grow_tree` | `>` | Widen the tree column |
+| | `toggle_wrap` | `w` | Force content-line wrapping on or off |
+| | `toggle_zoom` | `z` | Hide the tree so content fills the frame, or restore the split |
+| | `tree_scroll_left` | `H` | Scroll the tree pane left |
+| | `tree_scroll_right` | `L` | Scroll the tree pane right |
+| **Git & filters** | `toggle_ignore` | `i` | Reveal or hide gitignored files |
+| | `toggle_hidden` | `.` | Hide or reveal dot-prefixed (hidden) files and folders |
+| | `toggle_changed_only` | `c` | Restrict the tree to changed files, or restore the full tree |
+| | `toggle_baseline` | `b` | Switch the diff baseline between base-branch and `HEAD` |
+| | `refresh` | `r` | Re-read git state and re-render |
+| **Open & copy** | `open_in_editor` | `e` | Hand the selected file off to an external editor |
+| | `open_with_app` | `O` | Open the selected entry with the OS default application |
+| | `reveal_in_file_manager` | `R` | Reveal the selected entry in the OS file manager |
+| | `copy_repo_path` | `y` | Copy the selected node's repo-relative path to the clipboard |
+| | `copy_abs_path` | `Y` | Copy the selected node's absolute path to the clipboard |
+| **Search & jump** | `open_finder` | `f` | Open the go-to-file fuzzy finder |
+| | `open_go_to_line` | `:` | Open the go-to-line prompt |
+| | `open_search` | `/` | Open the in-file search prompt |
+| | `next_match` | `n` | Jump to the next search match (wraps) |
+| | `prev_match` | `N` | Jump to the previous search match (wraps) |
+| **Session** | `dismiss_update` | `u` | Dismiss the update-available banner for this session |
+| | `switch_worktree` | `W` | Open the worktree picker to re-root at another git worktree |
+| | `show_help` | `?` | Open the in-app help overlay (What's New and About) |
+| | `close` | `q`, `Esc` | Close the viewer and return to the prior pane |
+
+`Esc` always closes the viewer even if you rebind `close` — that floor can't be rebound away (see
+below). Keys handled inside a modal (the finder query, the `:` / `/` prompt, line-select mode) are
+fixed and not remappable.
+
 **Bindable keys** are the modifier-free surface the viewer already uses: any printable or shifted
 character (`g`, `<`, `?`, and capitals such as `W` are each their own key), plus the named keys
 `Tab`, `Enter`, `Esc`, the four arrows, `Home`, `End`, `PageUp`, `PageDown`, `Space`, `Backspace`,

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,6 +1,7 @@
 # Install & updating
 
-Requirements: **herdr 0.7.0+**, on **Linux** or **macOS**. **Git** must be on `PATH` at
+Requirements: **herdr 0.7.0+**, on **Linux** or **macOS** (native Windows
+`x86_64-pc-windows-msvc` is a [preview](windows.md)). **Git** must be on `PATH` at
 runtime. The viewer shells out to the system `git` CLI (read-only subcommands) for the
 git-aware tree (status markers, changed-only filter, baseline toggle) and the diff view.
 Without git the viewer still opens, but those features are degraded (no status colors, no
@@ -8,7 +9,8 @@ diffs). The optional renderers (`glow` / `delta` / `bat`) are separate. See
 [external renderers](renderers.md).
 
 > **No Rust toolchain needed when a prebuilt exists.** `herdr plugin install smarzban/herdr-file-viewer`
-> downloads a prebuilt, SHA-256-verified binary for your platform (macOS arm64/x86_64, Linux x86_64).
+> downloads a prebuilt, SHA-256-verified binary for your platform (macOS arm64/x86_64, Linux x86_64,
+> Windows x86_64 preview).
 > The prebuilt is matched by **version**, so you get it even when `main` is ahead of the latest tag.
 > You'll receive the most recent released binary (a note tells you when newer, unreleased changes
 > aren't in it yet). It builds from source with `cargo` (Rust 1.96+) only when there's no matching

--- a/docs/install.md
+++ b/docs/install.md
@@ -44,7 +44,7 @@ herdr's install output is intentionally terse (`Installed …` / `Config: …`) 
 so two quick steps remain:
 
 1. **Bind a key** to summon the viewer. See [Quick start](../README.md#quick-start) (or
-   [Summoning & keybindings](usage.md) for split-vs-tab and the `--remote` caveat). No key bound
+   [Summoning the viewer](summoning.md) for split-vs-tab and the `--remote` caveat). No key bound
    yet? Open it once from the CLI:
    `herdr plugin action invoke open-file-viewer --plugin herdr-file-viewer`.
 2. **(Optional) install the renderers** (`glow` / `delta` / `bat`) so markdown, diffs, and code are

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -1,0 +1,169 @@
+# Keys & mouse
+
+The complete key and mouse reference for the viewer. For a guided tour of what each feature
+*does*, see the [usage guide](usage.md); to remap any of these keys, see
+[configuration → Keybindings](configuration.md#keybindings).
+
+The viewer is **keyboard-first**: every function has a key and nothing requires a mouse. The mouse
+is additive and on by default.
+
+## Keys
+
+| Key | Action |
+| --- | --- |
+| `↑` / `k`, `↓` / `j` | Move the tree cursor, or **scroll the content pane** vertically when it is focused |
+| `→` / `l` | Expand the selected directory, or **scroll the content pane right** when it is focused |
+| `←` / `h` | Collapse the selected directory, or **scroll the content pane left** when it is focused |
+| `H` (Shift+`h`) | Scroll the **tree** pane left (long / deeply-nested rows), inert unless the tree is focused |
+| `L` (Shift+`l`) | Focus-gated: with the **tree** focused, scroll it right (long / deeply-nested rows); with the **content pane** focused (or zoomed), enter **line-select mode** to select lines and copy either a `file:line` reference or the content itself (see [below](#copy-a-line-reference-or-line-content-l)) |
+| _line-select mode_ | `j`/`k` (or `↑`/`↓`) move the marker, `Shift`+move (`J`/`K`, Shift+`↑`/`↓`) extends a line selection; **click-drag** with the mouse selects **text** (character-granular); `Enter` copies the `path:line` / `path:start-end` **reference**, `y`/`Y` copies the selected **content**, `Esc` exits |
+| `Enter` | Activate the selection: expand/collapse a directory, or open a file in **zoom mode** (content full-screen) |
+| `i` | Toggle gitignored files |
+| `.` | Toggle hidden (dot-prefixed) files and folders |
+| `c` | Toggle changed-files-only |
+| `b` | Toggle the diff baseline (base branch ⇄ `HEAD`) |
+| `v` | Cycle the content view mode |
+| `e` | Open the selected file in `$EDITOR` (see [Opening in an editor](#opening-in-an-editor)) |
+| `O` (Shift+`o`) | **Open with default app**: hand the selected file or directory to the OS default application (e.g. an image opens in the system viewer). Read-only hand-off; non-blocking (the viewer keeps running) |
+| `R` (Shift+`r`) | **Reveal in file manager**: open the OS file manager (Finder / Explorer / a Linux file manager) with the selected entry highlighted where supported, so you can drag it out (e.g. into Slack). Read-only hand-off |
+| `f` | **Go to file**: open a fuzzy finder over every file in the tree; type to filter, `↑` / `↓` move, `Enter` opens the selected file, `Esc` cancels (`←` / `→` scroll long paths) |
+| `:` | **Go to line**: open a prompt and jump the content pane to a source line by number (`Enter` jumps, `Esc` cancels; out-of-range clamps to the last line). Works in any view; in a rendered-markdown or diff view, confirming switches to the line-numbered content view and jumps there |
+| `/` | **Search in file**: open a prompt and highlight every match in the content pane as you type; `Enter` commits the search (highlights persist), `Esc` clears it and restores the scroll. Smartcase (a lowercase query is case-insensitive; a capital makes it case-sensitive). Works in any view |
+| `n` / `N` (Shift+`n`) | After a committed search, jump to the **next** / **previous** match and scroll it into view, wrapping at the ends with a notice |
+| `y` | Copy the selected file's **repo-relative** path to the clipboard (e.g. `src/app.rs`) |
+| `Y` | Copy the selected file's **absolute** path to the clipboard |
+| `Tab` | Move focus between the tree and content columns |
+| `<` / `>` | Narrow / widen the tree column (move the divider) |
+| `w` | Toggle line wrapping for the content pane. For rendered markdown this switches between the fit-to-pane view (wide tables sized to fit, over-long cells shown as `…`) and a wide view that renders tables at full width and scrolls horizontally (`←`/`→`) so you can read every cell |
+| `z` | Zoom: hide the tree so the content pane fills the frame; press again (or `q`/`Esc`) to restore the two-column layout |
+| `Z` (Shift+`z`) | **Full-screen a file** (toggle): open the selected file like `Enter` _and_ zoom the viewer's herdr pane to fill the whole terminal, so the file takes over the entire screen instead of just the split. Press `Z` again (or `Esc`/`q`, or `z`) to return to the normal two-column split; switching worktree or quitting also restores the pane. On a directory it just expands/collapses like `Enter`; falls back to the in-pane zoom when the host isn't herdr |
+| `r` | Refresh git state: pick up changes made outside the viewer (a merge / pull / commit elsewhere) |
+| `W` (Shift+`w`) | **Switch worktree**: open a picker of the repo's git worktrees and re-root the viewer to the one you pick (read-only; no branch checkout). Marks the current worktree and pre-selects the one with an active herdr agent; `↑`/`↓` move, `←`/`→` scroll long paths, `Enter` switches, `Esc` cancels |
+| `?` (Shift+`/`) | Open the **help overlay**: What's New (latest changelog, rendered markdown) + About (version, repo, license, update status); `Esc` / `q` closes it |
+| `u` | Dismiss the "update available" banner for this session |
+| `q` / `Esc` | Back out of zoom if zoomed; otherwise close the viewer and return to the prior pane |
+
+These are the **default** keys. Remap any of them with a `[keys]` table in the
+[config file](configuration.md#keybindings).
+
+`Tab` to the content pane, then the arrow keys (or `h`/`j`/`k`/`l`) scroll it in all four
+directions; `Tab` back to the tree to move between files. Long lines wrap in prose (markdown /
+plain text); diffs and code keep their original lines so columns stay aligned. Scroll
+sideways with `←`/`→`, or press `w` to wrap them instead. Rendered markdown fits the pane by
+default (wide tables sized to fit, over-long cells shown as `…`); press `w` for a wide view that
+renders tables at full width and scrolls sideways so you can read every cell. The layout reflows
+automatically when the pane is resized.
+
+**Git state stays current.** The viewer re-reads git status when the pane **regains focus**, so
+changes you make outside it (a merge, pull, or commit in another pane) show up automatically; `r`
+forces a full refresh on demand. (Focus-refresh updates the tree's status without disturbing your
+content scroll.)
+
+Character keys act only when no control chord is held (so terminal chords like `Ctrl+C` are
+never intercepted); `Shift` is permitted, for keys such as `<` and `>` (and `y`/`Y`, `W`, `N`,
+`O`, `R`, `Z`, `?`, `H`/`L`, and `J`/`K` in line-select mode).
+
+### Copy a path (`y` / `Y`)
+
+`y` copies the selected file's repo-relative path; `Y` copies its absolute path, handy for pasting
+into a prompt, a command, or an agent. The copy uses the terminal's **OSC 52** clipboard escape, so
+it travels through herdr (and SSH) to your real clipboard with no extra tooling. A confirmation
+appears in the notices strip. If nothing lands on your clipboard, your terminal likely needs OSC 52
+/ clipboard-write enabled (e.g. in tmux, `set -g set-clipboard on`).
+
+### Copy a line reference or line content (`L`)
+
+With the content pane focused (or zoomed), `L` enters **line-select mode**: a marker lands on the
+top visible line, `j`/`k` (or `↑`/`↓`) move it, and holding `Shift` (`J`/`K`, or Shift+`↑`/`↓`)
+extends a whole-line selection. Or **click-drag with the mouse** to select **text**
+character-by-character: press where the selection starts, drag to where it ends (the pane scrolls if
+you drag past an edge), release; the selected characters are highlighted as you go. One selection,
+two products:
+
+- **`Enter` copies a repo-relative reference**: `src/app.rs:42` for a single line,
+  `src/app.rs:42-58` for a range (a mouse selection references the lines it spans), ready to
+  paste into an agent chat or an issue to point at exact lines.
+- **`y` / `Y` copy the content itself**: for a line selection, the lines joined by newlines; for
+  a mouse text selection, exactly the characters you dragged over. The syntax view's line-number
+  gutter is stripped and indentation is preserved, so it pastes as real code.
+
+A confirmation notice names what was copied. Both copies use the same **OSC 52** path as the
+tree's `y`/`Y`. `Esc` leaves the mode.
+
+`Shift`+mouse is deliberately left alone so your terminal's own native selection/copy still works:
+most terminals reserve `Shift`+drag for exactly that. Selection works in wrapped views too (the
+`w` toggle): the click maps through the same wrapping the pane draws with, so the caret lands on
+the character under the cursor. Because selection only maps onto the source, entering line-select
+from a rendered-markdown or diff view first switches that file to the line-numbered content view.
+With the **tree** focused, `L` keeps its tree horizontal-scroll behavior instead. The mode is gated
+on which pane has focus.
+
+## Mouse
+
+The viewer is keyboard-first; the mouse is additive and on by default:
+
+| Gesture | Action |
+| --- | --- |
+| **Click** a tree row | Select it (focus the tree) |
+| **Double-click** a folder | Expand / collapse it (same as `Enter`) |
+| **Double-click** a file | Open it in **zoom mode**: content full-screen (same as `Enter`); the editor is the `e` key |
+| **Wheel** over the content pane | Scroll it vertically; over the tree, move the selection |
+| **Horizontal wheel / swipe** | Scroll the content, or the tree, sideways (terminal-dependent, see below) |
+| **Drag** a scrollbar | Scroll that pane: drag ↕ on a vertical bar, ↔ on a horizontal bar; pressing the track jumps there |
+| **Drag** the divider | Resize the tree / content split |
+| **Drag** over the content text | **Select and copy text**: the selection highlights character-by-character as you drag (auto-scrolling past an edge) and is copied to the clipboard on release; no mode needed. Works in wrapped views (prose/markdown) too. `Esc`, a click elsewhere, or switching files clears the highlight |
+
+**`Shift`+drag is left to your terminal**, so its native select-and-copy still works while the
+viewer owns ordinary clicks: herdr reserves `Shift`+mouse for exactly this. (herdr forwards
+mouse events to the pane because the viewer requests capture.)
+
+**Horizontal mouse scroll is terminal-dependent**: it works only where your terminal emits
+horizontal-scroll events (`ScrollLeft` / `ScrollRight`); many terminals send nothing for a
+sideways trackpad swipe. The `←` / `→` keys always scroll the content sideways, and `H` / `L`
+always scroll the tree sideways, regardless of terminal.
+
+The mouse-wheel step is configurable — see [`scroll_lines`](configuration.md).
+
+## Opening in an editor
+
+`e` hands the selected file to the editor named by the **`$EDITOR`** environment variable
+(e.g. `vim`, or `"code --wait"` for editors that fork). The viewer suspends, runs the editor,
+and resumes when it exits. If `$EDITOR` is unset, a notice is shown. The viewer never edits a
+file itself.
+
+**`e` does nothing, or says "no editor configured"?** The viewer reads `$EDITOR` from the
+**herdr server's** environment (the server spawns every pane), *not* from the shell you happen to
+be attached from. So if `$EDITOR` is set in your interactive shell but the server was started
+without it (common with `mosh`, `systemd`, or any login manager that doesn't source your shell
+startup files), the viewer won't see it. To fix it:
+
+1. **Export `$EDITOR` in the startup file your server's launch actually reads.** Pick the line(s)
+   that match how herdr starts on your machine:
+
+   ```bash
+   # zsh: interactive shells read ~/.zshrc; ~/.zshenv is read by *every* zsh invocation
+   echo 'export EDITOR=vim' >> ~/.zshrc
+
+   # bash: add to both, so interactive and login shells agree
+   echo 'export EDITOR=vim' >> ~/.bashrc
+   echo 'export EDITOR=vim' >> ~/.profile
+
+   # mosh / `sh -lc` / any POSIX login-shell launch (e.g. herdr started over SSH+mosh)
+   echo 'export EDITOR=vim' >> ~/.profile
+   ```
+
+   If you're unsure which applies, adding it to **`~/.profile`** covers the login-shell launch
+   paths; keep it in your shell's rc too for interactive use.
+
+2. **Restart the herdr server** so it re-reads the environment: `reload-config` and `prefix+q`
+   are **not** enough (the first doesn't re-read env; the second only quits the client and leaves
+   the detached server running with its old environment):
+
+   ```bash
+   herdr server stop   # stops the background daemon: ends all panes, so finish in-flight work first
+   herdr               # relaunch from a shell where `echo $EDITOR` already prints your editor
+   ```
+
+3. **Verify:** open any shell pane *inside* herdr and run `echo $EDITOR`. Once that prints your
+   editor (it was empty before), `e` will open it. (Or set `editor` directly in the
+   [config file](configuration.md), which overrides `$EDITOR` — no server env fiddling needed.)

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -126,16 +126,27 @@ The mouse-wheel step is configurable — see [`scroll_lines`](configuration.md).
 
 ## Opening in an editor
 
-`e` hands the selected file to the editor named by the **`$EDITOR`** environment variable
-(e.g. `vim`, or `"code --wait"` for editors that fork). The viewer suspends, runs the editor,
-and resumes when it exits. If `$EDITOR` is unset, a notice is shown. The viewer never edits a
-file itself.
+`e` opens the selected file in an external editor; the viewer suspends, runs the editor, and resumes
+when it exits. The viewer never edits a file itself. Choose the editor two ways — the config key is
+the reliable one:
 
-**`e` does nothing, or says "no editor configured"?** The viewer reads `$EDITOR` from the
-**herdr server's** environment (the server spawns every pane), *not* from the shell you happen to
-be attached from. So if `$EDITOR` is set in your interactive shell but the server was started
-without it (common with `mosh`, `systemd`, or any login manager that doesn't source your shell
-startup files), the viewer won't see it. To fix it:
+- **Recommended: set `editor` in [config.toml](configuration.md)** (e.g. `editor = "code --wait"`,
+  or `"vim"`). It takes precedence over `$EDITOR` and sidesteps the server-environment gotcha below
+  entirely — no shell-rc edits, no server restart.
+- **Fallback: `$EDITOR`.** With no `editor` configured, `e` uses the `$EDITOR` environment variable
+  (e.g. `vim`, or `"code --wait"` for editors that fork). Zero config if it's already set.
+
+If `e` says "no editor configured," neither source is set: add `editor` to your config (simplest),
+or export `$EDITOR` where the herdr server can see it (expand below).
+
+<details>
+<summary><strong>Why <code>$EDITOR</code> sometimes isn't seen (and how to fix it)</strong></summary>
+
+The viewer reads `$EDITOR` from the **herdr server's** environment (the server spawns every pane),
+*not* from the shell you happen to be attached from. So if `$EDITOR` is set in your interactive
+shell but the server was started without it (common with `mosh`, `systemd`, or any login manager
+that doesn't source your shell startup files), the viewer won't see it. Setting `editor` in the
+[config file](configuration.md) sidesteps all of this; to make `$EDITOR` itself work:
 
 1. **Export `$EDITOR` in the startup file your server's launch actually reads.** Pick the line(s)
    that match how herdr starts on your machine:
@@ -165,5 +176,6 @@ startup files), the viewer won't see it. To fix it:
    ```
 
 3. **Verify:** open any shell pane *inside* herdr and run `echo $EDITOR`. Once that prints your
-   editor (it was empty before), `e` will open it. (Or set `editor` directly in the
-   [config file](configuration.md), which overrides `$EDITOR` — no server env fiddling needed.)
+   editor (it was empty before), `e` will open it.
+
+</details>

--- a/docs/summoning.md
+++ b/docs/summoning.md
@@ -1,0 +1,88 @@
+# Summoning the viewer
+
+How the viewer gets opened: the open actions, the idempotent launcher, split vs. tab, and the
+`--remote` caveat. For a quick "install then bind a key," see the [Quick start](../README.md#quick-start);
+once it's open, see the [usage guide](usage.md) and [keys reference](keys.md).
+
+The viewer opens **only** in response to an explicit action. There are no event hooks and no
+automatic invocation. The manifest declares a `[[panes]]` entry (the split-pane viewer) and an
+`[[actions]]` whose command opens it:
+
+```toml
+[[panes]]
+id = "file-viewer"
+placement = "split"
+command = ["./target/release/herdr-file-viewer"]
+
+[[actions]]
+id = "open-file-viewer"
+title = "Open file viewer"
+command = ["bash", "scripts/open-file-viewer.sh"]   # opens the pane via the herdr CLI
+```
+
+Summon it by invoking the action:
+
+```bash
+herdr plugin action invoke open-file-viewer --plugin herdr-file-viewer
+```
+
+It opens the viewer in a **split** pane beside your current work. The launcher
+(`scripts/open-file-viewer.sh`, used by both the action and any keybinding) is **idempotent**,
+scoped to the current tab, so invoking it repeatedly is *launch-or-focus-or-toggle*:
+
+- no viewer pane open in this tab → open a split (focused)
+- a viewer pane open but not focused → focus it
+- the viewer pane already focused → close it (herdr has no hide-without-close; reopening just
+  re-walks the tree)
+
+**One-press access: bind a key.** herdr's `config.toml` binds keys to commands; point one at the
+action so it runs with the plugin's working directory (no hard-coded paths):
+
+```toml
+[[keys.command]]
+key = "prefix+f"   # any herdr key syntax, e.g. ctrl+b then f
+type = "shell"     # run detached; do NOT use "pane" (it would close when the command exits)
+command = "herdr plugin action invoke open-file-viewer --plugin herdr-file-viewer"
+```
+
+Reload with `herdr server reload-config`. Pressing the key then opens / focuses / hides the
+viewer via the same idempotent launcher. (Alternatively, `command` may invoke
+`scripts/open-file-viewer.sh` directly using the absolute install path from `herdr plugin list`.)
+
+## Open in a tab instead of a split
+
+A second action, `open-file-viewer-tab`, opens the viewer in its **own tab**
+(`scripts/open-file-viewer-tab.sh`, `--placement tab`). Its launcher is idempotent *across the tabs
+of the current workspace*, *open-or-switch-or-toggle*:
+
+- no viewer in this workspace → open it in a new tab (focused)
+- a viewer in another tab of this workspace → **switch to that tab** (never a duplicate)
+- a viewer in the current tab, not focused → focus it in place
+- the viewer already focused → close it (herdr auto-closes the emptied tab)
+
+The idempotency is scoped to the **current workspace**: a viewer already open in a *different*
+workspace is left where it is, and a fresh one opens here. The action reaches this workspace's
+viewer, it never pulls you across workspaces.
+
+Bind it to its own key, e.g. `prefix+shift+f` alongside `prefix+f` for the split:
+
+```toml
+[[keys.command]]
+key = "prefix+shift+f"
+type = "shell"
+command = "herdr plugin action invoke open-file-viewer-tab --plugin herdr-file-viewer"
+```
+
+## Limitation over `herdr --remote`
+
+`--remote` attaches with **local** keybindings by default, and herdr has no way to fire a plugin
+action into the *attached* (remote) session from a local key: a `type = "shell"` command runs
+against your **local** herdr (wrong session), and a `type = "pane"` command runs in a throwaway
+pane that closes the instant it exits (so the viewer doesn't persist). To drive the viewer on the
+remote, attach with **`herdr --remote <host> --remote-keybindings server`**. The binding then
+lives in the *server's* `config.toml` and behaves fully (open / focus / close-toggle).
+
+This is a herdr keybinding/remote limitation, not the plugin's. The action and launcher work
+the same locally and remotely; it's only *which* keymap fires them across `--remote` that differs.
+
+On Windows the action ids and keybinding requirements differ slightly — see [Windows](windows.md).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,79 +1,150 @@
-# Summoning & keybindings
+# Usage guide
 
-The viewer opens **only** in response to an explicit action. There are no event hooks and no
-automatic invocation. The manifest declares a `[[panes]]` entry (the split-pane viewer) and an
-`[[actions]]` whose command opens it:
+A tour of what the viewer does, feature by feature. For the exact keys and mouse gestures see the
+[keys reference](keys.md); to open the viewer in the first place see [summoning](summoning.md); to
+customize it see [configuration](configuration.md).
 
-```toml
-[[panes]]
-id = "file-viewer"
-placement = "split"
-command = ["./target/release/herdr-file-viewer"]
+- [The tree](#the-tree)
+- [Finding a file fast](#finding-a-file-fast)
+- [Viewing a file](#viewing-a-file)
+- [Git awareness](#git-awareness)
+- [Navigating within a file](#navigating-within-a-file)
+- [Copying paths and lines](#copying-paths-and-lines)
+- [Handing a file off](#handing-a-file-off)
+- [Switching worktree](#switching-worktree)
+- [In-app help](#in-app-help)
+- [Staying up to date](#staying-up-to-date)
+- [Using the mouse](#using-the-mouse)
 
-[[actions]]
-id = "open-file-viewer"
-title = "Open file viewer"
-command = ["bash", "scripts/open-file-viewer.sh"]   # opens the pane via the herdr CLI
-```
+## The tree
 
-Summon it by invoking the action:
+The left column is a recursive, expandable directory tree, **rooted at the worktree root** when you
+launch inside a git repo, otherwise at the launch directory. It honors `.gitignore` (press `i` to
+reveal ignored files), and a separate toggle (`.`) hides dot-prefixed "hidden" files and folders
+when a directory is full of them. The tree's **top border names the root** directory and its
+**bottom border shows the current branch**, so you always know *where* and *on what branch* you're
+looking.
 
-```bash
-herdr plugin action invoke open-file-viewer --plugin herdr-file-viewer
-```
+Move the cursor with `↑`/`↓` (or `k`/`j`), expand/collapse a directory with `→`/`←` (or `l`/`h`) or
+`Enter`. The tree scrolls to keep the selection in view, and sideways for long or deeply-nested
+names — reachable by keyboard with `H` / `L` when the tree is focused. A scrollbar appears whenever
+there's more than fits. Narrow or widen the tree column with `<` / `>`, or drag the divider; the
+starting split, the tree's side, and a column cap are all [configurable](configuration.md).
 
-It opens the viewer in a **split** pane beside your current work. The launcher
-(`scripts/open-file-viewer.sh`, used by both the action and any keybinding) is **idempotent**,
-scoped to the current tab, so invoking it repeatedly is *launch-or-focus-or-toggle*:
+## Finding a file fast
 
-- no viewer pane open in this tab → open a split (focused)
-- a viewer pane open but not focused → focus it
-- the viewer pane already focused → close it (herdr has no hide-without-close; reopening just
-  re-walks the tree)
+Press `f` to open a **fuzzy finder** over every file in the tree (`.gitignore`-aware). Type to
+filter, `↑`/`↓` to move, `Enter` to open, `Esc` to cancel — far faster than scrolling the tree in a
+large repo.
 
-**One-press access: bind a key.** herdr's `config.toml` binds keys to commands; point one at the
-action so it runs with the plugin's working directory (no hard-coded paths):
+## Viewing a file
 
-```toml
-[[keys.command]]
-key = "prefix+f"   # any herdr key syntax, e.g. ctrl+b then f
-type = "shell"     # run detached; do NOT use "pane" (it would close when the command exits)
-command = "herdr plugin action invoke open-file-viewer --plugin herdr-file-viewer"
-```
+The content pane shows **the right view for each file, automatically**: a changed file shows its
+**diff**, a markdown file **renders**, anything else is **syntax-highlighted** content with line
+numbers. No mode-switching, no commands.
 
-Reload with `herdr server reload-config`. Pressing the key then opens / focuses / hides the
-viewer via the same idempotent launcher. (Alternatively, `command` may invoke
-`scripts/open-file-viewer.sh` directly using the absolute install path from `herdr plugin list`.)
+- **Cycle the view** with `v` to override the automatic choice (e.g. see a changed markdown file's
+  raw source instead of its diff).
+- A changed file can also show a **full-file diff**: the whole file with line numbers and the diff
+  shown inline.
+- **Scroll** the content in all four directions once it's focused (`Tab` to it, then the arrows or
+  `h`/`j`/`k`/`l`). Prose (markdown / plain text) wraps; diffs and code keep their original lines so
+  columns stay aligned. Press `w` to toggle wrapping, or for rendered markdown to switch between the
+  fit-to-pane view (wide tables sized to fit, over-long cells shown as `…`) and a wide view that
+  renders tables at full width and scrolls sideways.
+- **Zoom** with `z` to hide the tree and read the file across the full pane; press again (or
+  `q`/`Esc`) to restore the split.
+- **Full-screen** with `Z` (Shift+`z`) to open the file *and* zoom the viewer's herdr pane to fill
+  the whole terminal — the file takes over the entire screen, not just the split. `Z` again (or
+  `Esc`/`q`/`z`) returns to the split.
 
-**Open in a tab instead of a split.** A second action, `open-file-viewer-tab`, opens the viewer
-in its **own tab** (`scripts/open-file-viewer-tab.sh`, `--placement tab`). Its launcher is
-idempotent *across the tabs of the current workspace*, *open-or-switch-or-toggle*:
+Rendering is **delegated** to `glow` (markdown), `delta` (diffs), and `bat` (syntax); when a
+renderer isn't installed the viewer falls back to plain text with a short notice. See
+[external renderers](renderers.md).
 
-- no viewer in this workspace → open it in a new tab (focused)
-- a viewer in another tab of this workspace → **switch to that tab** (never a duplicate)
-- a viewer in the current tab, not focused → focus it in place
-- the viewer already focused → close it (herdr auto-closes the emptied tab)
+## Git awareness
 
-The idempotency is scoped to the **current workspace**: a viewer already open in a *different*
-workspace is left where it is, and a fresh one opens here. The action reaches this workspace's
-viewer, it never pulls you across workspaces.
+Git status is woven straight into the tree, not a separate mode:
 
-Bind it to its own key, e.g. `prefix+shift+f` alongside `prefix+f` for the split:
+- **Status markers**: each file carries its git-status letter — `M` modified, `A` added, `D`
+  deleted, `?` untracked — and a directory containing any change carries a `●`. They're **colored**
+  so changes read at a glance (changed files and dirty folders red, new files green), with the glyph
+  as a non-color cue so status survives a colorblind palette or a non-default terminal theme.
+- **Changed-files-only filter**: press `c` to restrict the tree to files git reports as changed.
+- **Diff baseline**: press `b` to flip what "changed" and the diff compare against — the merge-base
+  of your branch (review your whole branch) versus `HEAD` (just your uncommitted work).
+- **Refresh**: the viewer re-reads git status automatically when the pane regains focus, so a merge,
+  pull, or commit you make elsewhere shows up on its own; `r` forces a full refresh on demand.
 
-```toml
-[[keys.command]]
-key = "prefix+shift+f"
-type = "shell"
-command = "herdr plugin action invoke open-file-viewer-tab --plugin herdr-file-viewer"
-```
+Git is read through the system `git` CLI (read-only subcommands only). Without git on `PATH` the
+viewer still opens, but the status markers, filter, baseline, and diffs are degraded — see
+[install](install.md).
 
-**Limitation over `herdr --remote`.** `--remote` attaches with **local** keybindings by
-default, and herdr has no way to fire a plugin action into the *attached* (remote) session from
-a local key: a `type = "shell"` command runs against your **local** herdr (wrong session), and a
-`type = "pane"` command runs in a throwaway pane that closes the instant it exits (so the viewer
-doesn't persist). To drive the viewer on the remote, attach with
-**`herdr --remote <host> --remote-keybindings server`**. The binding then lives in the
-*server's* `config.toml` and behaves fully (open / focus / close-toggle).
+## Navigating within a file
 
-This is a herdr keybinding/remote limitation, not the plugin's. The action and launcher work
-the same locally and remotely; it's only *which* keymap fires them across `--remote` that differs.
+- **Go to a line**: press `:` and type a line number to jump the content pane straight there. In a
+  rendered-markdown or diff view it switches to the line-numbered content view to make the jump;
+  out-of-range clamps to the last line.
+- **Search in the file**: press `/` to search the open file's content. Every match highlights as you
+  type, `Enter` commits, and `n` / `N` cycle through matches (wrapping at the ends). Smartcase — a
+  lowercase query matches any case; add a capital to go case-sensitive — and it works in every view
+  (code, markdown, or diff). `Esc` clears it and restores your scroll.
+
+## Copying paths and lines
+
+- **Copy a path**: `y` copies the selected file's **repo-relative** path (e.g. `src/app.rs`); `Y`
+  copies its **absolute** path — handy for pasting into a prompt, a command, or an agent.
+- **Copy a line reference or content**: with the content pane focused (or zoomed), `L` enters
+  **line-select mode**. `Enter` copies a repo-relative reference like `src/app.rs:42` or
+  `src/app.rs:42-58`; `y`/`Y` copy the selected line content itself. A mouse click-drag selects text
+  character-by-character.
+
+Both use the terminal's **OSC 52** clipboard escape, so the copy travels through herdr (and SSH) to
+your real clipboard with no extra tooling. Full mechanics — extending a selection, wrapped-view
+behavior, the OSC 52 caveat — are in the [keys reference](keys.md#copy-a-line-reference-or-line-content-l).
+
+## Handing a file off
+
+The viewer is read-only; to *act* on a file it hands off to another tool:
+
+- **Edit** (`e`): open the selected file in your `$EDITOR` (or the configured `editor`). The viewer
+  suspends, runs the editor, and resumes when it exits. If nothing happens, see the
+  [`$EDITOR` troubleshooting](keys.md#opening-in-an-editor).
+- **Open with default app** (`O`): hand the file or directory to the OS default application (an
+  image opens in the system viewer, and so on). Non-blocking — the viewer keeps running.
+- **Reveal in file manager** (`R`): open Finder / Explorer / a Linux file manager with the entry
+  highlighted where supported, so you can drag it out (e.g. into Slack).
+
+All three are read-only hand-offs; the viewer never modifies a file itself. The `open` / `reveal`
+commands are [configurable](configuration.md).
+
+## Switching worktree
+
+Press `W` to re-root the viewer at **another git worktree** of the repo without relaunching. It
+opens a picker that marks the current worktree and pre-selects the one a herdr agent is working in,
+so you can jump straight to an agent's checkout. `↑`/`↓` move, `Enter` switches, `Esc` cancels.
+Read-only: it changes only *what you're viewing*, never the branch or any files.
+
+## In-app help
+
+Press `?` to open a view-only **help overlay** with sections for **Keybindings** (every action's
+config-var name, effective keys, and description, marking your customizations), **What's New** (the
+latest changelog, rendered as markdown), **Settings** (your effective configuration), and **About**
+(version, repo, license, and update status). Keyboard and mouse; `Esc` or `q` closes it. A `? help`
+hint rides the content pane's bottom border so the overlay is discoverable without already knowing
+the key.
+
+## Staying up to date
+
+The viewer checks for a new release at most once a day (off the UI thread, over a read-only
+`git ls-remote`) and, when you're behind, shows an "update available" banner naming the new version
+and the update command. Press `u` to dismiss it for the session. The check and banner can be turned
+off — see [install & updating](install.md#updating) and the `update_check`
+[config key](configuration.md).
+
+## Using the mouse
+
+The mouse is additive and on by default: click a tree row to select it, double-click to
+open/expand, use the wheel to scroll, drag a scrollbar or the divider, and drag over content text to
+select-and-copy without any mode. The full gesture table is in the [keys reference](keys.md#mouse).
+`Shift`+drag is deliberately left to your terminal's own native selection.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -107,9 +107,9 @@ behavior, the OSC 52 caveat — are in the [keys reference](keys.md#copy-a-line-
 
 The viewer is read-only; to *act* on a file it hands off to another tool:
 
-- **Edit** (`e`): open the selected file in your `$EDITOR` (or the configured `editor`). The viewer
-  suspends, runs the editor, and resumes when it exits. If nothing happens, see the
-  [`$EDITOR` troubleshooting](keys.md#opening-in-an-editor).
+- **Edit** (`e`): open the selected file in the editor you set as `editor` in
+  [config.toml](configuration.md) (or, with none set, your `$EDITOR`). The viewer suspends, runs the
+  editor, and resumes when it exits. See [opening in an editor](keys.md#opening-in-an-editor).
 - **Open with default app** (`O`): hand the file or directory to the OS default application (an
   image opens in the system viewer, and so on). Non-blocking — the viewer keeps running.
 - **Reveal in file manager** (`R`): open Finder / Explorer / a Linux file manager with the entry

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -1,0 +1,35 @@
+# Windows (preview)
+
+Native Windows (`x86_64-pc-windows-msvc`) is supported as a **preview**, mirroring herdr's own
+posture there: the crate builds, the test suite runs (advisory) on `windows-latest` CI, and
+install works the same way as Linux/macOS: `herdr plugin install` downloads a SHA-256-verified
+prebuilt binary (via `scripts/fetch-or-build.ps1`) or falls back to `cargo build --release`, no
+extra tooling required beyond the in-box Windows PowerShell 5.1. The open/toggle actions work via
+PowerShell launcher scripts.
+
+- **On Windows, bind the `-windows` action ids.** herdr requires every action id to be unique, so
+  the Windows launchers register as **`open-file-viewer-windows`** and
+  **`open-file-viewer-tab-windows`** (the unqualified `open-file-viewer` / `open-file-viewer-tab`
+  ids are the Linux/macOS variants). Point your herdr keybinding at the `-windows` id:
+  `command = "herdr plugin action invoke open-file-viewer-windows --plugin herdr-file-viewer"`.
+- **A `prefix+f` keybinding needs herdr v0.7.2 or newer.** herdr runs custom-command
+  (`[[keys.command]]`) keybindings through the platform shell; before v0.7.2 that was `/bin/sh`,
+  absent on Windows, so the binding silently did nothing there. herdr **v0.7.2** runs them through
+  `cmd.exe /d /c`, so the `prefix+f` binding fires normally. On older herdr, summon the viewer
+  by invoking the action **directly** (`herdr plugin action invoke open-file-viewer-windows
+  --plugin herdr-file-viewer` from a shell, or via herdr's action menu) rather than through a
+  keybinding.
+- **Requires herdr's preview channel.** Windows herdr binaries ship only on herdr's pre-release
+  update channel, so you need to be on it before installing this plugin on Windows.
+- **Preview means best-effort, not a parity guarantee.** There's no Windows host in this
+  project's CI gate (the `windows-latest` job is advisory, not required), so a Windows-specific
+  regression can land between releases. Full feature parity with Linux/macOS is the goal, not a
+  promise. Please [open an issue](https://github.com/smarzban/herdr-file-viewer/issues) if you
+  hit a Windows-specific problem.
+- **WSL works today, with zero extra setup.** If you'd rather not wait on native-Windows preview
+  maturity, the existing Linux (`x86_64-unknown-linux-musl`) binary already runs unmodified
+  inside WSL. Install herdr and this plugin from within your WSL distro exactly as you would on
+  native Linux.
+
+See also [install & updating](install.md) for the shared install flow and [summoning](summoning.md)
+for the open actions and launcher.

--- a/src/input.rs
+++ b/src/input.rs
@@ -1401,24 +1401,24 @@ mod tests {
         assert!(!b.is_customized(Intent::NavDown));
     }
 
-    // --- T-8 docs consistency: the README `## Keys` table stays in sync with the registry (AC-21) ---
+    // --- T-8 docs consistency: the keys reference `## Keys` table stays in sync with the registry (AC-21) ---
 
-    /// The README source, compiled in so a drift between the registry and the front-door `## Keys`
-    /// table fails the build. This assertion lives here, not in `tests/docs_consistency.rs`,
-    /// because it reads the `pub(crate)` [`registry`] / [`key_label`], which an integration test
-    /// cannot see.
-    const README: &str = include_str!("../README.md");
+    /// The keys-reference source (`docs/keys.md`), compiled in so a drift between the registry and
+    /// the `## Keys` table fails the build. This assertion lives here, not in
+    /// `tests/docs_consistency.rs`, because it reads the `pub(crate)` [`registry`] / [`key_label`],
+    /// which an integration test cannot see.
+    const KEYS_DOC: &str = include_str!("../docs/keys.md");
 
     #[test]
-    fn readme_keys_table_documents_every_registry_action_ac21() {
-        // AC-21: the README `## Keys` table must document every global action in the registry so
-        // the table can never silently drift from the bindings. Scope the check to the `## Keys`
-        // section (its heading to the next `## ` heading) so a stray backtick elsewhere in the
-        // README cannot satisfy it.
-        let start = README
+    fn keys_doc_table_documents_every_registry_action_ac21() {
+        // AC-21: the `docs/keys.md` `## Keys` table must document every global action in the
+        // registry so the table can never silently drift from the bindings. Scope the check to the
+        // `## Keys` section (its heading to the next `## ` heading) so a stray backtick elsewhere in
+        // the doc cannot satisfy it.
+        let start = KEYS_DOC
             .find("## Keys")
-            .expect("README.md must carry a `## Keys` section");
-        let rest = &README[start + "## Keys".len()..];
+            .expect("docs/keys.md must carry a `## Keys` section");
+        let rest = &KEYS_DOC[start + "## Keys".len()..];
         let end = rest.find("\n## ").unwrap_or(rest.len());
         let keys_section = &rest[..end];
 
@@ -1436,7 +1436,7 @@ mod tests {
                 .any(|&code| keys_section.contains(&format!("`{}`", key_label(code))));
             assert!(
                 documented,
-                "the README `## Keys` table documents no key for `{}` (intent {:?}); expected a \
+                "the docs/keys.md `## Keys` table documents no key for `{}` (intent {:?}); expected a \
                  backtick-wrapped label for one of {:?}",
                 binding.name,
                 binding.intent,

--- a/src/input.rs
+++ b/src/input.rs
@@ -1448,4 +1448,26 @@ mod tests {
             );
         }
     }
+
+    /// The configuration-reference source (`docs/configuration.md`), compiled in so the
+    /// remappable-actions table can't drift from the registry. Every `[keys]` intent name is a
+    /// stable config identifier, so the doc must list them all.
+    const CONFIG_DOC: &str = include_str!("../docs/configuration.md");
+
+    #[test]
+    fn configuration_doc_lists_every_remappable_intent() {
+        // Every registry intent name must appear (backtick-wrapped) in docs/configuration.md's
+        // "Every remappable action" table, so the full `[keys]` surface is documented and can't
+        // drift: adding a new Intent to the registry without listing its name fails the build.
+        // Backtick-wrapping avoids matching a bare word that also appears in prose.
+        for binding in registry() {
+            let needle = format!("`{}`", binding.name);
+            assert!(
+                CONFIG_DOC.contains(&needle),
+                "docs/configuration.md must list the remappable intent `{}` (backtick-wrapped) in \
+                 the keybindings table",
+                binding.name,
+            );
+        }
+    }
 }

--- a/tests/docs_consistency.rs
+++ b/tests/docs_consistency.rs
@@ -1,12 +1,20 @@
-//! Docs definition-of-done checks for the copy-line-reference feature (T-10).
+//! Docs definition-of-done checks: the user-facing docs actually carry the surface they document.
 //!
-//! Cheap, hermetic assertions that the user-facing docs actually carry the line-select surface:
-//! the README `## Keys` table documents the `L` line-select key, and the CHANGELOG has a
-//! `### Added` entry for it under the release that introduced it (`[1.9.0]`). These guard the
-//! "docs match the feature in the same PR" rule so a future edit can't silently drop the key from
-//! the front-door docs.
+//! Cheap, hermetic assertions that the canonical docs stay in sync with the code/config:
+//! `docs/keys.md` documents the key surface (e.g. the `L` line-select and `O`/`R` hand-off keys),
+//! `docs/configuration.md` documents the config file + `[keys]` remapping, the bundled
+//! `config.example.toml` carries a commented assignment for every config key, the front-door README
+//! links out to the reference docs, and the CHANGELOG has the release entry for line-select. These
+//! guard the "docs match the feature in the same PR" rule so a future edit can't silently drop the
+//! surface from the docs.
+//!
+//! (The `docs/keys.md` `## Keys` table is *additionally* checked against the keybinding registry in
+//! a `src/input.rs` unit test — `keys_doc_table_documents_every_registry_action_ac21` — which can
+//! see the `pub(crate)` registry an integration test cannot.)
 
 const README: &str = include_str!("../README.md");
+const KEYS_DOC: &str = include_str!("../docs/keys.md");
+const CONFIG_DOC: &str = include_str!("../docs/configuration.md");
 const CHANGELOG: &str = include_str!("../CHANGELOG.md");
 const CONFIG_EXAMPLE: &str = include_str!("../config.example.toml");
 
@@ -78,12 +86,13 @@ fn config_example_documents_every_config_key() {
 }
 
 #[test]
-fn readme_and_example_document_scroll_lines() {
-    // AC-10: the mouse-wheel scroll-speed key must be documented in BOTH the README and the bundled
-    // config.example.toml, so the feature ships with a discoverable, copy-pasteable setting.
+fn configuration_doc_and_example_document_scroll_lines() {
+    // AC-10: the mouse-wheel scroll-speed key must be documented in BOTH the configuration reference
+    // and the bundled config.example.toml, so the feature ships with a discoverable, copy-pasteable
+    // setting.
     assert!(
-        README.contains("scroll_lines"),
-        "README.md must document the `scroll_lines` config key"
+        CONFIG_DOC.contains("scroll_lines"),
+        "docs/configuration.md must document the `scroll_lines` config key"
     );
     assert!(
         CONFIG_EXAMPLE.contains("scroll_lines"),
@@ -92,13 +101,14 @@ fn readme_and_example_document_scroll_lines() {
 }
 
 #[test]
-fn readme_and_example_document_tree_layout() {
-    // AC-13: the tree layout config keys must be documented in BOTH the README and the bundled
-    // config.example.toml, so the feature ships with discoverable, copy-pasteable settings.
+fn configuration_doc_and_example_document_tree_layout() {
+    // AC-13: the tree layout config keys must be documented in BOTH the configuration reference and
+    // the bundled config.example.toml, so the feature ships with discoverable, copy-pasteable
+    // settings.
     for key in ["tree_width", "tree_position", "tree_max_cols"] {
         assert!(
-            README.contains(key),
-            "README.md must document the `{key}` config key"
+            CONFIG_DOC.contains(key),
+            "docs/configuration.md must document the `{key}` config key"
         );
         assert!(
             CONFIG_EXAMPLE.contains(key),
@@ -108,91 +118,72 @@ fn readme_and_example_document_tree_layout() {
 }
 
 #[test]
-fn readme_points_to_the_config_example_template() {
-    // The README's Configuration section must point users at the bundled template.
-    let start = README
-        .find("## Configuration")
-        .expect("README.md must carry a `## Configuration` section");
-    let rest = &README[start..];
-    let end = rest[1..].find("\n## ").map(|i| i + 1).unwrap_or(rest.len());
-    let section = &rest[..end];
+fn configuration_doc_points_to_the_config_example_template() {
+    // The configuration reference must point users at the bundled template and tell them to rename
+    // the copy to config.toml.
     assert!(
-        section.contains("config.example.toml"),
-        "README `## Configuration` section must point users at config.example.toml"
+        CONFIG_DOC.contains("config.example.toml"),
+        "docs/configuration.md must point users at config.example.toml"
     );
-    // ...and carry the actual instructions, not just the file name: rename to config.toml.
     assert!(
-        section.contains("config.toml") && section.to_lowercase().contains("rename"),
-        "README `## Configuration` section must tell users to rename the copy to config.toml"
+        CONFIG_DOC.contains("config.toml") && CONFIG_DOC.to_lowercase().contains("rename"),
+        "docs/configuration.md must tell users to rename the copy to config.toml"
     );
 }
 
 #[test]
-fn readme_documents_line_select_key() {
+fn keys_doc_documents_line_select_key() {
     assert!(
-        README.contains("line-select"),
-        "README.md must document the `L` line-select mode"
+        KEYS_DOC.contains("line-select"),
+        "docs/keys.md must document the `L` line-select mode"
     );
     assert!(
-        README.contains("`L`"),
-        "README.md must mention the `L` key for line-select"
+        KEYS_DOC.contains("`L`"),
+        "docs/keys.md must mention the `L` key for line-select"
     );
 }
 
 #[test]
-fn readme_documents_reveal_open_keys() {
+fn keys_doc_documents_reveal_open_keys() {
     assert!(
-        README.contains("`O`"),
-        "README.md must document the `O` open-with-default-app key"
+        KEYS_DOC.contains("`O`"),
+        "docs/keys.md must document the `O` open-with-default-app key"
     );
     assert!(
-        README.contains("`R`"),
-        "README.md must document the `R` reveal-in-file-manager key"
+        KEYS_DOC.contains("`R`"),
+        "docs/keys.md must document the `R` reveal-in-file-manager key"
     );
-    let lower = README.to_lowercase();
+    let lower = KEYS_DOC.to_lowercase();
     assert!(
         lower.contains("open with default app"),
-        "README.md `## Keys` must describe the `O` key as 'open with default app'"
+        "docs/keys.md `## Keys` must describe the `O` key as 'open with default app'"
     );
     assert!(
         lower.contains("reveal"),
-        "README.md must describe the `R` key as 'reveal'"
+        "docs/keys.md must describe the `R` key as 'reveal'"
     );
     assert!(
         lower.contains("file manager"),
-        "README.md must describe the `R` key as revealing in the OS 'file manager'"
+        "docs/keys.md must describe the `R` key as revealing in the OS 'file manager'"
     );
 }
 
 #[test]
-fn readme_documents_config_file() {
-    // README must document the config file: its path (herdr-provided + XDG fallback) and every
-    // key. Scope every assertion to the `## Configuration` section itself (heading to the next
-    // `## ` heading) rather than the whole README -- several of these bare words (e.g. `editor`,
-    // `markdown`, `diff`, `open`, `reveal`) also appear elsewhere (the Keys table, the `e`/`O`/`R`
-    // key descriptions, the roadmap), so an unscoped `README.contains` would still pass even if
-    // the Configuration section were deleted outright. Slicing on the heading keeps this a real
-    // regression guard, the same way `changelog_documents_line_reference_release` slices the
-    // CHANGELOG on its release heading.
-    let start = README
-        .find("## Configuration")
-        .expect("README.md must carry a `## Configuration` section");
-    let rest = &README[start + "## Configuration".len()..];
-    let end = rest.find("\n## ").unwrap_or(rest.len());
-    let section = &rest[..end];
-
+fn configuration_doc_documents_config_file() {
+    // The configuration reference must document the config file: its path (herdr-provided + XDG
+    // fallback) and every key.
     assert!(
-        section.contains("config.toml"),
-        "README `## Configuration` section must name the config file config.toml"
+        CONFIG_DOC.contains("config.toml"),
+        "docs/configuration.md must name the config file config.toml"
     );
     assert!(
-        section.contains("HERDR_PLUGIN_CONFIG_DIR"),
-        "README `## Configuration` section must name the herdr config-dir env var"
+        CONFIG_DOC.contains("HERDR_PLUGIN_CONFIG_DIR"),
+        "docs/configuration.md must name the herdr config-dir env var"
     );
     // XDG fallback location:
     assert!(
-        section.contains(".config/herdr-file-viewer") || section.contains("XDG_CONFIG_HOME"),
-        "README `## Configuration` section must document the XDG fallback location"
+        CONFIG_DOC.contains(".config/herdr-file-viewer") || CONFIG_DOC.contains("XDG_CONFIG_HOME"),
+        "docs/configuration.md must document the XDG fallback location"
     );
     for key in [
         "editor",
@@ -205,51 +196,58 @@ fn readme_documents_config_file() {
         "update_check",
     ] {
         assert!(
-            section.contains(key),
-            "README `## Configuration` section must document the `{key}` key"
+            CONFIG_DOC.contains(key),
+            "docs/configuration.md must document the `{key}` key"
         );
     }
 }
 
 #[test]
-fn readme_documents_keys_remapping() {
-    // AC-22: the README `## Configuration` section must document the `[keys]` remapping surface --
-    // that a binding is written `intent_name = <key spec>` (a string AND an array example), that
-    // only modifier-free keys are bindable (no Ctrl/Alt), and that a `[keys]` value replaces the
-    // action's default keys. Scope every assertion to the `## Configuration` section (heading to
-    // the next `## ` heading), the same way `readme_documents_config_file` does, so a mention
-    // elsewhere in the README cannot satisfy the check.
-    let start = README
-        .find("## Configuration")
-        .expect("README.md must carry a `## Configuration` section");
-    let rest = &README[start + "## Configuration".len()..];
-    let end = rest.find("\n## ").unwrap_or(rest.len());
-    let section = &rest[..end];
-
+fn configuration_doc_documents_keys_remapping() {
+    // AC-22: the configuration reference must document the `[keys]` remapping surface -- that a
+    // binding is written `intent_name = <key spec>` (a string AND an array example), that only
+    // modifier-free keys are bindable (no Ctrl/Alt), and that a `[keys]` value replaces the action's
+    // default keys.
     assert!(
-        section.contains("[keys]"),
-        "README `## Configuration` section must name the `[keys]` remapping table"
+        CONFIG_DOC.contains("[keys]"),
+        "docs/configuration.md must name the `[keys]` remapping table"
     );
     // The `intent_name = <key spec>` form, shown by example in BOTH the string and the array shape.
     assert!(
-        section.contains("refresh = \"g\""),
-        "README `## Configuration` section must show a single-string key spec (refresh = \"g\")"
+        CONFIG_DOC.contains("refresh = \"g\""),
+        "docs/configuration.md must show a single-string key spec (refresh = \"g\")"
     );
     assert!(
-        section.contains("nav_up = [\"w\", \"Up\"]"),
-        "README `## Configuration` section must show an array key spec (nav_up = [\"w\", \"Up\"])"
+        CONFIG_DOC.contains("nav_up = [\"w\", \"Up\"]"),
+        "docs/configuration.md must show an array key spec (nav_up = [\"w\", \"Up\"])"
     );
     // Only modifier-free keys are bindable: no Ctrl / Alt chords.
     assert!(
-        section.contains("Ctrl") && section.contains("Alt"),
-        "README `## Configuration` section must state that Ctrl/Alt chords are not bindable"
+        CONFIG_DOC.contains("Ctrl") && CONFIG_DOC.contains("Alt"),
+        "docs/configuration.md must state that Ctrl/Alt chords are not bindable"
     );
     // Precedence: a `[keys]` value replaces/overrides the action's default keys.
-    let lower = section.to_lowercase();
     assert!(
-        lower.contains("replace"),
-        "README `## Configuration` section must state a `[keys]` value replaces the default keys"
+        CONFIG_DOC.to_lowercase().contains("replace"),
+        "docs/configuration.md must state a `[keys]` value replaces the default keys"
     );
+}
+
+#[test]
+fn readme_links_to_the_reference_docs() {
+    // The slimmed front-door README must route readers to the moved reference pages, so the detail
+    // that used to live inline is still one click away (and the link check keeps those targets real).
+    for target in [
+        "docs/keys.md",
+        "docs/configuration.md",
+        "docs/usage.md",
+        "docs/README.md",
+    ] {
+        assert!(
+            README.contains(target),
+            "README.md must link to `{target}` so the reference docs are discoverable"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## What & why

The README had grown to **445 lines** — a reference manual, not a front door. This overhaul slims it to a lean landing page, moves the full reference into a focused `docs/` tree, cleans up the CHANGELOG, documents the complete keybinding surface, and fixes/expands the contributor guide. **No product behavior changes** (source touched only to repoint doc-drift guards).

## Changes (6 commits)

1. **Slim README → front door + `docs/` tree** — README 445→124 lines (what/why, screenshots, a taste of keys, quickstart, config teaser, docs index). New `docs/`: `keys.md` (full keys + mouse + editor hand-off), `configuration.md` (config + `[keys]`), `usage.md` (grown per-feature guide), `summoning.md`, `windows.md`, and a `docs/README.md` index. New `CONTRIBUTING.md` + filled the seeded issue/PR templates + a `feature_request` template. Dropped the `## Roadmap` over-promise.
2. **Editor docs lead with the config key** — `docs/keys.md` now leads with `editor` in `config.toml` (the reliable path that beats `$EDITOR`); the `$EDITOR` server-env troubleshooting is collapsed into a `<details>`.
3. **Terse, credited CHANGELOG** — every release rewritten to scannable Added/Changed/Fixed (one line each, detail behind docs links), old `Docs` sections folded into `Changed`, missing `[1.8.0]`–`[1.11.0]` + `[Unreleased]` link refs added, and external contributors credited (`@alargoa`, `@amitav13`, `@sanirudh17`, `@julianduque`, `@mitralone`, `@riclib`, `@j-pollack`).
4. **List every remappable `[keys]` intent** — a complete table of all 33 intent names (grouped by category, with default keys) in `docs/configuration.md`; there was no written list anywhere before.
5. **AGENTS.md: fix stale facts + new-key touchpoints** — corrected the release asset count (4 binaries / 6 assets), the manifest `platforms` (adds `windows`), and a removed editor-pane-split claim; added a `docs/` layout pointer and an "Adding a keybinding or a config key" checklist naming every touchpoint + guard.
6. **CHANGELOG = single source for release notes** — the release process now derives the GitHub release body from the CHANGELOG section (no more separately-authored notes that drift); all 14 stable releases' notes backfilled to match.

## Doc-drift guards (repointed)

Moving the keys/config reference out of the README meant repointing the anti-drift guards, all still green:
- `tests/docs_consistency.rs` and the `src/input.rs` AC-21 test now assert against `docs/keys.md` / `docs/configuration.md`.
- New `configuration_doc_lists_every_remappable_intent` test: every registry intent name must appear in `docs/configuration.md` (so the remappable-actions list can't drift).

## Verification

- Full suite **974 passing**; `cargo fmt --all --check` + `cargo clippy --all-targets -- -D warnings` clean.
- Mechanized link check: **0 broken** internal links across README + `docs/`; **0** placeholders.
