### PR TITLE
fix: support bash/zsh panes on Windows and open splits on the left

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project are documented here. The format is based on
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Entries are short on purpose; follow the
 `→` links for the full detail.
 
+## [Unreleased]
+
+### Changed
+- The split-pane viewer now opens to the **left** of the focused work pane on all platforms (herdr only accepts `split --direction right|down`, so launchers open right then `pane swap --direction left`). → [summoning](docs/summoning.md)
+
+### Fixed
+- Windows launchers now support both PowerShell and Git Bash/zsh pane shells by reading `terminal.default_shell` and emitting the matching `pane run` form; they also use a short `%USERPROFILE%\bin\hfv.exe` shim and mirror `assets/markdown-style.json` beside it so glow markdown styling still works from the shim. → [windows](docs/windows.md)
+- Documented Windows renderer install via `winget` and the Git 2.41+ requirement for status markers. → [renderers](docs/renderers.md), [windows](docs/windows.md)
+
 ## [1.13.0] - 2026-07-16
 
 ### Added

--- a/docs/renderers.md
+++ b/docs/renderers.md
@@ -18,6 +18,16 @@ prints its manual install link instead of attempting a cargo install), run from 
 ./scripts/install-renderers.sh
 ```
 
+On **Windows**, `install-renderers.sh` is not used. Install via winget (or scoop) instead:
+
+```powershell
+winget install charmbracelet.glow
+winget install dandavison.delta
+winget install sharkdp.bat
+```
+
+Open a new herdr pane after installing so `PATH` updates.
+
 **If a renderer is not installed, the viewer falls back to plain text** and shows a short
 notice in the content pane naming the missing capability (e.g. *“Markdown renderer
 unavailable (glow: …); showing plain text.”*). The viewer never crashes or shows an empty

--- a/docs/summoning.md
+++ b/docs/summoning.md
@@ -26,11 +26,13 @@ Summon it by invoking the action:
 herdr plugin action invoke open-file-viewer --plugin herdr-file-viewer
 ```
 
-It opens the viewer in a **split** pane beside your current work. The launcher
-(`scripts/open-file-viewer.sh`, used by both the action and any keybinding) is **idempotent**,
-scoped to the current tab, so invoking it repeatedly is *launch-or-focus-or-toggle*:
+It opens the viewer in a **split** pane to the **left** of your current work. (herdr only accepts
+`split --direction right|down`, so the launchers open on the right and immediately
+`pane swap --direction left`.) The launcher (`scripts/open-file-viewer.sh`, used by both the
+action and any keybinding) is **idempotent**, scoped to the current tab, so invoking it repeatedly
+is *launch-or-focus-or-toggle*:
 
-- no viewer pane open in this tab → open a split (focused)
+- no viewer pane open in this tab → open a left split (focused)
 - a viewer pane open but not focused → focus it
 - the viewer pane already focused → close it (herdr has no hide-without-close; reopening just
   re-walks the tree)

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -24,6 +24,14 @@ PowerShell launcher scripts.
 - **Non-ASCII paths and pane titles are supported.** The launchers force UTF-8 before parsing
   herdr's JSON under Windows PowerShell 5.1, so names outside the active legacy code page do not
   make the viewer fall back to its plugin install directory.
+- **PowerShell and Git Bash/zsh pane shells are both supported.** `pane run` types into whatever
+  `terminal.default_shell` is (PowerShell when unset). The launchers read that setting from
+  `%APPDATA%\herdr\config.toml` and emit either `& "…\hfv.exe"` (PowerShell) or `"…/hfv.exe"`
+  (bash/zsh). They also install a short `%USERPROFILE%\bin\hfv.exe` shim and mirror
+  `assets/markdown-style.json` beside it so glow still finds its style when launched from the shim.
+- **Git 2.41+ is required for status markers and branch display.** The viewer passes
+  `--attr-source=…` on every git call; older Git for Windows (e.g. 2.39) rejects that flag and
+  silently degrades to a plain tree.
 - **Preview means best-effort, not a parity guarantee.** There's no Windows host in this
   project's CI gate (the `windows-latest` job is advisory, not required), so a Windows-specific
   regression can land between releases. Full feature parity with Linux/macOS is the goal, not a

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -61,14 +61,14 @@ command = ["./target/release/herdr-file-viewer"]
 id = "open-file-viewer"
 platforms = ["linux", "macos"]
 title = "Open file viewer"
