### PR TITLE
release: v1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented here. The format is based on
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Entries are short on purpose; follow the
 `→` links for the full detail.
 
-## [Unreleased]
+## [1.12.0] - 2026-07-13
 
 ### Added
 - Configurable tree layout: `tree_width` (split %, 20–80), `tree_position` (`left`/`right`), and `tree_max_cols` (column cap). → [configuration](docs/configuration.md)
@@ -149,7 +149,7 @@ First public release: a git-aware, read-only file viewer that runs as a herdr pl
 ### Security
 - Read-only by construction; untrusted content is escape-neutralized and fed to renderers on stdin; every `git` invocation is hardened for untrusted repos. See [SECURITY.md](SECURITY.md).
 
-[Unreleased]: https://github.com/smarzban/herdr-file-viewer/compare/v1.11.0...HEAD
+[1.12.0]: https://github.com/smarzban/herdr-file-viewer/releases/tag/v1.12.0
 [1.11.0]: https://github.com/smarzban/herdr-file-viewer/releases/tag/v1.11.0
 [1.10.0]: https://github.com/smarzban/herdr-file-viewer/releases/tag/v1.10.0
 [1.9.0]: https://github.com/smarzban/herdr-file-viewer/releases/tag/v1.9.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -574,7 +574,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "herdr-file-viewer"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "ansi-to-tui",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "herdr-file-viewer"
-version = "1.11.0"
+version = "1.12.0"
 edition = "2024"
 rust-version = "1.96"
 description = "A git-aware, read-only file viewer that runs as a herdr TUI pane"

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -24,7 +24,7 @@
 
 id = "herdr-file-viewer"
 name = "herdr-file-viewer"
-version = "1.11.0"
+version = "1.12.0"
 description = "A git-aware, read-only file viewer: a keyboard-driven TUI in a herdr split pane."
 min_herdr_version = "0.7.0"
 platforms = ["linux", "macos", "windows"]


### PR DESCRIPTION
Version bump to **v1.12.0** across `Cargo.toml`, `Cargo.lock`, and `herdr-plugin.toml`, and the dated CHANGELOG section. Batches the unreleased features into one minor release.

## [1.12.0] - 2026-07-13

### Added
- Configurable tree layout: `tree_width` (split %, 20–80), `tree_position` (`left`/`right`), and `tree_max_cols` (column cap). → [configuration](docs/configuration.md)
- Configurable mouse-wheel scroll speed: `scroll_lines` (1–10). Thanks @alargoa (#93). → [configuration](docs/configuration.md)
- Customizable keybindings: remap any global key with a `[keys]` table; the `?` overlay lists effective keys. → [keybindings](docs/configuration.md#keybindings)
- Config file (`config.toml`): override the editor, renderer/opener commands, and startup toggles (read-only, `config > env > default`). → [configuration](docs/configuration.md)
- `Z` full-screens the selected file (in-pane zoom + the herdr pane zoom); `z` still zooms in-pane only. → [keys](docs/keys.md)

### Changed
- Default tree width is now 30% (was 40%), for more content room.
- Tree is capped at 30 columns by default so it stays compact on wide panes.
- Docs reorganized: the README is a lean front door; the full reference moved to [docs/](docs/README.md), plus a `CONTRIBUTING.md` and issue/PR templates.

### Fixed
- Wide markdown tables now fit the pane instead of shattering; `w` toggles a full-width scrollable view.

