### PR TITLE
docs: restore dropped README screenshot + clearer config-file setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ Deeper detail lives in the docs: [install & updating](docs/install.md),
 
 An optional, **read-only** TOML config file lets you override the editor, the renderer/opener
 commands, a couple of startup toggles, the tree layout, and the keybindings. A fully-commented
-[`config.example.toml`](config.example.toml) ships in the plugin folder — copy it to the config
-path, rename it to `config.toml`, and uncomment what you want.
+[`config.example.toml`](config.example.toml) ships in the plugin folder; copy it as `config.toml`
+into the directory `herdr plugin config-dir herdr-file-viewer` prints, then uncomment what you want.
 
 The full reference — file location, precedence, every key, and `[keys]` remapping — is in
 **[docs/configuration.md](docs/configuration.md)**. See your effective settings any time in the `?`

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ right into the tree. It opens beside whatever you're doing and never touches you
 
 ![herdr-file-viewer rendering a markdown file: colored headings and styled inline code on the right, the git-status tree on the left](assets/Markdown-view.png)
 
+*…and running full-screen, the same tree + content, filling the terminal:*
+
+![herdr-file-viewer running full-screen](assets/File-Viewer-FS.png)
+
 ## Why you'd want it
 
 - **The right view, automatically.** Stop `cat`-ing files and squinting at raw diffs. A changed

--- a/config.example.toml
+++ b/config.example.toml
@@ -5,9 +5,11 @@
 #
 #   1. Copy it into your config directory and RENAME it to `config.toml`:
 #
-#        Under herdr, run `herdr plugin config-dir herdr-file-viewer` to print the directory
-#        (herdr provides it as $HERDR_PLUGIN_CONFIG_DIR; on Linux it resolves to
-#          ~/.config/herdr/plugins/config/herdr-file-viewer/config.toml):
+#        Under herdr, run `herdr plugin config-dir herdr-file-viewer` to print the
+#        directory it belongs in. On Linux that directory is
+#          ~/.config/herdr/plugins/config/herdr-file-viewer/
+#        (provided as $HERDR_PLUGIN_CONFIG_DIR), so your config file becomes:
+#          ~/.config/herdr/plugins/config/herdr-file-viewer/config.toml
 #
 #        Standalone, outside herdr:
 #          ~/.config/herdr-file-viewer/config.toml

--- a/config.example.toml
+++ b/config.example.toml
@@ -5,8 +5,9 @@
 #
 #   1. Copy it into your config directory and RENAME it to `config.toml`:
 #
-#        Under herdr (herdr provides the directory as $HERDR_PLUGIN_CONFIG_DIR):
-#          ~/.config/herdr/plugins/config/herdr-file-viewer/config.toml
+#        Under herdr, run `herdr plugin config-dir herdr-file-viewer` to print the directory
+#        (herdr provides it as $HERDR_PLUGIN_CONFIG_DIR; on Linux it resolves to
+#          ~/.config/herdr/plugins/config/herdr-file-viewer/config.toml):
 #
 #        Standalone, outside herdr:
 #          ~/.config/herdr-file-viewer/config.toml

--- a/config.example.toml
+++ b/config.example.toml
@@ -79,24 +79,33 @@
 
 # --- Layout ------------------------------------------------------------------
 
-# The tree/content split INSIDE the viewer's pane (not the size of the herdr
-# pane itself, which the host decides). `tree_width` is the directory tree
-# column's share of the pane, as a percent from 20 to 80; the content pane takes
-# the rest. You can still resize the split live with the grow/shrink keys or by
-# dragging the divider — this only sets the startup value. Default:
+# TWO keys size the directory tree, and the SMALLER of the two wins:
+#
+#     tree width shown = min( tree_width% of the pane , tree_max_cols columns )
+#
+# >>> Gotcha: if you raise `tree_width` (say to 50) and the tree does NOT get
+#     wider, `tree_max_cols` is the limit capping it. Raise `tree_max_cols` too,
+#     or set it high to switch the cap off. They work together, so tune both. <<<
+#
+# Both size the split INSIDE the viewer's pane, not the herdr pane itself (the
+# host decides that). You can always resize live with the grow/shrink keys or by
+# dragging the divider; these keys only set the STARTUP value.
+
+# tree_width: the tree column's share of the pane, as a percent from 20 to 80
+# (the content pane takes the rest). Default:
 #tree_width = 30
 
-# Which side of the content pane the tree is drawn on: "left" (default) or
-# "right". An unrecognized value falls back to "left". Default:
-#tree_position = "left"
-
-# Maximum tree width in CHARACTER COLUMNS (not a percent). The tree is drawn at
-# min(tree_width% of the pane, tree_max_cols), so on a wide pane (a full tab, a
-# big monitor) it stays compact instead of ballooning into a mostly-blank
-# column. Bites once the pane is wider than ~100 columns; below that the
-# percentage governs. Dragging the divider or the grow/shrink keys lifts the cap
-# (an explicit resize wins). Set it high (up to 1000) to disable. Default:
+# tree_max_cols: a HARD CAP on the tree width, in CHARACTER COLUMNS (not a
+# percent). Because the smaller value wins (see above), on a wide pane this is
+# usually what actually governs: at the default 30 the tree never grows past 30
+# columns even when `tree_width` would give it more, so it stays compact instead
+# of a mostly-blank column. Raise it (up to 1000, or just set it high) to let
+# `tree_width` take over. Default:
 #tree_max_cols = 30
+
+# tree_position: which side the tree sits on, "left" (default) or "right". An
+# unrecognized value falls back to "left". Default:
+#tree_position = "left"
 
 # --- Keybindings -------------------------------------------------------------
 #

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,8 +26,9 @@ filename itself is never read.
 ## File location
 
 When run under herdr, the config lives at `$HERDR_PLUGIN_CONFIG_DIR/config.toml` — herdr provides