-description = "Open the git-aware file viewer in a split pane beside the current work."
+description = "Open the git-aware file viewer in a split pane to the left of the current work."
 command = ["bash", "scripts/open-file-viewer.sh"]
 
 [[actions]]
 id = "open-file-viewer-windows"
 platforms = ["windows"]
 title = "Open file viewer"
-description = "Open the git-aware file viewer in a split pane beside the current work."
+description = "Open the git-aware file viewer in a split pane to the left of the current work."
 # Locate the launcher by asking herdr for its own plugin root (the action's cwd is unreliable on
 # Windows), forcing UTF-8 before parsing that JSON, stripping the `\\?\` verbatim prefix herdr
 # reports, then run the .ps1 by absolute path.

--- a/scripts/open-file-viewer-tab.ps1
+++ b/scripts/open-file-viewer-tab.ps1
@@ -14,12 +14,11 @@
 # you across workspaces).
 #
 # Sibling of scripts/open-file-viewer.ps1 (the split-pane variant) -- see its header for WHY the
-# Windows launchers spawn the viewer by ABSOLUTE path (`tab create` + `pane run`) instead of
-# `plugin pane open --entrypoint`: herdr can't spawn the manifest's relative pane command on Windows
-# (CreateProcessW resolves a relative program against herdr's own dir), and stores the plugin root
-# as a `\\?\` verbatim path. The OPEN/SWITCHTAB/FOCUS/CLOSE decision is computed in-process by the
-# viewer binary (`--launch-decision-tab`, fed `pane list` JSON on stdin) and is unit-tested
-# (src/launch.rs). Any failure degrades to OPEN (a fresh viewer tab).
+# Windows launchers spawn the viewer by ABSOLUTE PATH (`tab create` + `pane run`) instead of
+# `plugin pane open --entrypoint`, and for pane-shell / shim / glow-style notes. The
+# OPEN/SWITCHTAB/FOCUS/CLOSE decision is computed in-process by the viewer binary
+# (`--launch-decision-tab`, fed `pane list` JSON on stdin) and is unit-tested (src/launch.rs).
+# Any failure degrades to OPEN (a fresh viewer tab).
 
 $ErrorActionPreference = 'Continue'
 
