### PR TITLE
feat: configurable content-preview caps (preview_max_lines / preview_max_kib)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project are documented here. The format is based on
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Entries are short on purpose; follow the
 `→` links for the full detail.
 
+## [Unreleased]
+
+### Added
+- Configurable content-preview caps: `preview_max_lines` (100–100000, default 10000) and `preview_max_kib` (64–65536 KiB, default 1024 = 1 MB) set how much of a file the content pane shows before a truncated preview. → [configuration](docs/configuration.md)
+
 ## [1.12.0] - 2026-07-13
 
 ### Added

--- a/config.example.toml
+++ b/config.example.toml
@@ -109,6 +109,24 @@
 # unrecognized value falls back to "left". Default:
 #tree_position = "left"
 
+# --- Content preview ---------------------------------------------------------
+#
+# A file is shown in FULL until it exceeds one of two caps, then the content pane
+# shows a truncated preview plus a "⚠ Truncated preview" notice. The caps trigger
+# on whichever is hit FIRST, and they also apply to a large diff. For typical
+# source code the LINE cap bites first; the SIZE cap mainly guards minified or
+# generated files (bundles, big JSON, logs) and also bounds how much is ever read
+# from disk. Raise them to view bigger files; very large values can make the pane
+# slower to render.
+
+# preview_max_lines: show at most this many lines before truncating. From 100 to
+# 100000. Default:
+#preview_max_lines = 10000
+
+# preview_max_kib: show at most this size before truncating, in KiB (1024 = 1 MB).
+# From 64 to 65536 (64 MB). Default:
+#preview_max_kib = 1024
+
 # --- Keybindings -------------------------------------------------------------
 #
 # Remap any global key. Key each entry by its INTENT NAME: the stable snake_case

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,8 +39,8 @@ A config key always wins. Only two keys also have an environment-variable fallba
 config key and above the built-in default — `editor` (`$EDITOR`) and `update_check`
 (`$HERDR_FILE_VIEWER_NO_UPDATE_CHECK`) — giving those two a `config > env > default` chain. Every
 other key (`markdown`, `diff`, `syntax`, `open`, `reveal`, `hide_dotfiles`, `scroll_lines`,
-`tree_width`, `tree_position`, `tree_max_cols`) has no applicable environment variable; for those
-it's `config > default` only.
+`tree_width`, `tree_position`, `tree_max_cols`, `preview_max_lines`, `preview_max_kib`) has no
+applicable environment variable; for those it's `config > default` only.
 
 ## Keys
 
@@ -62,6 +62,9 @@ scroll_lines = 3            # mouse-wheel step (content/search/help), a 1 to 10 
 tree_width = 30             # tree column's share of the viewer pane, percent 20-80 (content takes the rest)
 tree_max_cols = 30          # HARD CAP in columns; the SMALLER of this and tree_width% wins (raise both to widen)
 tree_position = "left"      # which side the directory tree sits on: "left" (default) or "right"
+
+preview_max_lines = 10000   # show at most this many lines before a truncated preview (100–100000)
+preview_max_kib = 1024      # ...or this size before truncating, in KiB (1024 = 1 MB; 64–65536)
 ```
 
 `tree_width` and `tree_max_cols` **together** decide the tree's startup width, and the **smaller of
@@ -73,6 +76,15 @@ instead of a mostly-blank tree (it only bites past ~100 columns). `tree_position
 the `left` (default) or `right`. All three set the **startup** split inside the viewer's own pane
 (not the herdr pane, which the host decides); you can still resize live with the grow/shrink keys or
 by dragging the divider, and an explicit resize lifts the cap.
+
+`preview_max_lines` and `preview_max_kib` cap how much of a file the content pane shows: a file is
+displayed in full until it exceeds **either** cap, then the pane shows a truncated preview with a
+`⚠ Truncated preview` notice (the same bound also applies to a large diff). Truncation fires on
+whichever cap is hit **first**. For typical source code the **line** cap bites first; the **size**
+cap (in KiB, `1024` = 1 MB) mainly guards minified or generated files (bundles, big JSON, logs) and
+also bounds how much is ever read from disk, so a giant or hostile file is never slurped whole. Raise
+either to view bigger files (`preview_max_lines` up to `100000`, `preview_max_kib` up to `65536` =
+64 MB); both clamp into range, and a very large value can make the pane slower to render.
 
 ## Command values
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -86,6 +86,10 @@ also bounds how much is ever read from disk, so a giant or hostile file is never
 either to view bigger files (`preview_max_lines` up to `100000`, `preview_max_kib` up to `65536` =
 64 MB); both clamp into range, and a very large value can make the pane slower to render.
 
+One caveat for **diffs**: a diff is additionally bounded at ~4 MB by the git-capture step, independent
+of `preview_max_kib`. So raising `preview_max_kib` above ~4 MB widens how much *file content* is shown
+but not how much of a very large *diff* is (a diff past that bound is shown up to ~4 MB).
+
 ## Command values
 
 Command values (`editor`, `markdown`, `diff`, `syntax`, `open`, `reveal`) are **split into

