### PR TITLE
feat: git-status mode (d)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project are documented here. The format is based on
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Entries are short on purpose; follow the
 `→` links for the full detail.
 
+## [Unreleased]
+
+### Added
+- Git-status mode (`d`): filter the tree to current working-tree status and force working-tree diffs (file or directory-scoped); sticky until `d` again, mutually exclusive with baseline-aware `c`. → [usage](docs/usage.md#git-awareness) · [keys](docs/keys.md)
+
 ## [1.13.0] - 2026-07-16
 
 ### Added

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -155,7 +155,8 @@ customized).
 | | `tree_scroll_right` | `L` | Scroll the tree pane right |
 | **Git & filters** | `toggle_ignore` | `i` | Reveal or hide gitignored files |
 | | `toggle_hidden` | `.` | Hide or reveal dot-prefixed (hidden) files and folders |
-| | `toggle_changed_only` | `c` | Restrict the tree to changed files, or restore the full tree |
+| | `toggle_changed_only` | `c` | Restrict the tree to changed files (baseline-aware), or restore the full tree |
+| | `toggle_status_mode` | `d` | Toggle git-status mode: filter to current working-tree status and show working-tree diffs |
 | | `toggle_baseline` | `b` | Switch the diff baseline between base-branch and `HEAD` |
 | | `refresh` | `r` | Re-read git state and re-render |
 | **Open & copy** | `open_in_editor` | `e` | Hand the selected file off to an external editor |

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -20,8 +20,9 @@ is additive and on by default.
 | `Enter` | Activate the selection: expand/collapse a directory, or open a file in **zoom mode** (content full-screen) |
 | `i` | Toggle gitignored files |
 | `.` | Toggle hidden (dot-prefixed) files and folders |
-| `c` | Toggle changed-files-only |
-| `b` | Toggle the diff baseline (base branch ⇄ `HEAD`) |
+| `c` | Toggle changed-files-only (baseline-aware: follows `b`) |
+| `d` | **Git-status mode** (toggle): restrict the tree to current working-tree status (`M`/`A`/`?`/`D`) and force working-tree diffs in the content pane (file or directory-scoped). Mutually exclusive with `c`; press `d` again to leave |
+| `b` | Toggle the diff baseline (base branch ⇄ `HEAD`) — used by `c` and normal diffs; while `d` is on, content stays working-tree |
 | `v` | Cycle the content view mode |
 | `e` | Open the selected file in `$EDITOR` (see [Opening in an editor](#opening-in-an-editor)) |
 | `O` (Shift+`o`) | **Open with default app**: hand the selected file or directory to the OS default application (e.g. an image opens in the system viewer). Read-only hand-off; non-blocking (the viewer keeps running) |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -71,9 +71,15 @@ Git status is woven straight into the tree, not a separate mode:
   deleted, `?` untracked — and a directory containing any change carries a `●`. They're **colored**
   so changes read at a glance (changed files and dirty folders red, new files green), with the glyph
   as a non-color cue so status survives a colorblind palette or a non-default terminal theme.
-- **Changed-files-only filter**: press `c` to restrict the tree to files git reports as changed.
-- **Diff baseline**: press `b` to flip what "changed" and the diff compare against — the merge-base
-  of your branch (review your whole branch) versus `HEAD` (just your uncommitted work).
+- **Changed-files-only filter**: press `c` to restrict the tree to files changed against the active
+  baseline (`b`) — useful for reviewing a whole branch (merge-base) or just uncommitted work (`HEAD`).
+- **Git-status mode**: press `d` to filter the tree to **current working-tree status only**
+  (modified, staged, untracked, deleted — independent of baseline) and force working-tree diffs in
+  the content pane. On a directory, that means a unified diff of all tracked changes under it.
+  Press `d` again to leave. Mutually exclusive with `c` (turning one on turns the other off).
+- **Diff baseline**: press `b` to flip what "changed" and the normal/file-cycle diffs compare against
+  — the merge-base of your branch versus `HEAD`. While git-status mode (`d`) is on, content stays
+  working-tree; `b` still updates the stored baseline for when you leave `d` or use `c`.
 - **Refresh**: the viewer re-reads git status automatically when the pane regains focus, so a merge,
   pull, or commit you make elsewhere shows up on its own; `r` forces a full refresh on demand.
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -398,6 +398,14 @@ impl GitService for LiveGit {
             full_context,
         )
     }
+    fn diff_directory(&self, rel_dir: &Path, baseline: Baseline) -> String {
+        git::diff_directory(
+            &self.repo_root,
+            rel_dir,
+            baseline,
+            self.base_hint.as_deref(),
+        )
+    }
 }
 
 /// The live Content Renderer: classify + delegate to the external renderers, with guards.
@@ -844,6 +852,9 @@ mod tests {
         }
 
         fn diff(&self, _path: &Path, _baseline: Baseline, _full_context: bool) -> String {
+            String::new()
+        }
+        fn diff_directory(&self, _rel_dir: &Path, _baseline: Baseline) -> String {
             String::new()
         }
     }