@@ -32,18 +31,104 @@ $OutputEncoding = $Utf8NoBom
 $HerdrBin = if ($env:HERDR_BIN_PATH) { $env:HERDR_BIN_PATH } else { 'herdr' }
 
 function Strip-Verbatim([string]$p) {
-    if ($p -and $p.StartsWith('\\?\')) { return $p.Substring(4) }
+    # Use -like (not StartsWith('\\?\')): editors that treat \' as an escape
+    # misparse the EndsWith-backslash single-quoted form and report a bogus '}'.
+    if ($p -like '\\?\*') { return $p.Substring(4) }
     return $p
 }
 $PluginRoot = Strip-Verbatim (Split-Path -Parent $PSScriptRoot)
 $ViewerBin = Join-Path $PluginRoot 'target\release\herdr-file-viewer.exe'
 
-# Root the tree at the focused pane's cwd (the user's work pane). `pane list` prints JSON by default.
+function Get-HerdrDefaultShell {
+    if ($env:APPDATA) {
+        $cfg = Join-Path $env:APPDATA 'herdr\config.toml'
+        if (Test-Path -LiteralPath $cfg) {
+            foreach ($line in Get-Content -LiteralPath $cfg -ErrorAction SilentlyContinue) {
+                if ($line -match '^\s*default_shell\s*=\s*"(.*)"\s*$') {
+                    return $Matches[1].Trim()
+                }
+            }
+        }
+    }
+    return 'powershell.exe'
+}
+
+function Test-UnixLikeShell([string]$shell) {
+    if ([string]::IsNullOrWhiteSpace($shell)) { return $false }
+    $leaf = [IO.Path]::GetFileNameWithoutExtension($shell).ToLowerInvariant()
+    if ($leaf -in @('bash', 'zsh', 'sh', 'fish', 'dash', 'nu')) { return $true }
+    if ($shell -match '(?i)[\\/](bash|zsh|sh)(\.exe)?$') { return $true }
+    return $false
+}
+
+function Ensure-ViewerShim {
+    $shimDir = Join-Path $env:USERPROFILE 'bin'
+    $shim = Join-Path $shimDir 'hfv.exe'
+    if (-not (Test-Path -LiteralPath $ViewerBin)) { return $null }
+    New-Item -ItemType Directory -Force -Path $shimDir | Out-Null
+    $needsCopy = $true
+    if (Test-Path -LiteralPath $shim) {
+        try {
+            $src = Get-Item -LiteralPath $ViewerBin
+            $dst = Get-Item -LiteralPath $shim
+            if ($src.Length -eq $dst.Length -and $src.LastWriteTimeUtc -eq $dst.LastWriteTimeUtc) {
+                $needsCopy = $false
+            }
+        } catch {}
+    }
+    if ($needsCopy) {
+        Copy-Item -LiteralPath $ViewerBin -Destination $shim -Force
+    }
+
+    $styleSrc = Join-Path $PluginRoot 'assets\markdown-style.json'
+    $styleDstDir = Join-Path $shimDir 'assets'
+    $styleDst = Join-Path $styleDstDir 'markdown-style.json'
+    if (Test-Path -LiteralPath $styleSrc) {
+        $needsStyle = $true
+        if (Test-Path -LiteralPath $styleDst) {
+            try {
+                $ss = Get-Item -LiteralPath $styleSrc
+                $sd = Get-Item -LiteralPath $styleDst
+                if ($ss.Length -eq $sd.Length -and $ss.LastWriteTimeUtc -eq $sd.LastWriteTimeUtc) {
+                    $needsStyle = $false
+                }
+            } catch {}
+        }
+        if ($needsStyle) {
+            New-Item -ItemType Directory -Force -Path $styleDstDir | Out-Null
+            Copy-Item -LiteralPath $styleSrc -Destination $styleDst -Force
+        }
+    }
+    return $shim
+}
+
+function Invoke-ViewerInPane([string]$paneId, [string]$shimPath) {
+    if (Test-UnixLikeShell (Get-HerdrDefaultShell)) {
+        $fwd = ($shimPath -replace '\\', '/')
+        & $HerdrBin pane run $paneId "`"$fwd`""
+    } else {
+        & $HerdrBin pane run $paneId "& \`"$shimPath\`""
+    }
+}
+
+# Root the tree at the focused pane's cwd (the user's work pane). Prefer HERDR_ACTIVE_PANE_CWD
+# (injected when the keybinding fires), then pane list.
 function Get-UserCwd {
+    if ($env:HERDR_ACTIVE_PANE_CWD) {
+        $fromEnv = Strip-Verbatim $env:HERDR_ACTIVE_PANE_CWD
+        if ($fromEnv -and (Test-Path -LiteralPath $fromEnv -PathType Container)) {
+            return $fromEnv
+        }
+    }
     try {
         $focused = (& $HerdrBin pane list | ConvertFrom-Json).result.panes |
             Where-Object { $_.focused } | Select-Object -First 1
-        if ($focused -and $focused.cwd) { return Strip-Verbatim $focused.cwd }
+        if ($focused -and $focused.cwd) {
+            $fromPane = Strip-Verbatim $focused.cwd
+            if ($fromPane -and (Test-Path -LiteralPath $fromPane -PathType Container)) {
+                return $fromPane
+            }
+        }
     } catch {}
     return $PluginRoot
 }
@@ -59,9 +144,9 @@ function Open-Tab {
     $out = (& $HerdrBin tab create --cwd $cwd --label Files --focus | Out-String)
     $np = Get-PaneId $out
     if ($np) {
-        # Call operator + quoted absolute path so a spaced install path still launches — see
-        # open-file-viewer.ps1's Open-Pane for the full why. (GH #58 — confirmed live on Windows.)
-        & $HerdrBin pane run $np "& \`"$ViewerBin\`""
+        $shim = Ensure-ViewerShim
+        if (-not $shim) { $shim = $ViewerBin }
+        Invoke-ViewerInPane $np $shim
         & $HerdrBin pane rename $np Files *> $null
     }
     exit 0

--- a/scripts/open-file-viewer.ps1
+++ b/scripts/open-file-viewer.ps1
@@ -17,6 +17,16 @@
 # "Files" so the toggle (below) can find it again. We root the tree at the user's focused-pane cwd
 # (the viewer, launched via `pane run`, gets no HERDR_PLUGIN_CONTEXT_JSON, so it roots from its cwd).
 #
+# PANE SHELLS: herdr types `pane run` text into the NEW pane's interactive shell
+# (`terminal.default_shell`, else PowerShell on Windows). PowerShell needs the call operator
+# (`& "path"`); Git Bash/zsh need a plain quoted path (`"path"`). We read default_shell from
+# %APPDATA%\herdr\config.toml and emit the matching form. A short %USERPROFILE%\bin\hfv.exe shim
+# keeps typing fast; assets/markdown-style.json is mirrored beside it so glow still finds its
+# style when current_exe() is the shim (otherwise headings fall back to raw `##`).
+#
+# SPLIT SIDE: herdr only accepts `pane split --direction right|down`. We split right, then
+# `pane swap --direction left` so the Files pane opens on the left of the work pane.
+#
 # The OPEN/FOCUS/CLOSE decision is computed in-process by the viewer binary itself
 # (`herdr-file-viewer.exe --launch-decision`, fed the `pane list` JSON on stdin) -- so it is
 # unit-tested (src/launch.rs) and the pane id it returns is validated flag-safe. Any failure
@@ -35,19 +45,115 @@ $HerdrBin = if ($env:HERDR_BIN_PATH) { $env:HERDR_BIN_PATH } else { 'herdr' }
 # Plugin root as a NORMAL absolute path (strip herdr's `\\?\` verbatim prefix). `$PSScriptRoot` is
 # `<root>\scripts`, so the parent is the plugin root; the viewer binary is an ABSOLUTE path under it.
 function Strip-Verbatim([string]$p) {
-    if ($p -and $p.StartsWith('\\?\')) { return $p.Substring(4) }
+    # Use -like (not StartsWith('\\?\')): editors that treat \' as an escape
+    # misparse the EndsWith-backslash single-quoted form and report a bogus '}'.
+    if ($p -like '\\?\*') { return $p.Substring(4) }
     return $p
 }
 $PluginRoot = Strip-Verbatim (Split-Path -Parent $PSScriptRoot)
 $ViewerBin = Join-Path $PluginRoot 'target\release\herdr-file-viewer.exe'
 
+function Get-HerdrDefaultShell {
+    if ($env:APPDATA) {
+        $cfg = Join-Path $env:APPDATA 'herdr\config.toml'
+        if (Test-Path -LiteralPath $cfg) {
+            foreach ($line in Get-Content -LiteralPath $cfg -ErrorAction SilentlyContinue) {
+                if ($line -match '^\s*default_shell\s*=\s*"(.*)"\s*$') {
+                    return $Matches[1].Trim()
+                }
+            }
+        }
+    }
+    return 'powershell.exe'
+}
+
+function Test-UnixLikeShell([string]$shell) {
+    if ([string]::IsNullOrWhiteSpace($shell)) { return $false }
+    $leaf = [IO.Path]::GetFileNameWithoutExtension($shell).ToLowerInvariant()
+    if ($leaf -in @('bash', 'zsh', 'sh', 'fish', 'dash', 'nu')) { return $true }
+    if ($shell -match '(?i)[\\/](bash|zsh|sh)(\.exe)?$') { return $true }
+    return $false
+}
+
+# pane run types into the shell; long absolute plugin paths are slow to echo. Keep a short shim
+# at %USERPROFILE%\bin\hfv.exe so we only need to type a short command.
+#
+# Also mirror assets/markdown-style.json next to the shim. The viewer resolves glow's `-s`
+# style by walking ancestors of current_exe(); from ...\bin\hfv.exe that only finds
+# ...\bin\assets\…. Without it, glow falls back to built-in `dark`, which leaves `##` markers
+# on headings in the rendered markdown preview.
+function Ensure-ViewerShim {
+    $shimDir = Join-Path $env:USERPROFILE 'bin'
+    $shim = Join-Path $shimDir 'hfv.exe'
+    if (-not (Test-Path -LiteralPath $ViewerBin)) { return $null }
+    New-Item -ItemType Directory -Force -Path $shimDir | Out-Null
+    $needsCopy = $true
+    if (Test-Path -LiteralPath $shim) {
+        try {
+            $src = Get-Item -LiteralPath $ViewerBin
+            $dst = Get-Item -LiteralPath $shim
+            if ($src.Length -eq $dst.Length -and $src.LastWriteTimeUtc -eq $dst.LastWriteTimeUtc) {
+                $needsCopy = $false
+            }
+        } catch {}
+    }
+    if ($needsCopy) {
+        Copy-Item -LiteralPath $ViewerBin -Destination $shim -Force
+    }
+
+    $styleSrc = Join-Path $PluginRoot 'assets\markdown-style.json'
+    $styleDstDir = Join-Path $shimDir 'assets'
+    $styleDst = Join-Path $styleDstDir 'markdown-style.json'
+    if (Test-Path -LiteralPath $styleSrc) {
+        $needsStyle = $true
+        if (Test-Path -LiteralPath $styleDst) {
+            try {
+                $ss = Get-Item -LiteralPath $styleSrc
+                $sd = Get-Item -LiteralPath $styleDst
+                if ($ss.Length -eq $sd.Length -and $ss.LastWriteTimeUtc -eq $sd.LastWriteTimeUtc) {
+                    $needsStyle = $false
+                }
+            } catch {}
+        }
+        if ($needsStyle) {
+            New-Item -ItemType Directory -Force -Path $styleDstDir | Out-Null
+            Copy-Item -LiteralPath $styleSrc -Destination $styleDst -Force
+        }
+    }
+    return $shim
+}
+
+# Invoke the shim with a form the pane shell understands. PowerShell needs `& "path"` (GH #58);
+# Git Bash/zsh need a plain quoted path (the call operator is a parse error there).
+function Invoke-ViewerInPane([string]$paneId, [string]$shimPath) {
+    if (Test-UnixLikeShell (Get-HerdrDefaultShell)) {
+        $fwd = ($shimPath -replace '\\', '/')
+        & $HerdrBin pane run $paneId "`"$fwd`""
+    } else {
+        # Call-operator + quoted path; `\"` survives Windows PowerShell 5.1 native-arg stripping.
+        & $HerdrBin pane run $paneId "& \`"$shimPath\`""
+    }
+}
+
 # The directory to root the tree at: the focused pane's cwd (the user's work pane) at invocation
-# time. `pane list` prints JSON by default (it rejects a `--json` flag).
+# time. Prefer HERDR_ACTIVE_PANE_CWD (injected when the keybinding fires), then pane list.
+# `pane list` prints JSON by default (it rejects a `--json` flag).
 function Get-UserCwd {
+    if ($env:HERDR_ACTIVE_PANE_CWD) {
+        $fromEnv = Strip-Verbatim $env:HERDR_ACTIVE_PANE_CWD
+        if ($fromEnv -and (Test-Path -LiteralPath $fromEnv -PathType Container)) {
+            return $fromEnv
+        }
+    }
     try {
         $focused = (& $HerdrBin pane list | ConvertFrom-Json).result.panes |
             Where-Object { $_.focused } | Select-Object -First 1
-        if ($focused -and $focused.cwd) { return Strip-Verbatim $focused.cwd }
+        if ($focused -and $focused.cwd) {
+            $fromPane = Strip-Verbatim $focused.cwd
+            if ($fromPane -and (Test-Path -LiteralPath $fromPane -PathType Container)) {
+                return $fromPane
+            }
+        }
     } catch {}
     return $PluginRoot
 }
@@ -59,15 +165,14 @@ function Get-PaneId([string]$json) {
 
 function Open-Pane {
     $cwd = Get-UserCwd
+    # herdr pane split only accepts right|down. Split right, then swap left so Files lands on the left.
     $out = (& $HerdrBin pane split --direction right --cwd $cwd --focus | Out-String)
     $np = Get-PaneId $out
     if ($np) {
-        # Run the viewer by ABSOLUTE path via the PowerShell CALL OPERATOR. herdr types <command>
-        # into the pane's shell (PowerShell on Windows); a bare or plain-quoted path splits on a
-        # space in the install path (e.g. C:\Users\First Last\...) and the viewer never starts.
-        # `& "<path>"` executes it; the `\"` escaping survives Windows PowerShell 5.1's native-arg
-        # quote-stripping so herdr receives the quotes intact. (GH #58 — confirmed live on Windows.)
-        & $HerdrBin pane run $np "& \`"$ViewerBin\`""
+        & $HerdrBin pane swap --direction left --pane $np *> $null
+        $shim = Ensure-ViewerShim
+        if (-not $shim) { $shim = $ViewerBin }
+        Invoke-ViewerInPane $np $shim
         # Label it so a later invocation's launch-decision recognises it (best-effort).
         & $HerdrBin pane rename $np Files *> $null
     }

--- a/scripts/open-file-viewer.sh
+++ b/scripts/open-file-viewer.sh
@@ -23,12 +23,15 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 viewer_bin="$script_dir/../target/release/herdr-file-viewer"
 
 open_pane() {
-  exec "$herdr_bin" plugin pane open \
+  # herdr only accepts split --direction right|down. Open on the right, then swap left so the
+  # Files pane lands to the left of the work pane (same placement as the Windows launcher).
+  "$herdr_bin" plugin pane open \
     --plugin herdr-file-viewer \
     --entrypoint file-viewer \
     --placement split \
     --direction right \
-    --focus
+    --focus || exit $?
+  exec "$herdr_bin" pane swap --direction left
 }
 
 decision="OPEN"

--- a/tests/launcher_content.rs
+++ b/tests/launcher_content.rs
@@ -3,13 +3,15 @@
 //! `launcher_ps1.rs` parse-checks the scripts, but it is `#![cfg(windows)]` and so runs only on
 //! the advisory Windows CI job. These content checks are deliberately **not** gated to Windows:
 //! they read the launcher text and run on the *required* (Linux/macOS) matrix, so regressions in
-//! the spaced-path spawn form (GH #58) or UTF-8 JSON setup fail a blocking check.
+//! the spaced-path spawn form (GH #58), dual-shell handling, shim/glow assets, or UTF-8 JSON setup
+//! fail a blocking check.
 //!
 //! Why it matters: herdr's `pane run <id> <command>` types `<command>` into the pane's shell
-//! (PowerShell on Windows). A bare or plain-quoted path like `pane run $np "$ViewerBin"` splits on
-//! a space in the install path (e.g. `C:\Users\First Last\...`), so the viewer never launches —
-//! reproduced live on real Windows. The fix runs the viewer via the PowerShell call operator with
-//! a quoted absolute path: `pane run $np "& \"$ViewerBin\""`.
+//! (`terminal.default_shell`, else PowerShell on Windows). A bare or plain-quoted path like
+//! `pane run $np "$ViewerBin"` splits on a space in the install path (e.g. `C:\Users\First Last\...`),
+//! so the viewer never launches — reproduced live on real Windows. PowerShell needs the call
+//! operator (`& "path"`); Git Bash/zsh need a plain quoted path. The launchers detect
+//! `default_shell` and emit the matching form via a short `%USERPROFILE%\bin\hfv.exe` shim.
 
 use std::path::PathBuf;
 
@@ -21,7 +23,7 @@ fn read_script(name: &str) -> String {
 }
 
 #[test]
-fn windows_launchers_spawn_via_call_operator_not_a_bare_path() {
+fn windows_launchers_avoid_bare_viewerbin_pane_run() {
     for name in ["open-file-viewer.ps1", "open-file-viewer-tab.ps1"] {
         let s = read_script(name);
 
@@ -29,16 +31,68 @@ fn windows_launchers_spawn_via_call_operator_not_a_bare_path() {
         assert!(
             !s.contains(r#"pane run $np "$ViewerBin""#),
             "{name} still spawns with the bare `pane run $np \"$ViewerBin\"` form — it splits on a \
-             space in the install path (GH #58). Use the call-operator form."
-        );
-
-        // The viewer must be spawned via the call operator (`& ...`) so a quoted, spaced path runs.
-        assert!(
-            s.contains(r#"pane run $np "& "#),
-            "{name} must spawn the viewer via the PowerShell call operator: \
-             pane run $np \"& \\\"$ViewerBin\\\"\""
+             space in the install path (GH #58)."
         );
     }
+}
+
+#[test]
+fn windows_launchers_support_powershell_and_unix_like_pane_shells() {
+    for name in ["open-file-viewer.ps1", "open-file-viewer-tab.ps1"] {
+        let s = read_script(name);
+
+        assert!(
+            s.contains("Get-HerdrDefaultShell") && s.contains("Test-UnixLikeShell"),
+            "{name} must detect herdr terminal.default_shell so pane run matches PowerShell vs bash/zsh"
+        );
+        assert!(
+            s.contains("Invoke-ViewerInPane"),
+            "{name} must centralize pane-run command selection in Invoke-ViewerInPane"
+        );
+        // PowerShell path still uses the call operator (GH #58).
+        assert!(
+            s.contains(r#"pane run $paneId "& "#) || s.contains(r#"pane run $paneId "& `""#),
+            "{name} must keep the PowerShell call-operator form for non-unix shells"
+        );
+        // Unix-like path uses a plain quoted forward-slash path (no `&`).
+        assert!(
+            s.contains(r#"pane run $paneId "`"$fwd`"""#),
+            "{name} must pane-run a plain quoted path for Git Bash/zsh panes"
+        );
+    }
+}
+
+#[test]
+fn windows_launchers_shim_viewer_and_glow_style() {
+    for name in ["open-file-viewer.ps1", "open-file-viewer-tab.ps1"] {
+        let s = read_script(name);
+        assert!(
+            s.contains("Ensure-ViewerShim") && s.contains("hfv.exe"),
+            "{name} must install a short %USERPROFILE%\\bin\\hfv.exe shim"
+        );
+        assert!(
+            s.contains("markdown-style.json"),
+            "{name} must mirror assets/markdown-style.json beside the shim for glow"
+        );
+    }
+}
+
+#[test]
+fn windows_split_launcher_opens_on_the_left() {
+    let s = read_script("open-file-viewer.ps1");
+    assert!(
+        s.contains("pane split --direction right") && s.contains("pane swap --direction left"),
+        "open-file-viewer.ps1 must split right then swap left (herdr has no left split)"
+    );
+}
+
+#[test]
+fn unix_split_launcher_opens_on_the_left() {
+    let s = read_script("open-file-viewer.sh");
+    assert!(
+        s.contains("--direction right") && s.contains("pane swap --direction left"),
+        "open-file-viewer.sh must open right then swap left so Files lands on the left"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Windows launchers detect `terminal.default_shell` and emit PowerShell (`& "…"`) or Git Bash/zsh (`"…"`) `pane run` forms, with a short `%USERPROFILE%\bin\hfv.exe` shim plus mirrored `assets/markdown-style.json` so glow styling still works.
- Split-pane openers (Windows + unix) place the Files pane on the **left** via `split --direction right` then `pane swap --direction left` (herdr has no left split).
- Docs/changelog/tests updated (Git 2.41+ note, winget renderer install, dual-shell + left-split guards).

## Test plan
- [x] Windows + PowerShell default shell: `prefix+f` opens Files on the left; glow markdown headings styled
- [x] Windows + Git Bash/zsh `default_shell`: same, no `&` parse error; launch is fast (shim)
- [x] macOS/Linux: `open-file-viewer` opens Files on the left of the work pane
- [x] Toggle still works (open → focus → close)
- [x] `cargo test --test launcher_content` (and Windows parse job if available)