-that directory (on Linux it resolves to
-`~/.config/herdr/plugins/config/herdr-file-viewer/config.toml`). Run standalone (outside herdr), it
+that directory (on Linux it is
+`~/.config/herdr/plugins/config/herdr-file-viewer/`, so the file is that path plus `config.toml`).
+Run standalone (outside herdr), it
 falls back to `$XDG_CONFIG_HOME/herdr-file-viewer/config.toml`, defaulting to
 `~/.config/herdr-file-viewer/config.toml` when `XDG_CONFIG_HOME` isn't set. A missing file is the
 normal case — every key falls back to its default.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -59,17 +59,19 @@ hide_dotfiles = false       # true to hide dotfiles at startup (the `.` key stil
 update_check = true         # false to disable the once-a-day update check
 scroll_lines = 3            # mouse-wheel step (content/search/help), a 1 to 10 scale: 1 slow · 3 medium · 6 fast · 10 max
 tree_width = 30             # tree column's share of the viewer pane, percent 20-80 (content takes the rest)
+tree_max_cols = 30          # HARD CAP in columns; the SMALLER of this and tree_width% wins (raise both to widen)
 tree_position = "left"      # which side the directory tree sits on: "left" (default) or "right"
-tree_max_cols = 30          # cap the tree at this many columns so it stays compact on a wide pane
 ```
 
-`tree_width` / `tree_position` set the **startup** tree/content split inside the viewer's own pane
-(not the size of the herdr pane, which the host decides). You can still resize the split live with
-the grow/shrink keys or by dragging the divider; the config just seeds the initial value.
-`tree_max_cols` is a **column** ceiling (not a percent): the tree is drawn at
-`min(tree_width% of the pane, tree_max_cols)`, so a full-terminal tab gives the extra width to the
-content pane instead of a mostly-blank tree. It only bites past ~100 columns, and dragging the
-divider or the grow/shrink keys lifts it (an explicit resize wins); set it high to disable.
+`tree_width` and `tree_max_cols` **together** decide the tree's startup width, and the **smaller of
+the two wins**: the tree is drawn at `min(tree_width% of the pane, tree_max_cols)`. So if you set
+`tree_width = 50` and nothing changes, `tree_max_cols` (default 30 columns) is capping it: raise
+`tree_max_cols` too, or set it high to switch the cap off. The cap is a **column** count, not a
+percent; it exists so a full-terminal tab or a wide monitor gives the extra room to the content pane
+instead of a mostly-blank tree (it only bites past ~100 columns). `tree_position` puts the tree on
+the `left` (default) or `right`. All three set the **startup** split inside the viewer's own pane
+(not the herdr pane, which the host decides); you can still resize live with the grow/shrink keys or
+by dragging the divider, and an explicit resize lifts the cap.
 
 ## Command values
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,10 +6,22 @@ writes this file; edit it in your own editor and relaunch to pick up changes (th
 settings editor). You can see what's currently in effect any time in the `?` help overlay's
 **Settings** section.
 
-**Quick start:** a fully-commented [`config.example.toml`](../config.example.toml) ships in the
-plugin folder documenting every setting. Copy it to the config path below, **rename it to
-`config.toml`**, uncomment the lines you want, and relaunch — copying it as-is changes nothing
-(every line is commented out).
+**Quick start.** A fully-commented [`config.example.toml`](../config.example.toml) ships in the
+plugin folder, documenting every setting. You never have to guess where the live file goes: under
+herdr, `herdr plugin config-dir herdr-file-viewer` prints the exact directory herdr keeps it in.
+Copy the example there as `config.toml` in one line:
+
+```bash
+cp "$(herdr plugin list --json | jq -r '.result.plugins[]|select(.plugin_id=="herdr-file-viewer").plugin_root')/config.example.toml" \
+   "$(herdr plugin config-dir herdr-file-viewer)/config.toml"
+```
+
+No `jq`? Run `herdr plugin list` to see the plugin folder (shown in brackets) and copy from there:
+`cp <plugin-folder>/config.example.toml "$(herdr plugin config-dir herdr-file-viewer)/config.toml"`.
+
+Then uncomment the lines you want and relaunch. Copying it as-is changes nothing (every line is
+commented out). However you copy it, **rename the copy to `config.toml`**: the `config.example.toml`
+filename itself is never read.
 
 ## File location
 


### PR DESCRIPTION
Docs-only cleanup, batched for the next release. Three fixes, no behavior change.

## What

- **Restore a dropped README screenshot.** The #96 slim-down unlinked `assets/File-Viewer-FS.png` (the full-screen shot); the image file was still in the repo. Re-added with its caption after the markdown-view shot, so all three `assets/` screenshots render again.
- **Zero-guess config-file setup.** Documented that `herdr plugin config-dir herdr-file-viewer` prints the exact destination directory, and added a copy-paste one-liner (plus a jq-free fallback) to `docs/configuration.md`, the README Configuration section, and the `config.example.toml` header.
- **Clarify `tree_width` vs `tree_max_cols`.** Setting `tree_width` alone silently did nothing when `tree_max_cols` (default 30) was the binding cap. Grouped the two width keys adjacently and led with the `min(tree_width%, tree_max_cols)` rule and the exact gotcha, in both `config.example.toml` and `docs/configuration.md`.

## Notes

- Docs and config-example only, no code change. The doc-consistency guards (`tests/docs_consistency.rs`, `src/input.rs`) pass.
- No CHANGELOG entry: all three only refine unreleased docs/config work.