--- a/src/controller/finder.rs
+++ b/src/controller/finder.rs
@@ -275,9 +275,19 @@ impl Controller {
         self.last_click = None; // closing the finder resets double-click state
         if self.tree.reveal(&abs) {
             // reveal() may have relaxed the tree's changed_only/hide_hidden fields — re-sync
-            // the controller's mirror fields so a later `c`/`.` toggle stays consistent
-            // (the mirrors at controller.rs:166-168 drive those toggles).
-            self.changed_only = self.tree.changed_only();
+            // the controller's mirror fields so a later `c`/`.`/`d` toggle stays consistent.
+            // Status mode and baseline-aware changed-only both use the tree's changed_only flag;
+            // if reveal turned the filter off, both controller mirrors must clear.
+            let tree_changed_only = self.tree.changed_only();
+            if !tree_changed_only {
+                self.changed_only = false;
+                self.status_mode = false;
+            } else if self.status_mode {
+                // Status mode owns the filter while active.
+                self.changed_only = false;
+            } else {
+                self.changed_only = true;
+            }
             self.hide_hidden = self.tree.hide_hidden();
             // If the content pane isn't currently visible — the narrow, tree-only layout where the
             // last frame drew no content column (`content_width == 0`) — open the jumped-to file in

--- a/src/controller/git_apply.rs
+++ b/src/controller/git_apply.rs
@@ -24,27 +24,32 @@ impl Controller {
         Effects::redraw()
     }
 
-    /// Store a new changed-set and re-apply the changed-only filter against it (AC-16). The two
-    /// move together — the filter reads `self.changed` — so the pair lives in one place and the
-    /// stored set and the displayed filter can never disagree.
+    /// Store a new baseline-dependent changed-set. Re-applies the tree filter only when
+    /// baseline-aware `c` is on — status mode (`d`) filters from [`Self::git_status`] instead.
     pub(super) fn set_changed(&mut self, changed: BTreeMap<PathBuf, Status>) {
         self.changed = changed;
-        self.tree.set_changed_only(self.changed_only, &self.changed);
+        if self.changed_only && !self.status_mode {
+            self.tree.set_changed_only(true, &self.changed);
+        }
     }
 
     /// Push a freshly-queried git status + changed-set onto the tree together: per-node status
-    /// markers (AC-7) plus the changed-set behind the changed-only filter (AC-16). The single
-    /// place a status and its matching changed-set are applied in lockstep, so the markers can
-    /// never drift from the set the filter reads. `changed` is passed in because callers source
-    /// it differently — synchronously (`refresh_git_state`) or from the off-thread re-root fetch
-    /// (`poll`).
+    /// markers (AC-7), the cached working-tree status for status mode (`d`), and the
+    /// baseline-dependent changed-set for `c` (AC-16). Callers source `changed` differently —
+    /// synchronously (`refresh_git_state`) or from the off-thread re-root fetch (`poll`).
     pub(super) fn apply_git_state(
         &mut self,
         status: &BTreeMap<PathBuf, Status>,
         changed: BTreeMap<PathBuf, Status>,
     ) {
+        self.git_status = status.clone();
         self.tree.set_status(status);
         self.set_changed(changed);
+        // Status mode filters from working-tree status; re-apply after a refresh so external
+        // edits (focus-gain / `r`) update the filtered tree without leaving the mode.
+        if self.status_mode {
+            self.tree.set_changed_only(true, &self.git_status);
+        }
     }
 
     /// Re-query git for the working-tree status (tree markers, AC-7) and the changed-set

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -1941,8 +1941,11 @@ impl Controller {
     /// Toggle sticky git-status mode (`d`): filter the tree to current working-tree status
     /// and force working-tree diffs. Mutually exclusive with baseline-aware `c`.
     fn toggle_status_mode(&mut self) -> Effects {
-        if !self.is_git_repo {
-            return Effects::noop(); // inert without git (AC-26)
+        // Entering status mode needs a repo (AC-26). Leaving it must stay possible even after a
+        // re-root into a non-git directory, otherwise a carried-on `status_mode` can leave the
+        // user stuck on an empty filtered tree with no way to turn `d` off.
+        if !self.is_git_repo && !self.status_mode {
+            return Effects::noop();
         }
         if self.status_mode {
             self.status_mode = false;

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -104,6 +104,10 @@ pub trait GitService: Send + Sync {
     /// `full_context`, git emits the whole file as context (for the full-file diff view);
     /// otherwise it returns the compact hunks-only diff.
     fn diff(&self, rel_path: &Path, baseline: Baseline, full_context: bool) -> String;
+    /// Raw unified diff for every tracked change under a repo-root-relative directory against
+    /// `baseline`. Empty `rel_dir` means the whole tree root. Used by git-status mode (`d`)
+    /// when a directory is selected.
+    fn diff_directory(&self, rel_dir: &Path, baseline: Baseline) -> String;
 }
 
 /// The rendered content pane for one file: ingested text plus any non-fatal notices
@@ -271,6 +275,10 @@ struct RenderJob {
     mode: ViewMode,
     baseline: Baseline,
     is_git: bool,
+    /// When true, the worker runs [`GitService::diff_directory`] on `rel` (directory-scoped
+    /// working-tree / baseline diff) instead of a single-file [`GitService::diff`]. Used by
+    /// git-status mode when a directory is selected.
+    directory_diff: bool,
     /// The content pane's drawable text width (columns) at dispatch, or `None` when unknown
     /// (e.g. the very first render before the first draw measured the pane). Only the markdown
     /// delegate uses it: glow lays out and wraps tables to this width so they fit the pane
@@ -446,6 +454,14 @@ pub struct Controller {
     /// is the pre-confirm behavior.
     confirm_discard: bool,
     changed_only: bool,
+    /// Sticky git-status mode (`d`): tree filtered to current working-tree status and content
+    /// forced to working-tree diffs (file or directory-scoped). Mutually exclusive with
+    /// [`Self::changed_only`] (baseline-aware `c`). Cleared only by a second `d` (or by
+    /// entering `c`, which turns this off).
+    status_mode: bool,
+    /// Working-tree status (`git status`), cached separately from the baseline-dependent
+    /// [`Self::changed`] set so status mode can filter independently of `b`.
+    git_status: BTreeMap<PathBuf, Status>,
     /// The tree's horizontal scroll offset (columns), for reading long / deeply-nested rows. Like
     /// the cursor it is navigation state: reset on a re-root (AC-13), not carried.
     tree_hscroll: u16,
@@ -726,6 +742,8 @@ impl Controller {
             confirm_discard: true,
             tree_hscroll: 0,
             changed_only: false,
+            status_mode: false,
+            git_status: BTreeMap::new(),
             focus: Focus::Tree,
             width: 0,
             content_scroll: 0,
@@ -817,10 +835,17 @@ impl Controller {
                 let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
                     let raw_diff =
                         if matches!(job.mode, ViewMode::Diff | ViewMode::FullDiff) && job.is_git {
-                            let full = job.mode == ViewMode::FullDiff;
-                            job.rel
-                                .as_deref()
-                                .map(|rel| git.diff(rel, job.baseline, full))
+                            if job.directory_diff {
+                                // Status mode on a directory: pathspec-scoped working-tree/baseline
+                                // diff (rel is empty for the tree root).
+                                let rel = job.rel.as_deref().unwrap_or_else(|| Path::new(""));
+                                Some(git.diff_directory(rel, job.baseline))
+                            } else {
+                                let full = job.mode == ViewMode::FullDiff;
+                                job.rel
+                                    .as_deref()
+                                    .map(|rel| git.diff(rel, job.baseline, full))
+                            }
                         } else {
                             None
                         };
@@ -951,6 +976,7 @@ impl Controller {
             )
         });
         self.changed = BTreeMap::new();
+        self.git_status = BTreeMap::new();
         // Close whatever modal is open (one assignment, since `modal` is now a single value). A
         // re-root only fires via picker-confirm, so in practice it's the picker being torn down —
         // but a re-root also invalidates the finder's old-root candidate list and must not strand a
@@ -960,7 +986,7 @@ impl Controller {
         self.last_click = None;
 
         // PREFERENCES ARE CARRIED (AC-12) — deliberately NOT reset: show_ignored, hide_hidden,
-        // changed_only, split_pct, tree_position, tree_max_cols, split_manual, wrap_override, baseline keep their current values. The fresh
+        // changed_only, status_mode, split_pct, tree_position, tree_max_cols, split_manual, wrap_override, baseline keep their current values. The fresh
         // TreeModel starts with default filter flags. `show_ignored` and `hide_hidden` are
         // git-independent, so apply them now. The changed-only *filter* is NOT applied here: it
         // must be applied against the REAL changed-set, which `dispatch_status_refresh` computes
@@ -984,7 +1010,12 @@ impl Controller {
     /// the re-root path, where the heavier status/changed-set work must not block input.
     fn dispatch_status_refresh(&mut self) {
         if !self.is_git_repo {
-            self.tree.set_changed_only(self.changed_only, &self.changed); // self.changed is empty
+            // Non-repo: both filters collapse to empty. Prefer the active mode's set.
+            if self.status_mode {
+                self.tree.set_changed_only(true, &self.git_status);
+            } else {
+                self.tree.set_changed_only(self.changed_only, &self.changed); // empty
+            }
             self.status_rx = None;
             return;
         }
@@ -1018,6 +1049,10 @@ impl Controller {
     }
     pub fn changed_only(&self) -> bool {
         self.changed_only
+    }
+    /// Whether sticky git-status mode (`d`) is active.
+    pub fn status_mode(&self) -> bool {
+        self.status_mode
     }
     pub fn baseline(&self) -> Baseline {
         self.baseline
@@ -1086,11 +1121,16 @@ impl Controller {
     }
 
     /// The effective view mode for the selected file (override or policy default), or `None`
-    /// when nothing / a directory is selected.
+    /// when nothing is selected. Directories normally have no view mode, except in git-status
+    /// mode (`d`) where they render a directory-scoped working-tree Diff.
     pub fn selected_view_mode(&self) -> Option<ViewMode> {
         let node = self.tree.selected()?;
         if node.kind != NodeKind::File {
-            return None;
+            return if self.status_mode && self.is_git_repo {
+                Some(ViewMode::Diff)
+            } else {
+                None
+            };
         }
         Some(self.effective_mode(&node.path))
     }
@@ -1554,6 +1594,7 @@ impl Controller {
             Intent::ToggleIgnore => self.toggle_ignore(),
             Intent::ToggleHidden => self.toggle_hidden(),
             Intent::ToggleChangedOnly => self.toggle_changed_only(),
+            Intent::ToggleStatusMode => self.toggle_status_mode(),
             Intent::ToggleBaseline => self.toggle_baseline(),
             Intent::CycleView => self.cycle_view(),
             Intent::OpenInEditor => self.open_in_editor(),
@@ -1887,8 +1928,34 @@ impl Controller {
         if !self.is_git_repo {
             return Effects::noop(); // inert without git (AC-26)
         }
+        // Mutually exclusive with status mode (`d`): entering baseline-aware `c` leaves `d`.
+        if !self.changed_only && self.status_mode {
+            self.status_mode = false;
+        }
         self.changed_only = !self.changed_only;
         self.tree.set_changed_only(self.changed_only, &self.changed);
+        self.dispatch_render();
+        Effects::redraw()
+    }
+
+    /// Toggle sticky git-status mode (`d`): filter the tree to current working-tree status
+    /// and force working-tree diffs. Mutually exclusive with baseline-aware `c`.
+    fn toggle_status_mode(&mut self) -> Effects {
+        if !self.is_git_repo {
+            return Effects::noop(); // inert without git (AC-26)
+        }
+        if self.status_mode {
+            self.status_mode = false;
+            // Leaving status mode: if `c` is not on, restore the full tree.
+            if !self.changed_only {
+                self.tree.set_changed_only(false, &self.changed);
+            }
+        } else {
+            // Entering status mode turns off baseline-aware changed-only.
+            self.changed_only = false;
+            self.status_mode = true;
+            self.tree.set_changed_only(true, &self.git_status);
+        }
         self.dispatch_render();
         Effects::redraw()
     }
@@ -2453,6 +2520,7 @@ impl Controller {
             mode: ViewMode::RenderedMarkdown,
             baseline: self.baseline,
             is_git: self.is_git_repo,
+            directory_diff: false,
             wrap_width: self.md_wrap_width(),
         });
     }
@@ -2494,12 +2562,23 @@ impl Controller {
             // that matched nothing. Show guidance instead of a blank pane.
             return self.clear_content(EmptyReason::NoFiles);
         };
-        if node.kind != NodeKind::File {
-            // A directory is selected — it has no content to render; show guidance so
-            // the pane is not a blank void.
+        // Git-status mode (`d`): directories render a pathspec-scoped working-tree diff instead of
+        // empty-state guidance. Files still go through the normal job path with forced Diff.
+        let (mode, directory_diff, baseline) = if self.status_mode && self.is_git_repo {
+            match node.kind {
+                NodeKind::Dir => (ViewMode::Diff, true, Baseline::Head),
+                NodeKind::File => (
+                    ViewMode::Diff,
+                    false,
+                    Baseline::Head, // status mode always diffs the working tree, not merge-base
+                ),
+            }
+        } else if node.kind != NodeKind::File {
+            // A directory is selected outside status mode — no content; show guidance.
             return self.clear_content(EmptyReason::Directory);
-        }
-        let mode = self.effective_mode(&node.path);
+        } else {
+            (self.effective_mode(&node.path), false, self.baseline)
+        };
         let rel = self.rel(&node.path);
         // a slow render used to leave the PREVIOUS file's body visible under the NEW
         // selection's title (the title is derived from the tree cursor, which moves immediately,
@@ -2520,8 +2599,9 @@ impl Controller {
                 path: node.path,
                 rel,
                 mode,
-                baseline: self.baseline,
+                baseline,
                 is_git: self.is_git_repo,
+                directory_diff,
                 wrap_width: self.md_wrap_width(),
             })
             .is_ok()
@@ -2669,7 +2749,11 @@ impl Controller {
     }
 
     /// The effective view mode for a file: the user's override, else the policy default.
+    /// Git-status mode (`d`) forces Diff regardless of override — the mode is the product.
     fn effective_mode(&self, path: &Path) -> ViewMode {
+        if self.status_mode && self.is_git_repo {
+            return ViewMode::Diff;
+        }
         self.overrides
             .get(path)
             .copied()
@@ -2677,7 +2761,8 @@ impl Controller {
     }
 
     /// The View Policy facts about a file: markdown by extension, changed by the cached
-    /// changed-set (so it tracks the active baseline).
+    /// changed-set (so it tracks the active baseline). In status mode, "changed" means present
+    /// in the working-tree status set so Diff is always the default for filtered files.
     fn descriptor(&self, path: &Path) -> FileDescriptor {
         FileDescriptor {
             path: path.to_path_buf(),
@@ -2688,7 +2773,13 @@ impl Controller {
 
     fn is_changed(&self, path: &Path) -> bool {
         self.rel(path)
-            .map(|rel| self.changed.contains_key(&rel))
+            .map(|rel| {
+                if self.status_mode {
+                    self.git_status.contains_key(&rel)
+                } else {
+                    self.changed.contains_key(&rel)
+                }
+            })
             .unwrap_or(false)
     }
 
@@ -2799,6 +2890,9 @@ mod tests {
             BTreeMap::new()
         }
         fn diff(&self, _rel: &Path, _baseline: Baseline, _full: bool) -> String {
+            String::new()
+        }
+        fn diff_directory(&self, _rel_dir: &Path, _baseline: Baseline) -> String {
             String::new()
         }
     }

--- a/src/git.rs
+++ b/src/git.rs
@@ -260,10 +260,11 @@ pub fn diff(
     capture_stdout(cmd)
 }
 
-/// Raw unified diff for every tracked change under `rel_dir` against `baseline`.
+/// Raw unified diff for every change under `rel_dir` against `baseline`.
 /// `rel_dir` is repo-root-relative; an empty path means the whole tree root (no pathspec).
-/// Untracked files are not included — `git diff` only sees the index/worktree for tracked paths
-/// (file-level untracked still uses the single-file [`diff`] `--no-index` path).
+/// Tracked changes come from one directory-scoped git diff; untracked files are appended using the
+/// same `--no-index` path used by the single-file [`diff`] query, so a status-mode directory view
+/// includes every `?` descendant as well as modified/staged/deleted tracked files.
 pub fn diff_directory(
     repo_root: &Path,
     rel_dir: &Path,
@@ -290,7 +291,43 @@ pub fn diff_directory(
     if !rel_dir.as_os_str().is_empty() {
         cmd.arg(rel_dir);
     }
-    capture_stdout(cmd)
+    let mut output = capture_stdout(cmd);
+
+    // `git diff` intentionally omits untracked paths. Add each untracked descendant through the
+    // existing single-file path, which emits a safe /dev/null-vs-file patch and already handles
+    // binary content, path confinement, and platform null-device differences.
+    //
+    // Bound the running total to the SAME hard [`MAX_DIFF_BYTES`] limit [`capture_stdout`] applies
+    // to a single git invocation, so a directory with many (or large) untracked files can never
+    // build an oversized string in memory. The final admitted patch is trimmed to the remaining
+    // budget at a UTF-8 boundary (mirroring `capture_stdout`'s own byte-cap truncation); the render
+    // layer's AC-13 preview cap already truncates the visible pane far below this, so the trimmed
+    // tail is never displayed. `status` is a `BTreeMap`, so the paths admitted before the cap are
+    // the lexicographically-first ones (deterministic), not an arbitrary subset.
+    let cap = MAX_DIFF_BYTES as usize;
+    for (path, state) in status(repo_root) {
+        if cap.saturating_sub(output.len()) == 0 {
+            break;
+        }
+        if state != Status::Untracked
+            || (!rel_dir.as_os_str().is_empty() && !path.starts_with(rel_dir))
+        {
+            continue;
+        }
+        let file_diff = diff(repo_root, &path, baseline, base_hint, false);
+        if file_diff.is_empty() {
+            continue;
+        }
+        if !output.is_empty() && !output.ends_with('\n') {
+            output.push('\n');
+        }
+        // Append only what fits in the remaining budget, cut at a char boundary so the String
+        // stays valid UTF-8. `floor_char_boundary` returns the largest boundary <= the index.
+        let budget = cap.saturating_sub(output.len());
+        let take = file_diff.floor_char_boundary(budget.min(file_diff.len()));
+        output.push_str(&file_diff[..take]);
+    }
+    output
 }
 
 /// Build a `git -C <dir> <args>` command hardened for read-only use against an **untrusted**

--- a/src/git.rs
+++ b/src/git.rs
@@ -41,6 +41,12 @@ const FULL_CONTEXT: &str = "-U1000000";
 /// layer's display cap (AC-13) runs. Comfortably above that display cap (render's ~1 MB), so
 /// it never reduces what the user sees — only the transient buffer and git's work.
 const MAX_DIFF_BYTES: u64 = 4 * 1024 * 1024; // 4 MB
+/// Hard cap on how many untracked descendants a directory diff will spawn a `git` process for.
+/// The byte cap ([`MAX_DIFF_BYTES`]) alone does not bound process spawns: a directory of many
+/// *small* untracked files stays under it while still spawning one process each. The render
+/// layer's AC-13 preview cap truncates the visible pane far below this, so a dropped tail is
+/// never displayed.
+const MAX_UNTRACKED_DIFF_FILES: usize = 512;
 
 /// A file's git status against the working tree (AC-7).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -231,19 +237,7 @@ pub fn diff(
     // The path is appended as a raw OsStr arg (not lossy UTF-8) so non-ASCII / non-UTF-8
     // filenames reach git verbatim and their diffs are not silently empty.
     if is_untracked(repo_root, path) {
-        let mut args = vec![
-            "diff",
-            "--no-ext-diff",
-            "--no-textconv",
-            "--no-index",
-            "--no-color",
-        ];
-        args.extend(unified);
-        args.push("--");
-        args.push(NULL_DEVICE);
-        let mut cmd = git_command(repo_root, &args);
-        cmd.arg(path);
-        return capture_stdout(cmd);
+        return diff_untracked(repo_root, path, unified);
     }
     let against = match baseline {
         Baseline::Head => head_or_empty_tree(repo_root),
@@ -255,6 +249,30 @@ pub fn diff(
     args.extend(unified);
     args.push(&against);
     args.push("--");
+    let mut cmd = git_command(repo_root, &args);
+    cmd.arg(path);
+    capture_stdout(cmd)
+}
+
+/// The `/dev/null`-vs-file `--no-index` patch for a KNOWN-untracked path (all its content shown
+/// as additions). The caller guarantees `path` is untracked, so this skips the `is_untracked`
+/// probe that the general [`diff`] must run first — one `git` process, not two. `unified` is the
+/// optional full-context window. Read-only, and the same root-confinement guard [`diff`] applies
+/// (AC-N5) so a status-derived path can never resolve outside the tree.
+fn diff_untracked(repo_root: &Path, path: &Path, unified: Option<&str>) -> String {
+    if !is_within_root(repo_root, path) {
+        return String::new();
+    }
+    let mut args = vec![
+        "diff",
+        "--no-ext-diff",
+        "--no-textconv",
+        "--no-index",
+        "--no-color",
+    ];
+    args.extend(unified);
+    args.push("--");
+    args.push(NULL_DEVICE);
     let mut cmd = git_command(repo_root, &args);
     cmd.arg(path);
     capture_stdout(cmd)
@@ -293,20 +311,24 @@ pub fn diff_directory(
     }
     let mut output = capture_stdout(cmd);
 
-    // `git diff` intentionally omits untracked paths. Add each untracked descendant through the
-    // existing single-file path, which emits a safe /dev/null-vs-file patch and already handles
-    // binary content, path confinement, and platform null-device differences.
+    // `git diff` intentionally omits untracked paths. Append each untracked descendant as a safe
+    // /dev/null-vs-file patch via [`diff_untracked`] — NOT the general [`diff`], which would
+    // re-spawn `git ls-files` to re-establish untracked-ness we already have from `status` (a
+    // second, wasted process per file).
     //
-    // Bound the running total to the SAME hard [`MAX_DIFF_BYTES`] limit [`capture_stdout`] applies
-    // to a single git invocation, so a directory with many (or large) untracked files can never
-    // build an oversized string in memory. The final admitted patch is trimmed to the remaining
-    // budget at a UTF-8 boundary (mirroring `capture_stdout`'s own byte-cap truncation); the render
-    // layer's AC-13 preview cap already truncates the visible pane far below this, so the trimmed
-    // tail is never displayed. `status` is a `BTreeMap`, so the paths admitted before the cap are
-    // the lexicographically-first ones (deterministic), not an arbitrary subset.
+    // Two independent bounds, because they guard different resources:
+    //   • BYTES — cap the running total at [`MAX_DIFF_BYTES`] (like [`capture_stdout`] does for a
+    //     single invocation) so the string can't grow oversized; the final admitted patch is
+    //     trimmed to the remaining budget at a UTF-8 boundary.
+    //   • COUNT — cap the number of spawned processes at [`MAX_UNTRACKED_DIFF_FILES`]; the byte cap
+    //     alone doesn't bound spawns when the untracked files are small (many stay under it).
+    // The render layer's AC-13 preview cap truncates the visible pane far below either bound, so a
+    // dropped tail is never displayed. `status` is a `BTreeMap`, so the paths admitted before a cap
+    // are the lexicographically-first ones (deterministic), not an arbitrary subset.
     let cap = MAX_DIFF_BYTES as usize;
+    let mut spawned = 0usize;
     for (path, state) in status(repo_root) {
-        if cap.saturating_sub(output.len()) == 0 {
+        if cap.saturating_sub(output.len()) == 0 || spawned >= MAX_UNTRACKED_DIFF_FILES {
             break;
         }
         if state != Status::Untracked
@@ -314,7 +336,8 @@ pub fn diff_directory(
         {
             continue;
         }
-        let file_diff = diff(repo_root, &path, baseline, base_hint, false);
+        spawned += 1;
+        let file_diff = diff_untracked(repo_root, &path, None);
         if file_diff.is_empty() {
             continue;
         }

--- a/src/git.rs
+++ b/src/git.rs
@@ -260,6 +260,39 @@ pub fn diff(
     capture_stdout(cmd)
 }
 
+/// Raw unified diff for every tracked change under `rel_dir` against `baseline`.
+/// `rel_dir` is repo-root-relative; an empty path means the whole tree root (no pathspec).
+/// Untracked files are not included — `git diff` only sees the index/worktree for tracked paths
+/// (file-level untracked still uses the single-file [`diff`] `--no-index` path).
+pub fn diff_directory(
+    repo_root: &Path,
+    rel_dir: &Path,
+    baseline: Baseline,
+    base_hint: Option<&str>,
+) -> String {
+    if !rel_dir.as_os_str().is_empty() {
+        let abs = repo_root.join(rel_dir);
+        if !is_within_root(repo_root, &abs) {
+            return String::new();
+        }
+    }
+    let against = match baseline {
+        Baseline::Head => head_or_empty_tree(repo_root),
+        Baseline::Base => {
+            base_fork_point(repo_root, base_hint).unwrap_or_else(|| head_or_empty_tree(repo_root))
+        }
+    };
+    // Pathspec only when scoped to a subdir; empty pathspec = whole tree.
+    let mut args = vec!["diff", "--no-ext-diff", "--no-textconv", "--no-color"];
+    args.push(&against);
+    args.push("--");
+    let mut cmd = git_command(repo_root, &args);
+    if !rel_dir.as_os_str().is_empty() {
+        cmd.arg(rel_dir);
+    }
+    capture_stdout(cmd)
+}
+
 /// Build a `git -C <dir> <args>` command hardened for read-only use against an **untrusted**
 /// repository: `GIT_OPTIONAL_LOCKS=0` stops status/diff from writing the index (AC-N2);
 /// `core.fsmonitor` / `core.hooksPath` are neutralized so a planted `.git/config` can't run a

--- a/src/git.rs
+++ b/src/git.rs
@@ -270,11 +270,11 @@ pub fn diff_directory(
     baseline: Baseline,
     base_hint: Option<&str>,
 ) -> String {
-    if !rel_dir.as_os_str().is_empty() {
-        let abs = repo_root.join(rel_dir);
-        if !is_within_root(repo_root, &abs) {
-            return String::new();
-        }
+    // Same root-bound check as [`diff`]: reject absolute paths and any `..` component so a
+    // pathspec cannot escape the tree root (AC-N5). Pass the *relative* path — joining first
+    // would make `is_within_root` see an absolute path and always reject it.
+    if !rel_dir.as_os_str().is_empty() && !is_within_root(repo_root, rel_dir) {
+        return String::new();
     }
     let against = match baseline {
         Baseline::Head => head_or_empty_tree(repo_root),
@@ -487,6 +487,28 @@ fn classify_name_status(code: &str) -> Option<Status> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn diff_directory_rejects_parent_dir_and_absolute_pathspecs() {
+        // AC-N5: pathspecs must stay inside the tree root. `..` and absolute paths are rejected
+        // before any git invocation (is_within_root rejects both).
+        let root = Path::new("/tmp/some-repo");
+        assert_eq!(
+            diff_directory(root, Path::new(".."), Baseline::Head, None),
+            "",
+            "parent-dir pathspec must not run git"
+        );
+        assert_eq!(
+            diff_directory(root, Path::new("../outside"), Baseline::Head, None),
+            "",
+            "escaped relative pathspec must not run git"
+        );
+        assert_eq!(
+            diff_directory(root, Path::new("/etc"), Baseline::Head, None),
+            "",
+            "absolute pathspec must not run git"
+        );
+    }
 
     // ---- path_from_git_bytes: platform path-decode seam (AC-5, T-1) ------------
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -202,7 +202,14 @@ pub(crate) const REGISTRY: &[Binding] = &[
         intent: Intent::ToggleChangedOnly,
         name: "toggle_changed_only",
         default_keys: &[KeyCode::Char('c')],
-        description: "Restrict the tree to changed files, or restore the full tree.",
+        description: "Restrict the tree to changed files (baseline-aware), or restore the full tree.",
+        category: "Git & filters",
+    },
+    Binding {
+        intent: Intent::ToggleStatusMode,
+        name: "toggle_status_mode",
+        default_keys: &[KeyCode::Char('d')],
+        description: "Toggle git-status mode: filter to current working-tree status and show working-tree diffs.",
         category: "Git & filters",
     },
     Binding {
@@ -689,6 +696,7 @@ mod tests {
         (KeyCode::Char('i'), Intent::ToggleIgnore),
         (KeyCode::Char('.'), Intent::ToggleHidden),
         (KeyCode::Char('c'), Intent::ToggleChangedOnly),
+        (KeyCode::Char('d'), Intent::ToggleStatusMode),
         (KeyCode::Char('b'), Intent::ToggleBaseline),
         (KeyCode::Char('v'), Intent::CycleView),
         (KeyCode::Char('e'), Intent::OpenInEditor),
@@ -868,11 +876,21 @@ mod tests {
 
     #[test]
     fn modified_char_keys_do_not_trigger_intents() {
-        // Ctrl+C is the terminal interrupt, not "changed-only"; Alt-chords are unbound too.
-        // Accidental or reserved chords must not fire a viewer action.
+        // Ctrl+C is the terminal interrupt, not "changed-only"; Ctrl/Alt-d must not fire
+        // status mode either. Accidental or reserved chords must not fire a viewer action.
         assert_eq!(
             map_key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL)),
             None
+        );
+        assert_eq!(
+            map_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::CONTROL)),
+            None,
+            "Ctrl-d must not fire status mode"
+        );
+        assert_eq!(
+            map_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::ALT)),
+            None,
+            "Alt-d must not fire status mode"
         );
         assert_eq!(
             map_key(KeyEvent::new(KeyCode::Char('e'), KeyModifiers::ALT)),
@@ -881,6 +899,20 @@ mod tests {
         assert_eq!(
             map_key(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::CONTROL)),
             None
+        );
+    }
+
+    #[test]
+    fn d_maps_to_status_mode() {
+        assert_eq!(
+            map_key(k(KeyCode::Char('d'))),
+            Some(Intent::ToggleStatusMode),
+            "d toggles git-status mode"
+        );
+        assert_eq!(
+            map_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::SHIFT)),
+            Some(Intent::ToggleStatusMode),
+            "Shift-d still toggles status mode (same as bare d)"
         );
     }
 

--- a/src/intent.rs
+++ b/src/intent.rs
@@ -41,6 +41,10 @@ pub enum Intent {
     ToggleHidden,
     /// Restrict the tree to changed files / restore the full tree (AC-6).
     ToggleChangedOnly,
+    /// Toggle git-status mode: filter the tree to current working-tree status and force
+    /// working-tree diffs in the content pane (file or directory-scoped). Mutually exclusive
+    /// with [`Intent::ToggleChangedOnly`] (which stays baseline-aware for branch review).
+    ToggleStatusMode,
     /// Switch the diff baseline between base-branch and HEAD (AC-16).
     ToggleBaseline,
     /// Cycle the content pane's view mode over the applicable set (AC-11).
@@ -134,7 +138,7 @@ pub enum Intent {
 impl Intent {
     /// Every intent variant — lets the dispatcher and tests enumerate the closed set so
     /// keyboard-completeness (AC-18) and the no-file/git-mutation invariant (AC-N3) stay checkable.
-    pub const ALL: [Intent; 35] = [
+    pub const ALL: [Intent; 36] = [
         Intent::NavUp,
         Intent::NavDown,
         Intent::Expand,
@@ -144,6 +148,7 @@ impl Intent {
         Intent::ToggleIgnore,
         Intent::ToggleHidden,
         Intent::ToggleChangedOnly,
+        Intent::ToggleStatusMode,
         Intent::ToggleBaseline,
         Intent::CycleView,
         Intent::OpenInEditor,
@@ -195,6 +200,7 @@ mod tests {
                 | Intent::ToggleIgnore
                 | Intent::ToggleHidden
                 | Intent::ToggleChangedOnly
+                | Intent::ToggleStatusMode
                 | Intent::ToggleBaseline
                 | Intent::CycleView
                 | Intent::OpenInEditor
@@ -292,11 +298,11 @@ mod tests {
     }
 
     #[test]
-    fn all_length_is_35() {
+    fn all_length_is_36() {
         assert_eq!(
             Intent::ALL.len(),
-            35,
-            "Intent::ALL must have exactly 35 variants after adding annotation actions"
+            36,
+            "Intent::ALL must have exactly 36 variants after adding ToggleStatusMode"
         );
     }
 

--- a/tests/annotations.rs
+++ b/tests/annotations.rs
@@ -36,6 +36,9 @@ impl GitService for StubGit {
     fn diff(&self, _path: &Path, _baseline: Baseline, _full: bool) -> String {
         String::new()
     }
+    fn diff_directory(&self, _rel_dir: &Path, _baseline: Baseline) -> String {
+        String::new()
+    }
 }
 
 struct NoopEditor;

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -57,6 +57,9 @@ impl GitService for StubGit {
     fn diff(&self, _rel_path: &Path, _baseline: Baseline, _full_context: bool) -> String {
         String::new()
     }
+    fn diff_directory(&self, _rel_dir: &Path, _baseline: Baseline) -> String {
+        String::new()
+    }
 }
 
 /// A Content Renderer stub: returns fixed text and no notices, so the controller's content
@@ -146,6 +149,14 @@ fn controller(
         components,
     );
     (ctrl, changed_calls, opened)
+}
+
+fn visible_names(ctrl: &Controller) -> Vec<String> {
+    ctrl.tree()
+        .visible_nodes()
+        .iter()
+        .map(|n| n.path.file_name().unwrap().to_string_lossy().into_owned())
+        .collect()
 }
 
 // ---- tests ----------------------------------------------------------------------------
@@ -339,6 +350,120 @@ fn toggle_changed_only_flips_in_a_repo() {
     assert!(
         !ctrl.changed_only(),
         "toggling again restores the full tree"
+    );
+}
+
+#[test]
+fn toggle_status_mode_filters_by_git_status_not_baseline_changed_set() {
+    // `d` filters to working-tree status even when the baseline-dependent changed-set differs.
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("status_only.rs"), "s\n").unwrap();
+    std::fs::write(dir.path().join("base_only.rs"), "b\n").unwrap();
+    std::fs::write(dir.path().join("clean.rs"), "c\n").unwrap();
+
+    let mut status = BTreeMap::new();
+    status.insert(PathBuf::from("status_only.rs"), Status::Modified);
+    let mut changed = BTreeMap::new();
+    changed.insert(PathBuf::from("base_only.rs"), Status::Modified);
+    let git = StubGit {
+        status,
+        changed,
+        ..Default::default()
+    };
+    let (mut ctrl, _, _) = controller(dir.path(), true, git, false);
+
+    assert!(!ctrl.status_mode());
+    let fx = ctrl.handle(Intent::ToggleStatusMode);
+    assert!(ctrl.status_mode(), "d enters git-status mode");
+    assert!(!ctrl.changed_only(), "d is not baseline-aware c");
+    assert!(fx.redraw);
+
+    let visible = visible_names(&ctrl);
+    assert!(
+        visible.iter().any(|n| n == "status_only.rs"),
+        "status mode shows working-tree status files: {visible:?}"
+    );
+    assert!(
+        !visible.iter().any(|n| n == "base_only.rs"),
+        "status mode must not show baseline-only files: {visible:?}"
+    );
+    assert!(
+        !visible.iter().any(|n| n == "clean.rs"),
+        "status mode hides clean files: {visible:?}"
+    );
+
+    ctrl.handle(Intent::ToggleStatusMode);
+    assert!(!ctrl.status_mode(), "second d leaves status mode");
+    let restored = visible_names(&ctrl);
+    assert!(
+        restored.iter().any(|n| n == "clean.rs"),
+        "leaving d restores the full tree: {restored:?}"
+    );
+}
+
+#[test]
+fn status_mode_and_changed_only_are_mutually_exclusive() {
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.rs"), "a\n").unwrap();
+    let mut status = BTreeMap::new();
+    status.insert(PathBuf::from("a.rs"), Status::Modified);
+    let git = StubGit {
+        status: status.clone(),
+        changed: status,
+        ..Default::default()
+    };
+    let (mut ctrl, _, _) = controller(dir.path(), true, git, false);
+
+    ctrl.handle(Intent::ToggleChangedOnly);
+    assert!(ctrl.changed_only());
+    assert!(!ctrl.status_mode());
+
+    ctrl.handle(Intent::ToggleStatusMode);
+    assert!(ctrl.status_mode(), "d turns on status mode");
+    assert!(!ctrl.changed_only(), "d turns off c");
+
+    ctrl.handle(Intent::ToggleChangedOnly);
+    assert!(ctrl.changed_only(), "c turns on changed-only");
+    assert!(!ctrl.status_mode(), "c turns off d");
+}
+
+#[test]
+fn status_mode_is_inert_without_git() {
+    let dir = TempDir::new();
+    let (mut ctrl, _, _) = controller(dir.path(), false, StubGit::default(), false);
+    let fx = ctrl.handle(Intent::ToggleStatusMode);
+    assert!(!ctrl.status_mode());
+    assert!(!fx.redraw, "no git → d is a no-op");
+}
+
+#[test]
+fn baseline_toggle_while_status_mode_keeps_status_filter() {
+    // `b` must keep working while `d` is on (stored baseline updates) without leaving status mode.
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("wt.rs"), "w\n").unwrap();
+    let mut status = BTreeMap::new();
+    status.insert(PathBuf::from("wt.rs"), Status::Modified);
+    let git = StubGit {
+        status: status.clone(),
+        changed: status,
+        ..Default::default()
+    };
+    let (mut ctrl, calls, _) = controller(dir.path(), true, git, false);
+
+    ctrl.handle(Intent::ToggleStatusMode);
+    assert!(ctrl.status_mode());
+    assert_eq!(ctrl.baseline(), Baseline::Head);
+
+    ctrl.handle(Intent::ToggleBaseline);
+    assert_eq!(ctrl.baseline(), Baseline::Base, "b still flips baseline");
+    assert!(ctrl.status_mode(), "b does not leave status mode");
+    assert!(
+        visible_names(&ctrl).iter().any(|n| n == "wt.rs"),
+        "status filter stays applied after b"
+    );
+    assert!(
+        calls.lock().unwrap().contains(&Baseline::Base),
+        "b still recomputes the baseline changed-set for when c is used later"
     );
 }
 
@@ -2774,6 +2899,9 @@ impl GitService for EvolvingGit {
         }
     }
     fn diff(&self, _p: &Path, _b: Baseline, _full: bool) -> String {
+        String::new()
+    }
+    fn diff_directory(&self, _rel_dir: &Path, _baseline: Baseline) -> String {
         String::new()
     }
 }
@@ -9505,6 +9633,9 @@ impl GitService for CountingGit {
     }
     fn diff(&self, _rel_path: &Path, _baseline: Baseline, _full_context: bool) -> String {
         self.calls.lock().unwrap().push("diff");
+        String::new()
+    }
+    fn diff_directory(&self, _rel_dir: &Path, _baseline: Baseline) -> String {
         String::new()
     }
 }

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -401,6 +401,92 @@ fn toggle_status_mode_filters_by_git_status_not_baseline_changed_set() {
     );
 }
 
+/// A Git stub whose `status()` result CHANGES after the first call, so a test can drive the
+/// refresh path (`Refresh` / re-query) and see the tree re-filter from the new working-tree
+/// status. `changed_set` stays empty (status mode is baseline-independent).
+struct EvolvingStatusGit {
+    first: BTreeMap<PathBuf, Status>,
+    rest: BTreeMap<PathBuf, Status>,
+    calls: Arc<Mutex<usize>>,
+}
+impl GitService for EvolvingStatusGit {
+    fn status(&self) -> BTreeMap<PathBuf, Status> {
+        let mut n = self.calls.lock().unwrap();
+        *n += 1;
+        if *n <= 1 {
+            self.first.clone()
+        } else {
+            self.rest.clone()
+        }
+    }
+    fn changed_set(&self, _baseline: Baseline) -> BTreeMap<PathBuf, Status> {
+        BTreeMap::new()
+    }
+    fn diff(&self, _p: &Path, _b: Baseline, _full: bool) -> String {
+        String::new()
+    }
+    fn diff_directory(&self, _rel_dir: &Path, _baseline: Baseline) -> String {
+        String::new()
+    }
+}
+
+#[test]
+fn status_mode_refilters_from_working_tree_status_on_refresh() {
+    // In status mode, `r` (Refresh) must re-query git status and re-filter the tree from the NEW
+    // working-tree status WITHOUT leaving the mode — the `apply_git_state` status-mode branch. A
+    // single changed file at each step makes the visible set deterministic.
+    let dir = TempDir::new();
+    for f in ["a.rs", "b.rs"] {
+        std::fs::write(dir.path().join(f), "x\n").unwrap();
+    }
+    let (a, b) = (PathBuf::from("a.rs"), PathBuf::from("b.rs"));
+    let git = EvolvingStatusGit {
+        first: BTreeMap::from([(a.clone(), Status::Modified)]), // only a.rs dirty initially
+        rest: BTreeMap::from([(b.clone(), Status::Modified)]),  // after an external edit: only b.rs
+        calls: Arc::new(Mutex::new(0)),
+    };
+    let git: Arc<dyn GitService> = Arc::new(git);
+    let components = Components {
+        providers: Box::new(move |_resolved| RootProviders {
+            git: Arc::clone(&git),
+            content: Box::new(StubContent),
+        }),
+        editor: Box::new(StubEditor::default()),
+        clipboard: Box::new(common::RecordingClipboard::default()),
+        renderers: None,
+    };
+    let mut ctrl = Controller::new(
+        common::resolved(dir.path().to_path_buf(), true),
+        Baseline::Head,
+        components,
+    );
+
+    ctrl.handle(Intent::ToggleStatusMode);
+    assert!(ctrl.status_mode());
+    let before = visible_names(&ctrl);
+    assert!(
+        before.iter().any(|n| n == "a.rs"),
+        "initial status shows a.rs: {before:?}"
+    );
+    assert!(
+        !before.iter().any(|n| n == "b.rs"),
+        "b.rs is clean initially: {before:?}"
+    );
+
+    ctrl.handle(Intent::Refresh);
+
+    assert!(ctrl.status_mode(), "refresh must not leave status mode");
+    let after = visible_names(&ctrl);
+    assert!(
+        after.iter().any(|n| n == "b.rs"),
+        "refresh re-filters to the new status (b.rs): {after:?}"
+    );
+    assert!(
+        !after.iter().any(|n| n == "a.rs"),
+        "a.rs left the status set after refresh: {after:?}"
+    );
+}
+
 #[test]
 fn status_mode_and_changed_only_are_mutually_exclusive() {
     let dir = TempDir::new();

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -437,6 +437,39 @@ fn status_mode_is_inert_without_git() {
 }
 
 #[test]
+fn status_mode_can_be_turned_off_after_reroot_to_non_git() {
+    // status_mode is a carried preference. Re-rooting into a non-git directory must not
+    // trap the user: `d` still turns the mode off even though entering is inert without git.
+    let repo = TempDir::new();
+    std::fs::write(repo.path().join("a.rs"), "a\n").unwrap();
+    let mut status = BTreeMap::new();
+    status.insert(PathBuf::from("a.rs"), Status::Modified);
+    let git = StubGit {
+        status: status.clone(),
+        changed: status,
+        ..Default::default()
+    };
+    let (mut ctrl, _, _) = controller(repo.path(), true, git, false);
+    ctrl.handle(Intent::ToggleStatusMode);
+    assert!(ctrl.status_mode(), "precondition: status mode on");
+
+    let non_git = TempDir::new();
+    std::fs::write(non_git.path().join("plain.txt"), "x\n").unwrap();
+    ctrl.re_root(non_git.path());
+    assert!(
+        ctrl.status_mode(),
+        "status_mode is a carried preference across re-root"
+    );
+
+    let fx = ctrl.handle(Intent::ToggleStatusMode);
+    assert!(
+        !ctrl.status_mode(),
+        "d must still turn status mode off without git"
+    );
+    assert!(fx.redraw);
+}
+
+#[test]
 fn baseline_toggle_while_status_mode_keeps_status_filter() {
     // `b` must keep working while `d` is on (stored baseline updates) without leaving status mode.
     let dir = TempDir::new();

--- a/tests/controller_async.rs
+++ b/tests/controller_async.rs
@@ -73,6 +73,9 @@ impl GitService for NoGit {
     fn diff(&self, _: &Path, _: Baseline, _full: bool) -> String {
         String::new()
     }
+    fn diff_directory(&self, _rel_dir: &Path, _baseline: Baseline) -> String {
+        String::new()
+    }
 }
 
 struct NoEditor;
@@ -102,6 +105,55 @@ impl GitService for RecordingGit {
             "FULL".into()
         } else {
             "COMPACT".into()
+        }
+    }
+    fn diff_directory(&self, _rel_dir: &Path, _baseline: Baseline) -> String {
+        String::new()
+    }
+}
+
+/// Records file + directory diff calls and the baseline each used — for status-mode proofs.
+struct StatusModeGit {
+    status: BTreeMap<PathBuf, Status>,
+    file_diffs: Arc<Mutex<Vec<(PathBuf, Baseline)>>>,
+    dir_diffs: Arc<Mutex<Vec<(PathBuf, Baseline)>>>,
+}
+impl GitService for StatusModeGit {
+    fn status(&self) -> BTreeMap<PathBuf, Status> {
+        self.status.clone()
+    }
+    fn changed_set(&self, _: Baseline) -> BTreeMap<PathBuf, Status> {
+        // Deliberately empty / different from status: status mode must not use this set.
+        BTreeMap::new()
+    }
+    fn diff(&self, rel: &Path, baseline: Baseline, _full: bool) -> String {
+        self.file_diffs
+            .lock()
+            .unwrap()
+            .push((rel.to_path_buf(), baseline));
+        format!("FILEDIFF:{}", rel.display())
+    }
+    fn diff_directory(&self, rel_dir: &Path, baseline: Baseline) -> String {
+        self.dir_diffs
+            .lock()
+            .unwrap()
+            .push((rel_dir.to_path_buf(), baseline));
+        format!("DIRDIFF:{}", rel_dir.display())
+    }
+}
+
+/// Content provider that surfaces the raw_diff string so tests can assert which git path ran.
+struct EchoDiffContent;
+impl ContentProvider for EchoDiffContent {
+    fn render(&self, path: &Path, mode: ViewMode, raw_diff: Option<&str>) -> RenderResult {
+        let name = path.file_name().unwrap_or_default().to_string_lossy();
+        RenderResult {
+            content: Text::raw(format!(
+                "mode={mode:?};file={name};diff={}",
+                raw_diff.unwrap_or("-")
+            )),
+            notices: Vec::new(),
+            source: None,
         }
     }
 }
@@ -956,4 +1008,171 @@ fn a_committed_search_ordinal_is_clamped_when_a_reflow_shrinks_the_match_count()
     );
     // And navigation on the clamped state does not panic.
     ctrl.handle(Intent::NextMatch);
+}
+
+#[test]
+fn status_mode_forces_working_tree_file_diff() {
+    // Entering `d` on a status file must ask git.diff with Baseline::Head (working tree),
+    // even if the session baseline is Base.
+    let dir = TempDir::new();
+    std::fs::create_dir_all(dir.path().join("src")).unwrap();
+    std::fs::write(dir.path().join("src/a.rs"), "a\n").unwrap();
+
+    let mut status = BTreeMap::new();
+    status.insert(PathBuf::from("src/a.rs"), Status::Modified);
+    let file_diffs = Arc::new(Mutex::new(Vec::new()));
+    let dir_diffs = Arc::new(Mutex::new(Vec::new()));
+    let git: Arc<dyn GitService> = Arc::new(StatusModeGit {
+        status,
+        file_diffs: file_diffs.clone(),
+        dir_diffs: dir_diffs.clone(),
+    });
+    let components = Components {
+        providers: Box::new(move |_resolved| RootProviders {
+            git: Arc::clone(&git),
+            content: Box::new(EchoDiffContent),
+        }),
+        editor: Box::new(NoEditor),
+        clipboard: Box::new(common::RecordingClipboard::default()),
+        renderers: None,
+    };
+    let mut ctrl = Controller::new(
+        common::resolved(dir.path().to_path_buf(), true),
+        Baseline::Base, // session baseline is Base; status mode must still force Head
+        components,
+    );
+
+    ctrl.handle(Intent::ToggleStatusMode);
+    assert!(ctrl.status_mode());
+
+    // Synthetic status tree expands ancestor dirs; land on the status file itself.
+    let nodes = ctrl.tree().visible_nodes();
+    let file_idx = nodes
+        .iter()
+        .position(|n| n.path.ends_with("a.rs"))
+        .expect("status file should be visible in status mode");
+    while ctrl.tree().cursor() != file_idx {
+        if ctrl.tree().cursor() < file_idx {
+            ctrl.handle(Intent::NavDown);
+        } else {
+            ctrl.handle(Intent::NavUp);
+        }
+    }
+
+    // Wait for a file-diff call under status mode.
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        ctrl.poll();
+        if !file_diffs.lock().unwrap().is_empty() {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "status mode never requested a file working-tree diff"
+        );
+        std::thread::sleep(Duration::from_millis(5));
+    }
+
+    let calls = file_diffs.lock().unwrap().clone();
+    assert!(
+        calls
+            .iter()
+            .any(|(p, b)| p == Path::new("src/a.rs") && *b == Baseline::Head),
+        "status mode must diff the file against Head (working tree), got {calls:?}"
+    );
+    assert_eq!(
+        ctrl.selected_view_mode(),
+        Some(ViewMode::Diff),
+        "status mode forces Diff view"
+    );
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if let Some(fx) = ctrl.poll() {
+            let _ = fx;
+        }
+        if flatten(ctrl.content()).contains("FILEDIFF:src/a.rs") {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "status-mode file diff content never arrived: {}",
+            flatten(ctrl.content())
+        );
+        std::thread::sleep(Duration::from_millis(5));
+    }
+}
+
+#[test]
+fn status_mode_directory_uses_diff_directory_with_head() {
+    let dir = TempDir::new();
+    std::fs::create_dir_all(dir.path().join("src")).unwrap();
+    std::fs::write(dir.path().join("src/a.rs"), "a\n").unwrap();
+
+    let mut status = BTreeMap::new();
+    status.insert(PathBuf::from("src/a.rs"), Status::Modified);
+    let file_diffs = Arc::new(Mutex::new(Vec::new()));
+    let dir_diffs = Arc::new(Mutex::new(Vec::new()));
+    let git: Arc<dyn GitService> = Arc::new(StatusModeGit {
+        status,
+        file_diffs: file_diffs.clone(),
+        dir_diffs: dir_diffs.clone(),
+    });
+    let components = Components {
+        providers: Box::new(move |_resolved| RootProviders {
+            git: Arc::clone(&git),
+            content: Box::new(EchoDiffContent),
+        }),
+        editor: Box::new(NoEditor),
+        clipboard: Box::new(common::RecordingClipboard::default()),
+        renderers: None,
+    };
+    let mut ctrl = Controller::new(
+        common::resolved(dir.path().to_path_buf(), true),
+        Baseline::Base,
+        components,
+    );
+
+    ctrl.handle(Intent::ToggleStatusMode);
+    // In changed-only/status synthetic tree, directories are expanded ancestors of status files.
+    // Navigate to the `src` directory row if needed.
+    let nodes = ctrl.tree().visible_nodes();
+    let src_idx = nodes
+        .iter()
+        .position(|n| n.path.file_name().map(|f| f == "src").unwrap_or(false))
+        .expect("src dir should be visible in status mode");
+    // Move cursor to src (cursor 0 may already be root-relative first row).
+    while ctrl.tree().cursor() != src_idx {
+        if ctrl.tree().cursor() < src_idx {
+            ctrl.handle(Intent::NavDown);
+        } else {
+            ctrl.handle(Intent::NavUp);
+        }
+    }
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        ctrl.poll();
+        if !dir_diffs.lock().unwrap().is_empty() {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "status mode never requested a directory working-tree diff"
+        );
+        std::thread::sleep(Duration::from_millis(5));
+    }
+
+    let calls = dir_diffs.lock().unwrap().clone();
+    assert!(
+        calls
+            .iter()
+            .any(|(p, b)| p == Path::new("src") && *b == Baseline::Head),
+        "directory in status mode must call diff_directory(src, Head), got {calls:?}"
+    );
+    assert!(
+        flatten(ctrl.content()).contains("DIRDIFF:src"),
+        "content must be the directory working-tree diff: {}",
+        flatten(ctrl.content())
+    );
 }

--- a/tests/controller_async.rs
+++ b/tests/controller_async.rs
@@ -1150,15 +1150,21 @@ fn status_mode_directory_uses_diff_directory_with_head() {
         }
     }
 
+    // Wait for the directory diff's CONTENT to actually land, not merely for the worker to have
+    // been asked. Recording the `diff_directory` call happens on the worker thread; the result is
+    // applied only when `poll()` picks it up here — asserting the content immediately after the
+    // request races that hand-off. Mirror the file-diff wait loop above and poll until the src
+    // directory diff is on screen (which implies its call was made and applied).
     let deadline = Instant::now() + Duration::from_secs(5);
     loop {
         ctrl.poll();
-        if !dir_diffs.lock().unwrap().is_empty() {
+        if flatten(ctrl.content()).contains("DIRDIFF:src") {
             break;
         }
         assert!(
             Instant::now() < deadline,
-            "status mode never requested a directory working-tree diff"
+            "status-mode directory diff content never arrived: {}",
+            flatten(ctrl.content())
         );
         std::thread::sleep(Duration::from_millis(5));
     }
@@ -1169,10 +1175,5 @@ fn status_mode_directory_uses_diff_directory_with_head() {
             .iter()
             .any(|(p, b)| p == Path::new("src") && *b == Baseline::Head),
         "directory in status mode must call diff_directory(src, Head), got {calls:?}"
-    );
-    assert!(
-        flatten(ctrl.content()).contains("DIRDIFF:src"),
-        "content must be the directory working-tree diff: {}",
-        flatten(ctrl.content())
     );
 }

--- a/tests/git_baseline.rs
+++ b/tests/git_baseline.rs
@@ -239,6 +239,36 @@ fn directory_diff_includes_untracked_descendants() {
 }
 
 #[test]
+fn directory_diff_scopes_tracked_changes_to_the_pathspec() {
+    // The tracked side of a directory diff must be pathspec-scoped: a modified tracked file
+    // INSIDE the directory appears; one OUTSIDE it does not. (The untracked path is covered
+    // separately above; this guards the `git diff <baseline> -- <dir>` branch.)
+    let repo = make_repo();
+    fs::create_dir_all(repo.path().join("sub")).unwrap();
+    fs::write(repo.path().join("sub/inside.txt"), "orig\n").unwrap();
+    fs::write(repo.path().join("outside.txt"), "orig\n").unwrap();
+    git(repo.path(), &["add", "."]);
+    git(repo.path(), &["commit", "-q", "-m", "add tracked"]);
+    // Modify both tracked files; only the in-scope one may show in a `sub`-scoped diff.
+    fs::write(repo.path().join("sub/inside.txt"), "changed\n").unwrap();
+    fs::write(repo.path().join("outside.txt"), "changed\n").unwrap();
+
+    let d = diff_directory(repo.path(), Path::new("sub"), Baseline::Head, None);
+    assert!(
+        d.contains("sub/inside.txt"),
+        "in-scope tracked change missing: {d}"
+    );
+    assert!(
+        d.contains("+changed"),
+        "in-scope tracked diff content missing: {d}"
+    );
+    assert!(
+        !d.contains("outside.txt"),
+        "out-of-scope tracked change must be excluded: {d}"
+    );
+}
+
+#[test]
 fn directory_diff_bounds_untracked_accumulation() {
     // Many large untracked files must not build an unbounded string: the accumulation is capped
     // near the same MAX_DIFF_BYTES (4 MiB) bound `capture_stdout` applies to a single git call.

--- a/tests/git_baseline.rs
+++ b/tests/git_baseline.rs
@@ -6,7 +6,9 @@ mod common;
 use common::{TempDir, git};
 #[cfg(unix)]
 use herdr_file_viewer::git::status;
-use herdr_file_viewer::git::{Baseline, Status, changed_set, default_baseline, diff};
+use herdr_file_viewer::git::{
+    Baseline, Status, changed_set, default_baseline, diff, diff_directory,
+};
 use herdr_file_viewer::root::Resolved;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -219,6 +221,47 @@ fn untracked_file_diff_shows_added_content() {
         "untracked file diff shows its content as added"
     );
     assert!(d.contains("+world"));
+}
+
+#[test]
+fn directory_diff_includes_untracked_descendants() {
+    let repo = make_repo();
+    let dir = repo.path().join("demo");
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(dir.join("one.txt"), "one\n").unwrap();
+    fs::write(dir.join("two.txt"), "two\n").unwrap();
+
+    let d = diff_directory(repo.path(), Path::new("demo"), Baseline::Head, None);
+    assert!(d.contains("one.txt"), "first untracked child missing: {d}");
+    assert!(d.contains("+one"), "first untracked content missing: {d}");
+    assert!(d.contains("two.txt"), "second untracked child missing: {d}");
+    assert!(d.contains("+two"), "second untracked content missing: {d}");
+}
+
+#[test]
+fn directory_diff_bounds_untracked_accumulation() {
+    // Many large untracked files must not build an unbounded string: the accumulation is capped
+    // near the same MAX_DIFF_BYTES (4 MiB) bound `capture_stdout` applies to a single git call.
+    let repo = make_repo();
+    let dir = repo.path().join("big");
+    fs::create_dir_all(&dir).unwrap();
+    let one_mib = "x\n".repeat(512 * 1024); // exactly 1 MiB of text
+    // 8 MiB of untracked content — well past the 4 MiB cap, so an uncapped result would be ~8 MiB.
+    for i in 0..8 {
+        fs::write(dir.join(format!("f{i:02}.txt")), &one_mib).unwrap();
+    }
+
+    let d = diff_directory(repo.path(), Path::new("big"), Baseline::Head, None);
+    assert!(
+        d.len() <= 4 * 1024 * 1024,
+        "output must be bounded to the hard 4 MiB cap, got {} bytes",
+        d.len()
+    );
+    assert!(
+        d.len() >= 3 * 1024 * 1024,
+        "the cap must still admit a substantial (~4 MiB) prefix, got {} bytes",
+        d.len()
+    );
 }
 
 #[test]

--- a/tests/lineselect.rs
+++ b/tests/lineselect.rs
@@ -41,6 +41,9 @@ impl GitService for StubGit {
     fn diff(&self, _p: &Path, _b: Baseline, _full: bool) -> String {
         String::new()
     }
+    fn diff_directory(&self, _rel_dir: &Path, _baseline: Baseline) -> String {
+        String::new()
+    }
 }
 
 struct NoopEditor;

--- a/tests/reroot.rs
+++ b/tests/reroot.rs
@@ -37,6 +37,9 @@ impl GitService for FakeGit {
     fn diff(&self, _rel: &Path, _baseline: Baseline, _full: bool) -> String {
         String::new()
     }
+    fn diff_directory(&self, _rel_dir: &Path, _baseline: Baseline) -> String {
+        String::new()
+    }
 }
 
 /// A fake Git Service whose status / changed-set are canned per construction, so a re-root's
@@ -58,6 +61,9 @@ impl GitService for CannedGit {
     }
     fn diff(&self, _rel: &Path, _baseline: Baseline, _full: bool) -> String {
         self.diff.clone()
+    }
+    fn diff_directory(&self, _rel_dir: &Path, _baseline: Baseline) -> String {
+        String::new()
     }
 }
 

--- a/tests/reveal_open.rs
+++ b/tests/reveal_open.rs
@@ -55,6 +55,9 @@ impl GitService for StubGit {
     fn diff(&self, _p: &Path, _b: Baseline, _full: bool) -> String {
         String::new()
     }
+    fn diff_directory(&self, _rel_dir: &Path, _baseline: Baseline) -> String {
+        String::new()
+    }
 }
 
 struct NoopEditor;

--- a/tests/search_integration.rs
+++ b/tests/search_integration.rs
@@ -51,6 +51,9 @@ impl GitService for StubGit {
     fn diff(&self, _p: &Path, _b: Baseline, _full: bool) -> String {
         String::new()
     }
+    fn diff_directory(&self, _rel_dir: &Path, _baseline: Baseline) -> String {
+        String::new()
+    }
 }
 
 struct NoopEditor;

--- a/tests/update_banner.rs
+++ b/tests/update_banner.rs
@@ -32,6 +32,9 @@ impl GitService for Git {
     fn diff(&self, _rel: &Path, _baseline: Baseline, _full: bool) -> String {
         String::new()
     }
+    fn diff_directory(&self, _rel_dir: &Path, _baseline: Baseline) -> String {
+        String::new()
+    }
 }
 
 struct Content;


### PR DESCRIPTION
## What

Add a sticky **`d` git-status mode**:

- Filter the tree to **current working-tree status** only (`M` / `A` / `?` / `D`) — independent of baseline
- Force **working-tree diffs** in the content pane (file or directory-scoped, via `delta`)
- Sticky until `d` again
- **Mutually exclusive** with baseline-aware `c` (branch/history review)
- `b` still updates the stored baseline while `d` is on; content stays working-tree

## Why

`c` is baseline-aware (merge-base vs `HEAD`) and is useful for reviewing a whole branch. Reviewers also need a mode that always means “what’s dirty right now,” with diffs vs the working tree — including a whole-directory working-tree diff when a folder is selected.

Directory-level “scan everything under this folder” belongs inside that status mode, not as a separate product feature on `d`.

## How

- New `Intent::ToggleStatusMode` bound to `d` (registry + docs)
- Cached `git_status` separate from the baseline-dependent `changed` set
- Tree filter reuses the existing changed-only path, fed from `git_status` while status mode is on
- Render path forces `ViewMode::Diff` + `Baseline::Head`
  - file → `GitService::diff`
  - directory → `GitService::diff_directory` (pathspec-scoped; empty pathspec at root)
- Async worker path (AC-23) unchanged for files; directory jobs set `directory_diff`
- Entering `d` turns off `c` and vice versa; `b` recomputes the baseline changed-set without leaving `d`

### Commits

1. `feat(status-mode): add sticky d mode for working-tree status`
2. `test(status-mode): cover filter source, exclusivity, and WT diffs`
3. `docs(status-mode): document d in usage, keys, config, and changelog`

### Checklist

- [x] Behaviour tests (filter source, exclusivity, sticky `b`, file/dir Head diffs)
- [x] Registry + docs drift guards
- [x] Docs: usage / keys / configuration / CHANGELOG Unreleased
- [x] No breaking change to `c` / `b` outside status mode

### Testing

```bash
cargo test --lib
cargo test --test controller status_mode
cargo test --test controller_async status_mode
cargo test --test docs_consistency
cargo fmt --check
cargo clippy --all-targets -- -D warnings
```