--- a/src/app.rs
+++ b/src/app.rs
@@ -13,7 +13,7 @@ use crate::controller::{
 use crate::editor::{EditorLauncher, SpawnError, Spawner};
 use crate::git::{self, Baseline, Status};
 use crate::presenter::{self, ViewState};
-use crate::render::{self, Prepared, Renderers};
+use crate::render::{self, Caps, Prepared, Renderers};
 use crate::view_policy::ViewMode;
 use crate::{host, input, root};
 use crossterm::event::{
@@ -60,6 +60,10 @@ pub fn run() -> io::Result<()> {
     // `Components`), so a config override is honored identically wherever the renderers are used.
     let renderers = crate::config::effective_renderers(&eff, &default_renderers());
 
+    // The Content Renderer size caps (config `preview_max_lines` / `preview_max_kib`, already clamped
+    // and byte-converted). `Copy`, so the factory closure below captures it by value.
+    let caps = eff.preview_caps();
+
     // The root-bound providers are built by a factory so a later re-root rebuilds them against
     // the new root (ADR-0004). Non-capturing — it reads the passed `Resolved`, so re-root gets
     // the new root's git/renderer rather than closing over the launch root.
@@ -78,6 +82,7 @@ pub fn run() -> io::Result<()> {
             let content: Box<dyn ContentProvider> = Box::new(LiveContent {
                 root: resolved.root.clone(),
                 renderers: factory_renderers.clone(),
+                caps,
             });
             RootProviders { git, content }
         });
@@ -350,6 +355,9 @@ impl GitService for LiveGit {
 struct LiveContent {
     root: PathBuf,
     renderers: Renderers,
+    /// The size caps (line + byte) for classifying/previewing content, resolved from config
+    /// (`preview_max_lines` / `preview_max_kib`) at startup. `Copy`.
+    caps: Caps,
 }
 
 impl ContentProvider for LiveContent {
@@ -372,7 +380,7 @@ impl ContentProvider for LiveContent {
         let prepared = if matches!(mode, ViewMode::Diff | ViewMode::FullDiff) {
             Prepared::Binary
         } else {
-            render::classify(&self.root, path)
+            render::classify(&self.root, path, self.caps)
         };
         let name = path.file_name().and_then(OsStr::to_str);
         // Retain the raw source lines behind a source-mapped render: `SyntaxContent` displays one
@@ -399,9 +407,9 @@ impl ContentProvider for LiveContent {
                     markdown: render::with_wrap_width(&self.renderers.markdown, w),
                     ..self.renderers.clone()
                 };
-                render::render(&wrapped, &prepared, mode, raw_diff, name)
+                render::render(&wrapped, &prepared, mode, raw_diff, name, self.caps)
             }
-            _ => render::render(&self.renderers, &prepared, mode, raw_diff, name),
+            _ => render::render(&self.renderers, &prepared, mode, raw_diff, name, self.caps),
         };
         RenderResult {
             content,
@@ -863,6 +871,7 @@ mod tests {
                 syntax: vec!["cat".into()],
                 timeout: Duration::from_secs(5),
             },
+            caps: Caps::default(),
         }
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -875,6 +875,38 @@ mod tests {
         }
     }
 
+    /// End-to-end wiring: a NON-default cap on `LiveContent` must reach `classify` and truncate,
+    /// guarding the `eff.preview_caps()` → `LiveContent.caps` → `render::classify(.., self.caps)`
+    /// thread that the config/render unit tests each cover only on their own side.
+    #[cfg(unix)]
+    #[test]
+    fn livecontent_threads_a_configured_cap_into_classify() {
+        let root = tmp("cfg-cap-wiring");
+        let file = root.join("many.txt");
+        std::fs::write(&file, "line\n".repeat(200)).unwrap(); // 200 lines, well under the default cap
+        let content = LiveContent {
+            root: root.clone(),
+            renderers: Renderers {
+                markdown: vec!["cat".into()],
+                diff: vec!["cat".into()],
+                full_diff: vec!["cat".into()],
+                syntax: vec!["cat".into()],
+                timeout: Duration::from_secs(5),
+            },
+            // A 50-line cap the default would never apply — proves the injected cap is what bites.
+            caps: Caps {
+                max_lines: 50,
+                max_bytes: 1024 * 1024,
+            },
+        };
+        let out = content.render_at_width(&file, ViewMode::SyntaxContent, None, None);
+        assert!(
+            out.notices.iter().any(|n| n.contains("50-line")),
+            "the configured 50-line cap must reach classify through LiveContent: {:?}",
+            out.notices
+        );
+    }
+
     #[cfg(unix)]
     fn flatten_content(r: &RenderResult) -> String {
         r.content

--- a/src/config.rs
+++ b/src/config.rs
@@ -46,6 +46,28 @@ pub const MIN_TREE_MAX_COLS: u16 = 10;
 /// `MIN_TREE_MAX_COLS..=MAX_TREE_MAX_COLS`.
 pub const MAX_TREE_MAX_COLS: u16 = 1000;
 
+/// The built-in **content preview line cap**: past this many lines a file (or a large diff) is shown
+/// as a truncated preview plus a visible notice (AC-13), not whole. `preview_max_lines` overrides it.
+/// Mirrors [`crate::render::Caps::default`]'s line cap so a config-absent run is unchanged; the
+/// `render_caps_default_matches_config_defaults` test pins the two together.
+pub const DEFAULT_PREVIEW_MAX_LINES: u32 = 10000;
+/// The fewest lines a preview cap may be set to — below this the pane could truncate away almost
+/// everything, so a smaller configured value clamps up to it.
+pub const MIN_PREVIEW_MAX_LINES: u32 = 100;
+/// The most lines a preview may show. Bounds the work the render pipeline (external CLI +
+/// `ansi-to-tui` parse) does per file so a huge cap cannot wedge the UI; a larger value clamps down.
+pub const MAX_PREVIEW_MAX_LINES: u32 = 100_000;
+
+/// The built-in **content preview size cap**, in KiB: past this many kibibytes a file is previewed,
+/// not shown whole, and it bounds the actual disk read so a giant/hostile file is never slurped
+/// (AC-N1). `preview_max_kib` overrides it. 1024 KiB = 1 MiB. Mirrors [`crate::render::Caps::default`].
+pub const DEFAULT_PREVIEW_MAX_KIB: u32 = 1024;
+/// The smallest preview size cap (KiB); a smaller configured value clamps up to it.
+pub const MIN_PREVIEW_MAX_KIB: u32 = 64;
+/// The largest preview size cap (KiB) — 64 MiB. Even the maximum is a finite read, so the
+/// bounded-read guarantee (AC-N1) holds at every setting; a larger value clamps down to it.
+pub const MAX_PREVIEW_MAX_KIB: u32 = 65_536;
+
 /// Which side of the content pane the directory tree is drawn on (`tree_position` config key). A
 /// pure display preference; the config value is a lenient `Option<String>` resolved into this by
 /// [`resolve`] (case-insensitive, trimmed), so this enum is never deserialized directly. `Left` is
@@ -119,6 +141,16 @@ pub struct Config {
     /// out-of-`u16` number clamps into range instead of tripping the parse; only a negative /
     /// non-integer value fails to parse and degrades the whole config to defaults.
     pub tree_max_cols: Option<u32>,
+    /// The **content preview line cap**: past this many lines a file (or a large diff) is shown as a
+    /// truncated preview plus a notice, not whole (AC-13). `None` falls back to
+    /// [`DEFAULT_PREVIEW_MAX_LINES`]; the resolver clamps a present value into
+    /// `MIN_PREVIEW_MAX_LINES..=MAX_PREVIEW_MAX_LINES`. Held as `u32` (like the other numeric keys)
+    /// so an out-of-range number still clamps into range instead of tripping the parse.
+    pub preview_max_lines: Option<u32>,
+    /// The **content preview size cap**, in KiB: past this size a file is previewed, not shown whole,
+    /// and it bounds the disk read (AC-N1). `None` falls back to [`DEFAULT_PREVIEW_MAX_KIB`]; the
+    /// resolver clamps a present value into `MIN_PREVIEW_MAX_KIB..=MAX_PREVIEW_MAX_KIB`. 1024 = 1 MiB.
+    pub preview_max_kib: Option<u32>,
     /// The `[keys]` remapping table: **intent name -> key spec** (T-4, Slice B). `None` when the
     /// config omits `[keys]`. A `BTreeMap` keeps the entries in deterministic order. Rides the
     /// existing defensive `load_config` / `parse_config` with no wiring change: a malformed `[keys]`
@@ -245,6 +277,27 @@ pub struct EffectiveSettings {
     /// `MIN_TREE_MAX_COLS..=MAX_TREE_MAX_COLS` when present, else [`DEFAULT_TREE_MAX_COLS`]. The tree
     /// is drawn at `min(tree_width% of the pane, tree_max_cols)`. Config-or-default (no env var).
     pub tree_max_cols: u16,
+    /// The effective **content preview line cap**: the config `preview_max_lines` clamped to
+    /// `MIN_PREVIEW_MAX_LINES..=MAX_PREVIEW_MAX_LINES` when present, else [`DEFAULT_PREVIEW_MAX_LINES`].
+    /// Wired into the Content Renderer's [`crate::render::Caps`] via [`Self::preview_caps`].
+    /// Config-or-default (no env var).
+    pub preview_max_lines: u32,
+    /// The effective **content preview size cap**, in KiB: the config `preview_max_kib` clamped to
+    /// `MIN_PREVIEW_MAX_KIB..=MAX_PREVIEW_MAX_KIB` when present, else [`DEFAULT_PREVIEW_MAX_KIB`].
+    /// Config-or-default (no env var).
+    pub preview_max_kib: u32,
+}
+
+impl EffectiveSettings {
+    /// The Content Renderer size caps (line + byte) derived from the resolved preview settings —
+    /// the single place `preview_max_kib` is converted to bytes (× 1024). Wired into
+    /// [`crate::render::classify`] / [`crate::render::render`] at startup.
+    pub fn preview_caps(&self) -> crate::render::Caps {
+        crate::render::Caps {
+            max_lines: self.preview_max_lines as usize,
+            max_bytes: self.preview_max_kib as u64 * 1024,
+        }
+    }
 }
 
 /// Pure resolver: `Config` + injected env getter -> `EffectiveSettings` (AC-3, AC-4, AC-5,
@@ -324,6 +377,22 @@ pub fn resolve(config: &Config, get_env: impl Fn(&str) -> Option<String>) -> Eff
         .map(|n| n.clamp(MIN_TREE_MAX_COLS as u32, MAX_TREE_MAX_COLS as u32) as u16)
         .unwrap_or(DEFAULT_TREE_MAX_COLS);
 
+    // Config > default; no env var. Clamp to `MIN_PREVIEW_MAX_LINES..=MAX_PREVIEW_MAX_LINES` so a
+    // preview can never truncate to near-nothing, and a huge cap can't wedge the render pipeline. A
+    // non-representable value degraded the whole config to defaults and arrived as `None`.
+    let preview_max_lines = config
+        .preview_max_lines
+        .map(|n| n.clamp(MIN_PREVIEW_MAX_LINES, MAX_PREVIEW_MAX_LINES))
+        .unwrap_or(DEFAULT_PREVIEW_MAX_LINES);
+
+    // Config > default; no env var. Clamp to `MIN_PREVIEW_MAX_KIB..=MAX_PREVIEW_MAX_KIB`: the upper
+    // bound keeps the bounded-read guarantee (AC-N1) even at the max, so no configured value can ask
+    // the viewer to slurp an arbitrary file whole.
+    let preview_max_kib = config
+        .preview_max_kib
+        .map(|n| n.clamp(MIN_PREVIEW_MAX_KIB, MAX_PREVIEW_MAX_KIB))
+        .unwrap_or(DEFAULT_PREVIEW_MAX_KIB);
+
     EffectiveSettings {
         editor,
         markdown,
@@ -337,6 +406,8 @@ pub fn resolve(config: &Config, get_env: impl Fn(&str) -> Option<String>) -> Eff
         tree_width,
         tree_position,
         tree_max_cols,
+        preview_max_lines,
+        preview_max_kib,
     }
 }
 
@@ -818,6 +889,16 @@ mod tests {
     }
 
     #[test]
+    fn preview_cap_keys_parse_from_toml() {
+        // Proves the TOML key names bind to the fields (the `Config { .. }` resolve tests bypass
+        // parsing). Both are plain integers landing in their `Option<u32>` fields.
+        let (config, outcome) = parse_config("preview_max_lines = 20000\npreview_max_kib = 4096\n");
+        assert_eq!(config.preview_max_lines, Some(20000));
+        assert_eq!(config.preview_max_kib, Some(4096));
+        assert_eq!(outcome, LoadOutcome::Loaded);
+    }
+
+    #[test]
     fn resolve_scroll_lines_config_value_wins() {
         // AC-1: a valid config value (>= 1) is the effective scroll step (config > default).
         let config = Config {
@@ -1052,6 +1133,111 @@ mod tests {
                 "value {input} must clamp to {want}"
             );
         }
+    }
+
+    #[test]
+    fn resolve_preview_max_lines_config_value_wins() {
+        // A valid in-range config value is the effective preview line cap (config > default).
+        let cfg = Config {
+            preview_max_lines: Some(12_000),
+            ..Default::default()
+        };
+        assert_eq!(resolve(&cfg, |_| None).preview_max_lines, 12_000);
+    }
+
+    #[test]
+    fn resolve_preview_max_lines_defaults_when_absent() {
+        let effective = resolve(&Config::default(), |_| None);
+        assert_eq!(effective.preview_max_lines, DEFAULT_PREVIEW_MAX_LINES);
+        assert_eq!(effective.preview_max_lines, 10000);
+    }
+
+    #[test]
+    fn resolve_preview_max_lines_clamps_to_range() {
+        // Below the floor clamps up (a preview can't shrink to near-nothing); above the ceiling
+        // clamps down (a huge cap can't wedge the render pipeline). u32 field so a giant value is
+        // clamped, not degraded to default.
+        assert_eq!(
+            (MIN_PREVIEW_MAX_LINES, MAX_PREVIEW_MAX_LINES),
+            (100, 100_000)
+        );
+        for (input, want) in [
+            (0u32, 100u32),
+            (99, 100),
+            (100_001, 100_000),
+            (u32::MAX, 100_000),
+        ] {
+            let cfg = Config {
+                preview_max_lines: Some(input),
+                ..Default::default()
+            };
+            assert_eq!(
+                resolve(&cfg, |_| None).preview_max_lines,
+                want,
+                "value {input} must clamp to {want}"
+            );
+        }
+    }
+
+    #[test]
+    fn resolve_preview_max_kib_config_value_wins() {
+        let cfg = Config {
+            preview_max_kib: Some(4096),
+            ..Default::default()
+        };
+        assert_eq!(resolve(&cfg, |_| None).preview_max_kib, 4096);
+    }
+
+    #[test]
+    fn resolve_preview_max_kib_defaults_when_absent() {
+        let effective = resolve(&Config::default(), |_| None);
+        assert_eq!(effective.preview_max_kib, DEFAULT_PREVIEW_MAX_KIB);
+        assert_eq!(effective.preview_max_kib, 1024); // 1 MiB
+    }
+
+    #[test]
+    fn resolve_preview_max_kib_clamps_to_range() {
+        // The upper clamp keeps the bounded-read guarantee (AC-N1) at every setting: even the max
+        // is a finite read, never "slurp an arbitrary file whole".
+        assert_eq!((MIN_PREVIEW_MAX_KIB, MAX_PREVIEW_MAX_KIB), (64, 65_536));
+        for (input, want) in [
+            (0u32, 64u32),
+            (63, 64),
+            (65_537, 65_536),
+            (u32::MAX, 65_536),
+        ] {
+            let cfg = Config {
+                preview_max_kib: Some(input),
+                ..Default::default()
+            };
+            assert_eq!(
+                resolve(&cfg, |_| None).preview_max_kib,
+                want,
+                "value {input} must clamp to {want}"
+            );
+        }
+    }
+
+    #[test]
+    fn preview_caps_converts_kib_to_bytes() {
+        // The single conversion point: preview_max_kib × 1024 → Caps.max_bytes; lines pass through.
+        let cfg = Config {
+            preview_max_lines: Some(3000),
+            preview_max_kib: Some(512),
+            ..Default::default()
+        };
+        let caps = resolve(&cfg, |_| None).preview_caps();
+        assert_eq!(caps.max_lines, 3000);
+        assert_eq!(caps.max_bytes, 512 * 1024);
+    }
+
+    #[test]
+    fn render_caps_default_matches_config_defaults() {
+        // Lockstep guard: render::Caps::default() (used by the width-less/help paths and tests) must
+        // equal what a config-absent resolve produces, so a config-less run behaves identically no
+        // matter which side computes the caps. If someone changes one default, this fails.
+        let from_config = resolve(&Config::default(), |_| None).preview_caps();
+        assert_eq!(crate::render::Caps::default(), from_config);
     }
 
     #[test]

--- a/src/controller/help.rs
+++ b/src/controller/help.rs
@@ -145,8 +145,15 @@ impl Controller {
             ),
             ..self.renderers.clone()
         };
-        let (whats_new_body, _notice) =
-            crate::render::render(&r, &prepared, ViewMode::RenderedMarkdown, None, None);
+        // The embedded CHANGELOG is small and never user-tunable, so the default caps apply.
+        let (whats_new_body, _notice) = crate::render::render(
+            &r,
+            &prepared,
+            ViewMode::RenderedMarkdown,
+            None,
+            None,
+            crate::render::Caps::default(),
+        );
         let whats_new = HelpSectionState {
             label: HelpSection::WhatsNew.label(),
             body: whats_new_body,

--- a/src/help.rs
+++ b/src/help.rs
@@ -238,21 +238,24 @@ pub fn settings_text(
             .unwrap_or_else(|| "(default)".to_owned())
     };
 
+    // Keys are padded to the widest name (`preview_max_lines`, 17) so the `=` column lines up.
     format!(
         "{status_line}\n\
          {location_line}\n\
-         editor        = {editor}\n\
-         markdown      = {markdown}\n\
-         diff          = {diff}\n\
-         syntax        = {syntax}\n\
-         open          = {open}\n\
-         reveal        = {reveal}\n\
-         hide_dotfiles = {hide_dotfiles}\n\
-         update_check  = {update_check}\n\
-         scroll_lines  = {scroll_lines}\n\
-         tree_width    = {tree_width}\n\
-         tree_position = {tree_position}\n\
-         tree_max_cols = {tree_max_cols}",
+         editor            = {editor}\n\
+         markdown          = {markdown}\n\
+         diff              = {diff}\n\
+         syntax            = {syntax}\n\
+         open              = {open}\n\
+         reveal            = {reveal}\n\
+         hide_dotfiles     = {hide_dotfiles}\n\
+         update_check      = {update_check}\n\
+         scroll_lines      = {scroll_lines}\n\
+         tree_width        = {tree_width}\n\
+         tree_position     = {tree_position}\n\
+         tree_max_cols     = {tree_max_cols}\n\
+         preview_max_lines = {preview_max_lines}\n\
+         preview_max_kib   = {preview_max_kib}",
         editor = opt_os(&eff.editor),
         markdown = opt_argv(&eff.markdown),
         diff = opt_argv(&eff.diff),
@@ -265,6 +268,8 @@ pub fn settings_text(
         tree_width = eff.tree_width,
         tree_position = eff.tree_position.label(),
         tree_max_cols = eff.tree_max_cols,
+        preview_max_lines = eff.preview_max_lines,
+        preview_max_kib = eff.preview_max_kib,
     )
 }
 
@@ -756,6 +761,8 @@ mod tests {
             tree_width: 25,
             tree_position: crate::config::TreePosition::Right,
             tree_max_cols: 50,
+            preview_max_lines: 8000,
+            preview_max_kib: 2048,
         }
     }
 
@@ -782,6 +789,8 @@ mod tests {
             "tree_width",
             "tree_position",
             "tree_max_cols",
+            "preview_max_lines",
+            "preview_max_kib",
         ] {
             assert!(
                 text.contains(key),
@@ -809,6 +818,17 @@ mod tests {
             text.lines()
                 .any(|l| l.trim_start().starts_with("tree_max_cols") && l.contains("50")),
             "settings_text must show the effective tree_max_cols value (50):\n{text}"
+        );
+        // The effective content-preview caps each appear as their own row with their value.
+        assert!(
+            text.lines()
+                .any(|l| l.trim_start().starts_with("preview_max_lines") && l.contains("8000")),
+            "settings_text must show the effective preview_max_lines value (8000):\n{text}"
+        );
+        assert!(
+            text.lines()
+                .any(|l| l.trim_start().starts_with("preview_max_kib") && l.contains("2048")),
+            "settings_text must show the effective preview_max_kib value (2048):\n{text}"
         );
         assert!(text.contains("nano"), "editor value must appear:\n{text}");
         assert!(

--- a/src/render.rs
+++ b/src/render.rs
@@ -61,6 +61,23 @@ fn human_bytes(n: u64) -> String {
     }
 }
 
+/// Truncate `s` in place to at most `max_bytes` bytes, cutting on a UTF-8 char boundary so a
+/// multi-byte character is never split. Shared by [`classify`] and [`cap_preview`] so the byte cap
+/// bounds the *displayed* preview, not only the disk read: `from_utf8_lossy` can expand invalid
+/// bytes (each becomes a 3-byte U+FFFD), so a line-bounded-only preview of a hostile file could
+/// otherwise exceed the cap by up to ~3× before rendering.
+fn truncate_to_bytes(s: &mut String, max_bytes: u64) {
+    let max = max_bytes.min(s.len() as u64) as usize;
+    if max == s.len() {
+        return; // already within the cap — no allocation, no scan
+    }
+    let mut end = max;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    s.truncate(end);
+}
+
 /// The guarded result of reading a file's content.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Prepared {
@@ -125,11 +142,14 @@ pub fn classify(root: &Path, path: &Path, caps: Caps) -> Prepared {
     let line_count = text.lines().count();
     let over_lines = line_count >= caps.max_lines;
     if over_bytes || over_lines {
-        let preview: String = text
+        let mut preview: String = text
             .lines()
             .take(caps.max_lines)
             .collect::<Vec<_>>()
             .join("\n");
+        // Byte-bound the (possibly lossy-expanded) preview so the byte cap bounds what is *shown*,
+        // not only the disk read — matching cap_preview's guarantee for diffs.
+        truncate_to_bytes(&mut preview, caps.max_bytes);
         let cap = if over_bytes {
             format!("{} size", human_bytes(caps.max_bytes))
         } else {
@@ -276,15 +296,7 @@ fn cap_preview(text: &str, caps: Caps) -> (String, Option<String>) {
         .take(caps.max_lines)
         .collect::<Vec<_>>()
         .join("\n");
-    if preview.len() as u64 > caps.max_bytes {
-        let end = preview
-            .char_indices()
-            .take_while(|(i, _)| (*i as u64) < caps.max_bytes)
-            .last()
-            .map(|(i, c)| i + c.len_utf8())
-            .unwrap_or(0);
-        preview.truncate(end);
-    }
+    truncate_to_bytes(&mut preview, caps.max_bytes);
     (
         preview,
         Some("⚠ Truncated diff preview: diff exceeds the size cap.".into()),
@@ -647,6 +659,11 @@ mod tests {
                     text.len() as u64 <= caps.max_bytes,
                     "AC-13: preview is bounded"
                 );
+                // Exercises human_bytes' MB branch on the default 1 MiB cap (the common path).
+                assert!(
+                    notice.contains("1 MB"),
+                    "notice names the default 1 MB size cap: {notice}"
+                );
             }
             other => panic!("expected Truncated, got {other:?}"),
         }
@@ -720,6 +737,66 @@ mod tests {
             other => panic!("expected Truncated at a 64 KiB cap, got {other:?}"),
         }
         fs::remove_file(&p).ok();
+    }
+
+    #[test]
+    fn classify_byte_bounds_a_lossy_expanded_single_line_preview() {
+        // A hostile over-cap file that is ONE long line of INVALID UTF-8: the line cap never trips
+        // (1 line), and from_utf8_lossy expands each 0xFF into a 3-byte U+FFFD — so a line-bounded-only
+        // preview would balloon past the cap. The byte-bound must hold the shown preview at <= the cap.
+        let cap = 64 * 1024u64;
+        let raw = vec![0xFFu8; (cap as usize) + 4096]; // over the cap, no NUL, no newline
+        let p = tmp("lossy.bin", &raw);
+        let caps = Caps {
+            max_lines: DEFAULT_MAX_LINES,
+            max_bytes: cap,
+        };
+        match classify(&std::env::temp_dir(), &p, caps) {
+            Prepared::Truncated { text, .. } => {
+                assert!(
+                    text.len() as u64 <= cap,
+                    "lossy-expanded preview must still honor the byte cap: {} > {cap}",
+                    text.len()
+                );
+            }
+            other => panic!("expected Truncated, got {other:?}"),
+        }
+        fs::remove_file(&p).ok();
+    }
+
+    #[test]
+    fn truncate_to_bytes_respects_char_boundaries_and_the_cap() {
+        // Never split a multi-byte char, always land <= cap, and be a no-op under the cap.
+        let mut s = "aé…z".to_string(); // 'a'(1) 'é'(2) '…'(3) 'z'(1) = 7 bytes
+        truncate_to_bytes(&mut s, 4); // cap lands mid-'…' (bytes 3..6) → must cut back to "aé"
+        assert_eq!(s, "aé");
+        let mut whole = "hello".to_string();
+        truncate_to_bytes(&mut whole, 100); // over-cap: unchanged
+        assert_eq!(whole, "hello");
+        let mut empty = "hello".to_string();
+        truncate_to_bytes(&mut empty, 0); // zero cap: empty, no panic
+        assert_eq!(empty, "");
+    }
+
+    #[test]
+    fn cap_preview_byte_bounds_a_long_line_diff_under_the_line_cap() {
+        // A diff of few lines but many BYTES trips cap_preview's byte cap (not its line cap): the
+        // returned preview must be byte-bounded and carry a notice.
+        let caps = Caps {
+            max_lines: DEFAULT_MAX_LINES,
+            max_bytes: 8 * 1024,
+        };
+        let long_line = "+".to_string() + &"x".repeat(32 * 1024); // one line, > 8 KiB
+        let (preview, notice) = cap_preview(&long_line, caps);
+        assert!(
+            preview.len() as u64 <= caps.max_bytes,
+            "cap_preview must byte-bound a long-line diff: {}",
+            preview.len()
+        );
+        assert!(
+            notice.unwrap().to_lowercase().contains("truncated"),
+            "a byte-over diff gets a truncation notice"
+        );
     }
 
     #[test]

--- a/src/render.rs
+++ b/src/render.rs
@@ -15,12 +15,51 @@ use std::process::{Command, Stdio};
 use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
-/// The size cap: files at or above this many bytes are previewed, not shown whole (AC-13).
-const MAX_BYTES: u64 = 1024 * 1024; // 1 MB
-/// The size cap by line count (AC-13).
-const MAX_LINES: usize = 5000;
+/// The default preview line cap — mirror of [`crate::config::DEFAULT_PREVIEW_MAX_LINES`]. Used by
+/// [`Caps::default`] so a config-absent run behaves exactly as before; a config test keeps the two
+/// in lockstep.
+const DEFAULT_MAX_LINES: usize = 10000;
+/// The default preview size cap (1 MiB) — mirror of [`crate::config::DEFAULT_PREVIEW_MAX_KIB`].
+const DEFAULT_MAX_BYTES: u64 = 1024 * 1024;
 /// Cap on bytes captured from a renderer's stdout, bounding memory if it spews output.
 const MAX_RENDER_OUTPUT: u64 = 16 * 1024 * 1024; // 16 MB
+
+/// The Content Renderer's size caps: past `max_lines` lines **or** `max_bytes` bytes a file (or a
+/// large diff) is shown as a truncated preview plus a visible notice (AC-13), and `max_bytes` also
+/// bounds the actual file read so a giant/hostile file is never slurped whole (AC-N1). Injected
+/// (from the `preview_max_lines` / `preview_max_kib` config keys) so the caps are configurable while
+/// tests stay hermetic. `Copy` — it is two integers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Caps {
+    /// Truncate the preview past this many lines.
+    pub max_lines: usize,
+    /// Truncate the preview past this many bytes; also the bounded-read ceiling.
+    pub max_bytes: u64,
+}
+
+impl Default for Caps {
+    /// The built-in caps (10000 lines / 1 MiB). Must equal what [`crate::config::resolve`] produces
+    /// for an empty config; `crate::config`'s `render_caps_default_matches_config_defaults` test
+    /// pins that so the two constants can never drift apart.
+    fn default() -> Self {
+        Caps {
+            max_lines: DEFAULT_MAX_LINES,
+            max_bytes: DEFAULT_MAX_BYTES,
+        }
+    }
+}
+
+/// Render a cap as a short human label for a truncation notice (`1 MB`, `512 KB`). Values come from
+/// a KiB config knob, so they are whole kibibytes; MiB-round values read as `N MB` (matching the
+/// historical "1 MB" wording), everything else as `N KB`.
+fn human_bytes(n: u64) -> String {
+    let kib = n / 1024;
+    if kib >= 1024 && kib.is_multiple_of(1024) {
+        format!("{} MB", kib / 1024)
+    } else {
+        format!("{kib} KB")
+    }
+}
 
 /// The guarded result of reading a file's content.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -34,13 +73,13 @@ pub enum Prepared {
 }
 
 /// Classify a file for display: binary vs. truncated-preview vs. full text. Reads at most
-/// `MAX_BYTES` from disk, so a huge or hostile file can never be slurped whole (AC-N1).
+/// `caps.max_bytes` from disk, so a huge or hostile file can never be slurped whole (AC-N1).
 ///
 /// Refuses to read anything that does not resolve to a **regular file inside `root`**:
 /// a symlink (or `..`) escaping the root cannot leak out-of-root content into the pane
 /// (AC-N5), and a FIFO/device/dir is never opened (no hang, no garbage). Such paths
 /// return `Binary` (a placeholder, no bytes).
-pub fn classify(root: &Path, path: &Path) -> Prepared {
+pub fn classify(root: &Path, path: &Path, caps: Caps) -> Prepared {
     let (Ok(canonical), Ok(canon_root)) = (path.canonicalize(), root.canonicalize()) else {
         return Prepared::Binary; // unresolvable / missing
     };
@@ -56,9 +95,11 @@ pub fn classify(root: &Path, path: &Path) -> Prepared {
     let Ok(file) = File::open(&canonical) else {
         return Prepared::Binary; // unreadable (e.g. permissions) → placeholder, not a misleading empty pane
     };
-    // Bounded read: at most MAX_BYTES, so a giant/hostile file is never slurped whole.
+    // Bounded read: at most caps.max_bytes, so a giant/hostile file is never slurped whole. The
+    // config resolver clamps the cap to a finite ceiling, so even a configured value keeps this
+    // guarantee (AC-N1).
     let mut buf = Vec::new();
-    if file.take(MAX_BYTES).read_to_end(&mut buf).is_err() {
+    if file.take(caps.max_bytes).read_to_end(&mut buf).is_err() {
         return Prepared::Full {
             text: String::new(),
         };
@@ -69,7 +110,7 @@ pub fn classify(root: &Path, path: &Path) -> Prepared {
         return Prepared::Binary;
     }
 
-    let over_bytes = byte_len >= MAX_BYTES;
+    let over_bytes = byte_len >= caps.max_bytes;
     // If the file fit under the cap, invalid UTF-8 means binary. If it was capped, the
     // read may have split a multi-byte char, so decode lossily rather than misclassify.
     let text = if over_bytes {
@@ -82,10 +123,18 @@ pub fn classify(root: &Path, path: &Path) -> Prepared {
     };
 
     let line_count = text.lines().count();
-    let over_lines = line_count >= MAX_LINES;
+    let over_lines = line_count >= caps.max_lines;
     if over_bytes || over_lines {
-        let preview: String = text.lines().take(MAX_LINES).collect::<Vec<_>>().join("\n");
-        let cap = if over_bytes { "1 MB size" } else { "5000-line" };
+        let preview: String = text
+            .lines()
+            .take(caps.max_lines)
+            .collect::<Vec<_>>()
+            .join("\n");
+        let cap = if over_bytes {
+            format!("{} size", human_bytes(caps.max_bytes))
+        } else {
+            format!("{}-line", caps.max_lines)
+        };
         let notice = format!(
             "⚠ Truncated preview: showing {} lines ({} of {} bytes); file exceeds the {} cap.",
             preview.lines().count(),
@@ -127,6 +176,7 @@ pub fn render(
     mode: ViewMode,
     raw_diff: Option<&str>,
     file_name: Option<&str>,
+    caps: Caps,
 ) -> (Text<'static>, Option<String>) {
     let name = sanitize_name(file_name.unwrap_or(""));
     let name = name.as_str();
@@ -141,7 +191,7 @@ pub fn render(
         } else {
             &renderers.diff
         };
-        let (diff, notice) = cap_preview(raw_diff.unwrap_or(""));
+        let (diff, notice) = cap_preview(raw_diff.unwrap_or(""), caps);
         return delegate(
             &with_name(cmd, name),
             &diff,
@@ -216,16 +266,20 @@ fn with_name(command: &[String], name: &str) -> Vec<String> {
 /// Bound a text block to the size cap, returning a preview plus a truncation notice when
 /// it exceeds it. Used for diff text (AC-13's bound applied to large diffs, keeping the
 /// UI path responsive regardless of how big a changed file's diff is).
-fn cap_preview(text: &str) -> (String, Option<String>) {
-    let over = text.lines().count() >= MAX_LINES || text.len() as u64 >= MAX_BYTES;
+fn cap_preview(text: &str, caps: Caps) -> (String, Option<String>) {
+    let over = text.lines().count() >= caps.max_lines || text.len() as u64 >= caps.max_bytes;
     if !over {
         return (text.to_string(), None);
     }
-    let mut preview: String = text.lines().take(MAX_LINES).collect::<Vec<_>>().join("\n");
-    if preview.len() as u64 > MAX_BYTES {
+    let mut preview: String = text
+        .lines()
+        .take(caps.max_lines)
+        .collect::<Vec<_>>()
+        .join("\n");
+    if preview.len() as u64 > caps.max_bytes {
         let end = preview
             .char_indices()
-            .take_while(|(i, _)| (*i as u64) < MAX_BYTES)
+            .take_while(|(i, _)| (*i as u64) < caps.max_bytes)
             .last()
             .map(|(i, c)| i + c.len_utf8())
             .unwrap_or(0);
@@ -530,7 +584,10 @@ mod tests {
     #[test]
     fn nul_bytes_classify_as_binary_without_emitting_raw_bytes() {
         let p = tmp("bin", &[0x00, 0x01, 0x02, b'h', b'i']);
-        assert_eq!(classify(&std::env::temp_dir(), &p), Prepared::Binary); // AC-12
+        assert_eq!(
+            classify(&std::env::temp_dir(), &p, Caps::default()),
+            Prepared::Binary
+        ); // AC-12
         fs::remove_file(&p).ok();
     }
 
@@ -571,7 +628,7 @@ mod tests {
     #[test]
     fn small_text_file_is_returned_in_full() {
         let p = tmp("small.txt", b"hello\nworld\n");
-        match classify(&std::env::temp_dir(), &p) {
+        match classify(&std::env::temp_dir(), &p, Caps::default()) {
             Prepared::Full { text } => assert!(text.contains("hello")),
             other => panic!("expected Full, got {other:?}"),
         }
@@ -580,12 +637,16 @@ mod tests {
 
     #[test]
     fn file_over_one_megabyte_is_truncated_with_a_notice() {
-        let big = vec![b'a'; (MAX_BYTES as usize) + 100];
+        let caps = Caps::default();
+        let big = vec![b'a'; (caps.max_bytes as usize) + 100];
         let p = tmp("big.txt", &big);
-        match classify(&std::env::temp_dir(), &p) {
+        match classify(&std::env::temp_dir(), &p, caps) {
             Prepared::Truncated { text, notice } => {
                 assert!(!notice.is_empty(), "AC-13: a visible truncation notice");
-                assert!(text.len() as u64 <= MAX_BYTES, "AC-13: preview is bounded");
+                assert!(
+                    text.len() as u64 <= caps.max_bytes,
+                    "AC-13: preview is bounded"
+                );
             }
             other => panic!("expected Truncated, got {other:?}"),
         }
@@ -593,13 +654,14 @@ mod tests {
     }
 
     #[test]
-    fn file_over_five_thousand_lines_is_truncated() {
-        let many = "x\n".repeat(6000);
+    fn file_over_the_default_line_cap_is_truncated() {
+        let caps = Caps::default();
+        let many = "x\n".repeat(caps.max_lines + 1000);
         let p = tmp("many.txt", many.as_bytes());
-        match classify(&std::env::temp_dir(), &p) {
+        match classify(&std::env::temp_dir(), &p, caps) {
             Prepared::Truncated { text, notice } => {
                 assert!(
-                    text.lines().count() <= MAX_LINES,
+                    text.lines().count() <= caps.max_lines,
                     "AC-13: preview line-bounded"
                 );
                 assert!(notice.contains("line"), "notice describes the line cap");
@@ -610,10 +672,61 @@ mod tests {
     }
 
     #[test]
+    fn a_configured_smaller_line_cap_truncates_a_file_the_default_would_show_whole() {
+        // 200 lines is well under the default line cap (would be `Full`), but a caller-supplied
+        // 100-line cap must truncate it to a bounded preview — proving the cap is injected, not fixed.
+        let text = "line\n".repeat(200);
+        let p = tmp("cfg-lines.txt", text.as_bytes());
+        let caps = Caps {
+            max_lines: 100,
+            max_bytes: DEFAULT_MAX_BYTES,
+        };
+        match classify(&std::env::temp_dir(), &p, caps) {
+            Prepared::Truncated { text, notice } => {
+                assert!(
+                    text.lines().count() <= 100,
+                    "preview honors the configured line cap"
+                );
+                assert!(
+                    notice.contains("100-line"),
+                    "notice names the configured cap: {notice}"
+                );
+            }
+            other => panic!("expected Truncated at a 100-line cap, got {other:?}"),
+        }
+        fs::remove_file(&p).ok();
+    }
+
+    #[test]
+    fn a_configured_smaller_byte_cap_truncates_and_names_the_size_in_the_notice() {
+        // 200 KiB is under the 1 MiB default, but a 64 KiB cap must truncate it and label the size.
+        let text = vec![b'a'; 200 * 1024];
+        let p = tmp("cfg-bytes.txt", &text);
+        let caps = Caps {
+            max_lines: DEFAULT_MAX_LINES,
+            max_bytes: 64 * 1024,
+        };
+        match classify(&std::env::temp_dir(), &p, caps) {
+            Prepared::Truncated { text, notice } => {
+                assert!(
+                    text.len() as u64 <= caps.max_bytes,
+                    "preview honors the configured byte cap"
+                );
+                assert!(
+                    notice.contains("64 KB"),
+                    "notice names the configured size: {notice}"
+                );
+            }
+            other => panic!("expected Truncated at a 64 KiB cap, got {other:?}"),
+        }
+        fs::remove_file(&p).ok();
+    }
+
+    #[test]
     fn classify_does_not_modify_the_file() {
         let p = tmp("ro.txt", b"unchanged\n");
         let before = fs::read(&p).unwrap();
-        let _ = classify(&std::env::temp_dir(), &p);
+        let _ = classify(&std::env::temp_dir(), &p, Caps::default());
         assert_eq!(fs::read(&p).unwrap(), before); // AC-N1
         fs::remove_file(&p).ok();
     }
@@ -640,7 +753,7 @@ mod tests {
         let link = root.join("link.txt");
         symlink(&outside, &link).unwrap();
         assert_eq!(
-            classify(&root, &link),
+            classify(&root, &link, Caps::default()),
             Prepared::Binary,
             "AC-N5: no out-of-root read"
         );
@@ -657,7 +770,7 @@ mod tests {
         fs::write(&real, "hello inside").unwrap();
         let link = root.join("link.txt");
         symlink(&real, &link).unwrap();
-        match classify(&root, &link) {
+        match classify(&root, &link, Caps::default()) {
             Prepared::Full { text } => assert!(text.contains("hello inside")),
             other => panic!("expected Full, got {other:?}"),
         }
@@ -670,7 +783,7 @@ mod tests {
         // a directory is not a regular file
         let sub = root.join("subdir");
         fs::create_dir_all(&sub).unwrap();
-        assert_eq!(classify(&root, &sub), Prepared::Binary);
+        assert_eq!(classify(&root, &sub, Caps::default()), Prepared::Binary);
         fs::remove_dir_all(&root).ok();
     }
 

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -9463,6 +9463,8 @@ fn open_help_appends_settings_section_when_display_is_set() {
         tree_width: 30,
         tree_position: herdr_file_viewer::config::TreePosition::Left,
         tree_max_cols: 45,
+        preview_max_lines: 5000,
+        preview_max_kib: 1024,
     };
     ctrl.set_settings_display(
         &eff,

--- a/tests/docs_consistency.rs
+++ b/tests/docs_consistency.rs
@@ -51,6 +51,8 @@ fn config_example_documents_every_config_key() {
         "tree_width",
         "tree_position",
         "tree_max_cols",
+        "preview_max_lines",
+        "preview_max_kib",
     ] {
         assert!(
             has_commented_assignment(CONFIG_EXAMPLE, key),
@@ -106,6 +108,22 @@ fn configuration_doc_and_example_document_tree_layout() {
     // the bundled config.example.toml, so the feature ships with discoverable, copy-pasteable
     // settings.
     for key in ["tree_width", "tree_position", "tree_max_cols"] {
+        assert!(
+            CONFIG_DOC.contains(key),
+            "docs/configuration.md must document the `{key}` config key"
+        );
+        assert!(
+            CONFIG_EXAMPLE.contains(key),
+            "config.example.toml must document the `{key}` config key"
+        );
+    }
+}
+
+#[test]
+fn configuration_doc_and_example_document_preview_caps() {
+    // The content-preview cap keys must be documented in BOTH the configuration reference and the
+    // bundled config.example.toml, so the feature ships with discoverable, copy-pasteable settings.
+    for key in ["preview_max_lines", "preview_max_kib"] {
         assert!(
             CONFIG_DOC.contains(key),
             "docs/configuration.md must document the `{key}` config key"

--- a/tests/render_delegate.rs
+++ b/tests/render_delegate.rs
@@ -4,7 +4,7 @@
 //! Renderer commands are injected: `cat` echoes stdin (a working renderer), a nonexistent
 //! program simulates a missing one — so the tests never depend on glow/delta/bat.
 
-use herdr_file_viewer::render::{Prepared, Renderers, render};
+use herdr_file_viewer::render::{Caps, Prepared, Renderers, render};
 use herdr_file_viewer::view_policy::ViewMode;
 use ratatui::text::Text;
 use std::process::{Command, Stdio};
@@ -33,7 +33,14 @@ fn syntax_mode_invokes_the_syntax_renderer_and_ingests_output() {
     let prepared = Prepared::Full {
         text: "fn main() {}".into(),
     };
-    let (text, notice) = render(&cat(), &prepared, ViewMode::SyntaxContent, None, None);
+    let (text, notice) = render(
+        &cat(),
+        &prepared,
+        ViewMode::SyntaxContent,
+        None,
+        None,
+        Caps::default(),
+    );
     assert!(flatten(&text).contains("fn main"), "AC-10");
     assert!(notice.is_none());
 }
@@ -43,7 +50,14 @@ fn markdown_mode_invokes_the_markdown_renderer() {
     let prepared = Prepared::Full {
         text: "# Title".into(),
     };
-    let (text, _) = render(&cat(), &prepared, ViewMode::RenderedMarkdown, None, None);
+    let (text, _) = render(
+        &cat(),
+        &prepared,
+        ViewMode::RenderedMarkdown,
+        None,
+        None,
+        Caps::default(),
+    );
     assert!(flatten(&text).contains("# Title"), "AC-8");
 }
 
@@ -58,20 +72,30 @@ fn diff_mode_renders_the_supplied_raw_diff() {
         ViewMode::Diff,
         Some("@@ -1 +1 @@\n+new line"),
         None,
+        Caps::default(),
     );
     assert!(flatten(&text).contains("+new line"), "AC-9");
 }
 
 #[test]
 fn an_oversized_diff_is_truncated_with_a_notice() {
-    let huge = "+line\n".repeat(6000); // > 5000 lines
+    // Cap-relative so the test can't rot when the default line cap changes.
+    let cap = Caps::default().max_lines;
+    let huge = "+line\n".repeat(cap + 1000); // over the line cap
     let prepared = Prepared::Full { text: "x".into() };
-    let (text, notice) = render(&cat(), &prepared, ViewMode::Diff, Some(&huge), None);
+    let (text, notice) = render(
+        &cat(),
+        &prepared,
+        ViewMode::Diff,
+        Some(&huge),
+        None,
+        Caps::default(),
+    );
     assert!(
         notice.unwrap().to_lowercase().contains("truncated"),
         "AC-13: large diff bounded"
     );
-    assert!(text.lines.len() <= 5000, "diff preview is line-bounded");
+    assert!(text.lines.len() <= cap, "diff preview is line-bounded");
 }
 
 #[test]
@@ -84,6 +108,7 @@ fn diff_mode_renders_even_for_a_binary_or_deleted_file() {
         ViewMode::Diff,
         Some("@@ -1 +0 @@\n-removed"),
         None,
+        Caps::default(),
     );
     let s = flatten(&text);
     assert!(s.contains("-removed"), "deletion diff is shown");
@@ -111,6 +136,7 @@ fn missing_renderer_falls_back_to_plain_text_with_a_notice() {
         ViewMode::RenderedMarkdown,
         None,
         None,
+        Caps::default(),
     );
     assert!(
         flatten(&text).contains("# Title"),
@@ -153,6 +179,7 @@ fn binary_shows_a_placeholder_not_raw_bytes() {
         ViewMode::SyntaxContent,
         None,
         None,
+        Caps::default(),
     );
     assert!(
         flatten(&text).to_lowercase().contains("binary"),
@@ -180,6 +207,7 @@ fn syntax_renderer_receives_the_file_name_via_placeholder() {
         ViewMode::SyntaxContent,
         None,
         Some("main.rs"),
+        Caps::default(),
     );
     assert!(
         flatten(&text).contains("main.rs"),
@@ -210,6 +238,7 @@ fn a_malicious_file_name_cannot_inject_via_the_placeholder() {
         ViewMode::SyntaxContent,
         None,
         Some(&evil),
+        Caps::default(),
     );
     assert!(!marker.exists(), "command substitution must not execute");
     let out = flatten(&text);
@@ -240,6 +269,7 @@ fn full_diff_mode_renders_the_diff_text_via_the_full_diff_renderer() {
         ViewMode::FullDiff,
         Some(full),
         None,
+        Caps::default(),
     );
     let s = flatten(&text);
     assert!(
@@ -260,13 +290,16 @@ fn full_diff_mode_renders_the_diff_text_via_the_full_diff_renderer() {
 fn an_oversized_full_diff_is_truncated_with_a_notice() {
     // AC-13 on the FullDiff path: a full-context diff of a large file is bounded with a visible
     // truncation notice before it is rendered, so it can't blow up the content pane.
-    let big_diff = "+line\n".repeat(6000); // > the 5000-line cap
+    // Cap-relative so the test can't rot when the default line cap changes.
+    let cap = Caps::default().max_lines;
+    let big_diff = "+line\n".repeat(cap + 1000); // over the line cap
     let (text, notice) = render(
         &cat(),
         &Prepared::Binary,
         ViewMode::FullDiff,
         Some(&big_diff),
         None,
+        Caps::default(),
     );
     let n = notice.expect("AC-13: an oversized full-context diff gets a truncation notice");
     assert!(
@@ -274,7 +307,7 @@ fn an_oversized_full_diff_is_truncated_with_a_notice() {
         "the notice names the truncation: {n}"
     );
     assert!(
-        flatten(&text).lines().count() <= 5000,
+        flatten(&text).lines().count() <= cap,
         "the rendered diff is line-bounded (AC-13)"
     );
 }
@@ -298,6 +331,7 @@ fn a_hanging_renderer_times_out_and_falls_back() {
         ViewMode::RenderedMarkdown,
         None,
         None,
+        Caps::default(),
     );
     assert!(
         start.elapsed() < Duration::from_secs(3),
@@ -319,7 +353,14 @@ fn truncation_notice_is_preserved_through_rendering() {
         text: "head".into(),
         notice: "truncated-preview".into(),
     };
-    let (_, notice) = render(&cat(), &prepared, ViewMode::SyntaxContent, None, None);
+    let (_, notice) = render(
+        &cat(),
+        &prepared,
+        ViewMode::SyntaxContent,
+        None,
+        None,
+        Caps::default(),
+    );
     assert!(
         notice.unwrap().contains("truncated-preview"),
         "AC-13 notice survives"
@@ -384,6 +425,7 @@ This is a long prose paragraph that at its natural width would be wider than the
         ViewMode::RenderedMarkdown,
         None,
         None,
+        Caps::default(),
     );
     for line in &text.lines {
         assert!(

--- a/tests/render_perf.rs
+++ b/tests/render_perf.rs
@@ -5,7 +5,7 @@
 mod common;
 
 use common::TempDir;
-use herdr_file_viewer::render::{Prepared, classify, to_text};
+use herdr_file_viewer::render::{Caps, Prepared, classify, to_text};
 use std::fs;
 use std::time::Instant;
 
@@ -23,7 +23,7 @@ fn classify_and_ingest_one_megabyte_within_300ms() {
     fs::write(&path, &content).unwrap();
 
     let start = Instant::now();
-    let prepared = classify(dir.path(), &path);
+    let prepared = classify(dir.path(), &path, Caps::default());
     let text = match &prepared {
         Prepared::Full { text } | Prepared::Truncated { text, .. } => text.clone(),
         Prepared::Binary => String::new(),


### PR DESCRIPTION
## What

Makes the content-pane truncation caps configurable instead of the fixed 5000-line / 1 MB. Two new `config.toml` keys (`config > default`, no env tier), each clamped into a safe range:

| Key | Default | Range | Caps |
|---|---|---|---|
| `preview_max_lines` | 10000 | 100–100000 | lines before a truncated preview |
| `preview_max_kib` | 1024 (= 1 MB) | 64–65536 (64 MB) | size before truncating; also bounds the disk read |

Truncation still fires on whichever cap is hit first, and now applies uniformly to file content **and** large diffs. The `⚠ Truncated preview…` notice reports the actual configured cap instead of a hardcoded "1 MB / 5000-line".

## Why

Answers a direct ask: files past 5000 lines were cut with no way to raise the limit. The default line cap is also bumped 5000 → 10000 (friendlier for large-but-normal-width source, still reachable under the unchanged 1 MB byte cap).

## Design notes

- **Safety preserved (AC-N1).** The byte cap still bounds the actual file read; the upper clamp (64 MB) keeps every setting a *finite* read, so no configured value can make the viewer slurp an arbitrary file whole. Default stays 1 MB.
- **Single wiring seam.** `render::Caps` is injected into `classify` / `render`, resolved from config via `EffectiveSettings::preview_caps()` (the one place KiB → bytes). A lockstep test pins `Caps::default()` to a config-absent `resolve()` so the two default sources can't drift.
- Effective values surface in the `?` overlay's Settings tab.

## Docs (same PR)

`docs/configuration.md`, `config.example.toml`, `CHANGELOG.md` (`[Unreleased]`), plus the Settings-overlay rows and drift-guard tests (`tests/docs_consistency.rs`).

## Tests

- New: injected-cap truncation (a file the default shows whole is truncated at a smaller configured cap — line and byte paths), config parse → resolve → clamp for both keys, TOML key-name binding, and the default-lockstep guard.
- Existing diff-truncation tests made cap-relative so they can't rot on a future default change.
- Deterministic tier green locally: `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, full `cargo test` (0 failures), `cargo audit` unchanged.

Read-only, no new deps.