### PR TITLE
fix: thread pane width into delta's -w for diff/full_diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to this project are documented here. The format is based on
 ### Added
 - Git-status mode (`d`): filter the tree to current working-tree status and force working-tree diffs (file or directory-scoped); sticky until `d` again, mutually exclusive with baseline-aware `c`. → [usage](docs/usage.md#git-awareness) · [keys](docs/keys.md)
 
+### Fixed
+- Diff and full-file-diff panes now pass the pane width to delta's `-w` on every render, keeping it in sync across resizes instead of a fixed 80 columns (delta can't auto-detect a piped stdout's width). Matters most for a `side-by-side` delta setup, where it corrects real column-wrap width; plain delta output only changes a decorative rule's width. → [configuration](docs/configuration.md)
+
 ## [1.13.0] - 2026-07-16
 
 ### Added

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -111,11 +111,17 @@ instead get the file **content on stdin** and your value **replaces** the whole 
 (flags aren't merged), so a custom renderer must read stdin (glow and bat need a trailing `-`)
 and set its own flags — the token `{name}` is substituted with the file name.
 
-**Known limitation:** the full-file-diff view derives its line-numbered gutter from the `diff`
-command by appending delta's `--line-numbers` flag; if you point `diff` at a tool that rejects
-that flag (nonzero exit or spawn failure), the full-file-diff view falls all the way back to
-plain, unrendered diff text (with a notice), not just a missing gutter. Renderer timeouts and
-other limits aren't configurable.
+**Known limitation:** both `diff` and the full-file-diff view assume a delta-compatible renderer.
+The full-file-diff view derives its line-numbered gutter from the `diff` command by appending
+delta's `--line-numbers` flag, and every diff render additionally appends `-w <pane width>`. How
+much that second one actually changes depends on delta's own mode, which this app doesn't
+control — delta reads `side-by-side` from your `~/.gitconfig` `[delta]` section directly, since
+this app never passes `--no-gitconfig`. With `side-by-side` on, `-w` genuinely sets each column's
+wrap width to the pane instead of a stuck-at-80 fallback; without it, delta's default output isn't
+wrapped by `-w` at all — only the width of its decorative underline/overline rule changes. If you
+point `diff` at a tool that rejects `-w` or `--line-numbers` (nonzero exit or spawn failure), the
+affected view falls all the way back to plain, unrendered diff text (with a notice), not just a
+missing gutter or a fixed width. Renderer timeouts and other limits aren't configurable.
 
 ## Keybindings
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -455,13 +455,41 @@ impl ContentProvider for LiveContent {
         // out and wraps tables to fit the pane (columns sized, cells ellipsized, borders intact),
         // and pads every line to exactly that width — the Presenter's re-wrap is then a no-op
         // rather than shattering a natural-width `-w 0` table across the border rows. The bundled
-        // markdown style has `margin: 0`, so glow's output lines are exactly `width` wide. Every
-        // other mode is width-independent here (delta/bat manage their own width; they h-scroll,
-        // never re-wrap), so they use the base renderers unchanged.
+        // markdown style has `margin: 0`, so glow's output lines are exactly `width` wide.
+        //
+        // delta gets the same treatment for Diff/FullDiff: both glow and delta size their own
+        // layout from the *terminal* width they detect via a tty ioctl on their own stdout — but
+        // here stdout is a plain OS pipe (`Stdio::piped()` in `renderer_command`), not a tty, so
+        // that detection always fails. glow then falls back to `-w 0` (no wrap, harmless); delta
+        // instead falls back to a fixed, tty-less width (per `delta --help`, `-w` is "the width of
+        // underline/overline decorations"; observed as 80 columns for bare delta). In delta's
+        // default (non-`side-by-side`) mode that only widens/narrows the decorative rule under a
+        // filename — diff content itself isn't wrapped by `-w`,
+        // and delta's terminal-width background-fill relies on an erase-in-line escape our AC-27
+        // neutralizer strips, so it never reaches the pane either way. With `side-by-side` enabled
+        // (delta reads `~/.gitconfig`'s `[delta]` section directly; this app never passes
+        // `--no-gitconfig`) `-w` genuinely governs each column's wrap width, which is the case this
+        // fix chiefly matters for — verified empirically against delta 0.19.2, not from its docs
+        // alone. bat is the one renderer that's genuinely width-independent (no `-w` flag; it never
+        // wraps or pads, so long lines simply h-scroll), so it's excluded.
         let (content, notice) = match (mode, width.filter(|w| *w > 0)) {
             (ViewMode::RenderedMarkdown, Some(w)) => {
                 let wrapped = Renderers {
                     markdown: render::with_wrap_width(&self.renderers.markdown, w),
+                    ..self.renderers.clone()
+                };
+                render::render(&wrapped, &prepared, mode, raw_diff, name, self.caps)
+            }
+            (ViewMode::Diff, Some(w)) => {
+                let wrapped = Renderers {
+                    diff: render::with_wrap_width(&self.renderers.diff, w),
+                    ..self.renderers.clone()
+                };
+                render::render(&wrapped, &prepared, mode, raw_diff, name, self.caps)
+            }
+            (ViewMode::FullDiff, Some(w)) => {
+                let wrapped = Renderers {
+                    full_diff: render::with_wrap_width(&self.renderers.full_diff, w),
                     ..self.renderers.clone()
                 };
                 render::render(&wrapped, &prepared, mode, raw_diff, name, self.caps)
@@ -1312,6 +1340,92 @@ mod tests {
             "the width-less render() must keep -w 0: {:?}",
             flatten_content(&via_render)
         );
+    }
+
+    /// A `LiveContent` whose diff/full_diff delegates echo back the value that followed a literal
+    /// `-w` token among their invoked args (as `W=<n>`, empty when no `-w` was ever appended), so a
+    /// test can prove the pane width reaches delta's `-w` the same way it already reaches glow's.
+    /// Scans `"$@"` for `-w` rather than reading a fixed positional index, because `full_diff`'s
+    /// base command carries an extra `--line-numbers` token ahead of wherever `-w` lands.
+    #[cfg(unix)]
+    fn echoing_diff_content(root: &Path) -> LiveContent {
+        const SCAN: &str = "p=; for a in \"$@\"; do [ \"$p\" = -w ] && printf 'W=%s' \"$a\"; p=\"$a\"; done; cat >/dev/null";
+        // The leading `sh` is a placeholder `$0` (sh -c's convention) so real args start at `$1`
+        // and are visible in `"$@"` — otherwise an appended `-w` with nothing ahead of it would
+        // itself be swallowed as `$0` instead of showing up in `"$@"`.
+        LiveContent {
+            root: root.to_path_buf(),
+            renderers: Renderers {
+                markdown: vec!["cat".into()],
+                diff: vec!["sh".into(), "-c".into(), SCAN.into(), "sh".into()],
+                full_diff: vec![
+                    "sh".into(),
+                    "-c".into(),
+                    SCAN.into(),
+                    "sh".into(),
+                    "--line-numbers".into(),
+                ],
+                syntax: vec!["cat".into()],
+                timeout: Duration::from_secs(5),
+            },
+            caps: Caps::default(),
+        }
+    }
+
+    /// The delta fix: a compact diff at a known pane width hands delta `-w <width>` instead of
+    /// leaving it at the fixed, tty-less fallback width delta uses when its stdout is a pipe (no
+    /// tty to auto-detect from — see `render_at_width`'s doc for what `-w` actually changes, which
+    /// depends on delta's own side-by-side setting).
+    #[cfg(unix)]
+    #[test]
+    fn render_at_width_points_diff_wrap_at_the_pane_width() {
+        let root = tmp("diff-wrap-width");
+        let file = root.join("f.rs");
+        std::fs::write(&file, "fn main() {}\n").unwrap();
+        let content = echoing_diff_content(&root);
+        let out = content.render_at_width(&file, ViewMode::Diff, Some("diff\n"), Some(120));
+        assert!(
+            flatten_content(&out).contains("W=120"),
+            "the pane width must reach delta's -w: {:?}",
+            flatten_content(&out)
+        );
+    }
+
+    /// Same fix, the full-context diff variant — `-w` must reach delta even with the extra
+    /// `--line-numbers` token already ahead of it in the base `full_diff` command.
+    #[cfg(unix)]
+    #[test]
+    fn render_at_width_points_full_diff_wrap_at_the_pane_width() {
+        let root = tmp("full-diff-wrap-width");
+        let file = root.join("f.rs");
+        std::fs::write(&file, "fn main() {}\n").unwrap();
+        let content = echoing_diff_content(&root);
+        let out = content.render_at_width(&file, ViewMode::FullDiff, Some("diff\n"), Some(120));
+        assert!(
+            flatten_content(&out).contains("W=120"),
+            "the pane width must reach delta's -w in the full-context diff too: {:?}",
+            flatten_content(&out)
+        );
+    }
+
+    /// No width known yet — delta's base commands (`delta` / `delta --line-numbers`) are left
+    /// unmodified, same as the pre-fix behavior, rather than injecting a `-w 0` sentinel (unlike
+    /// glow, delta has no meaningful "unbounded" width to request).
+    #[cfg(unix)]
+    #[test]
+    fn render_at_width_leaves_diff_unmodified_without_a_pane_width() {
+        let root = tmp("diff-wrap-none");
+        let file = root.join("f.rs");
+        std::fs::write(&file, "fn main() {}\n").unwrap();
+        let content = echoing_diff_content(&root);
+        for w in [None, Some(0)] {
+            let out = content.render_at_width(&file, ViewMode::Diff, Some("diff\n"), w);
+            assert!(
+                !flatten_content(&out).contains("W="),
+                "width {w:?} must not inject -w: {:?}",
+                flatten_content(&out)
+            );
+        }
     }
 
     #[test]

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -1286,9 +1286,14 @@ impl Controller {
         // width change (terminal resize or split-bar drag) must reflow it, preserving scroll and
         // search (unlike a selection-change render). When unwrapped (the `w` horizontal-scroll view)
         // glow's natural-width output is width-independent — the pane just re-clamps h-scroll, no
-        // re-render. A height-only change never affects glow's layout either.
-        if width_changed && self.effective_wrap() {
-            self.rerender_markdown_reflow();
+        // re-render. A diff reflows on every width change unconditionally — delta's own `-w` tracks
+        // the pane width regardless of the wrap toggle (see `diff_render_width`'s doc). A
+        // height-only change never affects either delegate's layout.
+        if width_changed {
+            if self.effective_wrap() {
+                self.rerender_markdown_reflow();
+            }
+            self.rerender_diff_reflow(); // a no-op unless the selection is a diff
         }
     }
 
@@ -2342,9 +2347,11 @@ impl Controller {
     /// preference applied uniformly — `Some(true)` wraps everywhere, `Some(false)` unwraps
     /// everywhere — so switching files doesn't spring a surprise wrap on the next one.
     ///
-    /// For code/diffs this is pure layout (the delegate output is unchanged, only how the Presenter
-    /// lays it out). For rendered markdown the wrap state changes glow's `-w` (fit-to-pane vs.
-    /// natural width for horizontal scroll), so the content itself is re-rendered — preserving
+    /// For code AND diffs this is pure layout (delta/bat's output is unchanged — a diff's `-w`
+    /// tracks the pane width unconditionally, never this wrap toggle, see
+    /// [`diff_render_width`](Self::diff_render_width) — only how the Presenter lays the existing
+    /// output out changes). For rendered markdown the wrap state changes glow's `-w` (fit-to-pane
+    /// vs. natural width for horizontal scroll), so the content itself is re-rendered — preserving
     /// scroll and search, like a resize reflow. The scroll clamp recomputes from the new layout.
     fn toggle_wrap(&mut self) -> Effects {
         self.wrap_override = Some(!self.effective_wrap());
@@ -2486,19 +2493,57 @@ impl Controller {
     /// markdown is effectively **wrapped** (the fit-to-pane default) so glow lays the table out to
     /// fit; `None` when unwrapped (the `w` horizontal-scroll view) so glow keeps its base `-w 0`
     /// natural-width layout and the pane scrolls to reveal the whole table, and `None` before the
-    /// first draw has measured the pane (`content_width == 0`). Only the markdown delegate uses it.
+    /// first draw has measured the pane (`content_width == 0`).
     fn md_wrap_width(&self) -> Option<u16> {
         (self.content_width > 0 && self.effective_wrap()).then_some(self.content_width)
     }
 
-    /// Re-render the current markdown selection **without** the view-state reset [`dispatch_render`]
-    /// performs — the triggers are a content-pane resize and the `w` wrap toggle, neither of which is
-    /// a selection change, so scroll position and any active search must survive. Only rendered
-    /// markdown is re-rendered: glow's layout is tied to the wrap width we pass it (fit-to-pane vs.
-    /// natural width), so a resize-while-fit or a wrap toggle must re-run glow; every other mode is
-    /// width-independent here (diffs/code re-wrap in the Presenter alone), so this is a no-op for
-    /// them. The current content stays on screen until the new render lands (no `Rendering…`
-    /// placeholder), so a live split-drag doesn't flash; the worker collapses the backlog so only the
+    /// The width to hand a diff/full-context-diff render job: the measured pane width,
+    /// unconditionally (`None` only before the first draw has measured one) — unlike
+    /// [`md_wrap_width`](Self::md_wrap_width), NOT gated on [`effective_wrap`](Self::effective_wrap).
+    /// delta sizes its own layout from the *terminal* width it detects via a tty ioctl on its own
+    /// stdout — but here stdout is a plain OS pipe (`Stdio::piped()` in
+    /// `render::renderer_command`), never a tty, so that detection always fails and delta falls back
+    /// to a fixed, tty-less width instead (observed as 80 columns for bare delta). This chiefly
+    /// matters when delta runs `side-by-side` (its own `~/.gitconfig` `[delta]` setting, read
+    /// directly since this app never passes `--no-gitconfig`): there, `-w` genuinely governs each
+    /// column's wrap width — verified against delta 0.19.2 — so without this it stays stuck at
+    /// whatever delta falls back to, not the pane, even as the pane is resized. In delta's default
+    /// (non-side-by-side) mode `-w` only changes a decorative rule's width; content isn't
+    /// wrapped by it either way (see `render_at_width`'s doc in `app.rs` for the full detail). The
+    /// wrap toggle plays no part here: it only ever governs how the *Presenter* lays
+    /// out a diff's already-rendered lines (reflow vs. h-scroll), never how wide delta itself
+    /// believes the pane to be.
+    fn diff_render_width(&self) -> Option<u16> {
+        (self.content_width > 0).then_some(self.content_width)
+    }
+
+    /// The width to hand `mode`'s render job for the delegate's own layout, at initial dispatch
+    /// ([`dispatch_render`](Self::dispatch_render)) where — unlike the two incremental reflow paths
+    /// below — there's no "did this actually change" question to optimize, so the two width sources
+    /// are simply selected by mode: [`md_wrap_width`](Self::md_wrap_width) for markdown,
+    /// [`diff_render_width`](Self::diff_render_width) for a diff, and `None` for syntax content
+    /// (bat has no `-w` flag and never wraps or pads, so it is genuinely width-independent).
+    fn render_wrap_width(&self, mode: ViewMode) -> Option<u16> {
+        match mode {
+            ViewMode::RenderedMarkdown => self.md_wrap_width(),
+            ViewMode::Diff | ViewMode::FullDiff => self.diff_render_width(),
+            ViewMode::SyntaxContent => None,
+        }
+    }
+
+    /// Re-render the current markdown selection **without** the view-state reset
+    /// [`dispatch_render`](Self::dispatch_render) performs — the triggers are a content-pane resize
+    /// (while wrapped) and the `w` wrap toggle, neither of which is a selection change, so scroll
+    /// position and any active search must survive. Only rendered markdown is re-rendered here:
+    /// glow's layout is tied to the wrap width we pass it (fit-to-pane vs. natural width), so *any*
+    /// wrap-toggle flip must re-run glow — including wrapped → unwrapped, which still needs a fresh
+    /// render to drop back to natural width, so this must NOT skip just because the resulting width
+    /// is `None`. Every other mode is a no-op here: diffs get their own reflow path
+    /// ([`rerender_diff_reflow`](Self::rerender_diff_reflow), since delta's width is independent of
+    /// this wrap toggle entirely) and syntax content never needs one (bat is width-independent). The
+    /// current content stays on screen until the new render lands (no `Rendering…` placeholder), so
+    /// a live split-drag or `w` press doesn't flash; the worker collapses the backlog so only the
     /// final state renders. [`poll`] applies the result by `seq` and, seeing it flagged in
     /// `reflow_seq`, keeps the scroll and recomputes an active search.
     fn rerender_markdown_reflow(&mut self) {
@@ -2525,6 +2570,39 @@ impl Controller {
             is_git: self.is_git_repo,
             directory_diff: false,
             wrap_width: self.md_wrap_width(),
+        });
+    }
+
+    /// Re-render the current diff/full-context-diff selection on a content-pane resize — the same
+    /// shape as [`rerender_markdown_reflow`](Self::rerender_markdown_reflow), but a diff always
+    /// re-renders on a width change (delta's width is unconditional on the wrap toggle — see
+    /// [`diff_render_width`](Self::diff_render_width)'s doc), so unlike markdown there's no wrap-
+    /// toggle path calling this: `toggle_wrap` never needs it, since a diff's delta invocation
+    /// doesn't depend on the wrap axis at all. A no-op for every other mode.
+    fn rerender_diff_reflow(&mut self) {
+        let Some(node) = self.tree.selected() else {
+            return;
+        };
+        if node.kind != NodeKind::File {
+            return;
+        }
+        let mode = self.effective_mode(&node.path);
+        if !matches!(mode, ViewMode::Diff | ViewMode::FullDiff) {
+            return;
+        }
+        self.latest_seq += 1;
+        let seq = self.latest_seq;
+        self.reflow_seq = Some(seq);
+        let rel = self.rel(&node.path);
+        let _ = self.job_tx.send(RenderJob {
+            seq,
+            path: node.path,
+            rel,
+            mode,
+            baseline: self.baseline,
+            is_git: self.is_git_repo,
+            directory_diff: false,
+            wrap_width: self.diff_render_width(),
         });
     }
 
@@ -2605,7 +2683,7 @@ impl Controller {
                 baseline,
                 is_git: self.is_git_repo,
                 directory_diff,
-                wrap_width: self.md_wrap_width(),
+                wrap_width: self.render_wrap_width(mode),
             })
             .is_ok()
         {

--- a/src/render.rs
+++ b/src/render.rs
@@ -247,11 +247,13 @@ pub fn render(
     }
 }
 
-/// Return a copy of a markdown renderer command (e.g. glow) with its wrap width set to `width`:
-/// replace the argument following the `-w` flag, or append `-w <width>` if absent. Used by the help
-/// overlay's What's New render so glow wraps the changelog to the fixed help-box body width (with its
-/// own hanging indents) instead of the default `-w 0` (no wrap → the Presenter's flat re-wrap loses
-/// the indents). The base command (and its `{name}`/`-` args) is otherwise unchanged.
+/// Return a copy of a renderer command (glow or delta — both accept `-w`/`--width <N>`) with its
+/// width set to `width`: replace the argument following the `-w` flag, or append `-w <width>` if
+/// absent. Used by the help overlay's What's New render so glow wraps the changelog to the fixed
+/// help-box body width (with its own hanging indents) instead of the default `-w 0` (no wrap → the
+/// Presenter's flat re-wrap loses the indents), and by `render_at_width` to hand delta the pane
+/// width it can't otherwise detect (its stdout is a pipe, not a tty — see `render_at_width`'s doc).
+/// The base command (and its `{name}`/`-` args) is otherwise unchanged.
 pub(crate) fn with_wrap_width(command: &[String], width: u16) -> Vec<String> {
     let mut out = command.to_vec();
     let w = width.to_string();

--- a/tests/controller_async.rs
+++ b/tests/controller_async.rs
@@ -807,11 +807,11 @@ fn a_width_reflow_preserves_scroll_and_recomputes_a_committed_search() {
     );
 }
 
-/// A resize only reflows rendered markdown — a non-markdown view (code / plain text) is
-/// width-independent here (it h-scrolls, and its delegate manages its own width), so a width change
-/// must not re-render it.
+/// A resize never reflows syntax-highlighted content — bat has no `-w` flag and never wraps or
+/// pads (it h-scrolls), so it is genuinely width-independent, unlike markdown and (see the diff
+/// tests below) diffs, both of which now do reflow on a width change.
 #[test]
-fn a_width_change_does_not_reflow_non_markdown() {
+fn a_width_change_does_not_reflow_syntax_content() {
     let dir = TempDir::new();
     std::fs::write(dir.path().join("a.rs"), "fn main() {}\n").unwrap();
     let widths = Arc::new(Mutex::new(Vec::new()));
@@ -829,7 +829,99 @@ fn a_width_change_does_not_reflow_non_markdown() {
     assert_eq!(
         widths.lock().unwrap().len(),
         before,
-        "a resize must not re-render a non-markdown view"
+        "a resize must not re-render syntax-highlighted content"
+    );
+}
+
+/// Components pairing [`RecordingGit`] (one changed file, so it defaults to `Diff`) with
+/// [`WidthProbe`], so a test can observe the width threaded into a diff/full-diff render job the
+/// same way [`width_probe_components`] lets one observe markdown's.
+fn changed_width_probe_components(
+    changed_path: &Path,
+    widths: Arc<Mutex<Vec<Option<u16>>>>,
+    lines: usize,
+) -> Components {
+    let mut changed = BTreeMap::new();
+    changed.insert(changed_path.to_path_buf(), Status::Modified);
+    let git: Arc<dyn GitService> = Arc::new(RecordingGit {
+        changed,
+        diff_full_calls: Arc::new(Mutex::new(Vec::new())),
+    });
+    Components {
+        providers: Box::new(move |_resolved| RootProviders {
+            git: Arc::clone(&git),
+            content: Box::new(WidthProbe {
+                widths: Arc::clone(&widths),
+                lines,
+            }),
+        }),
+        editor: Box::new(NoEditor),
+        clipboard: Box::new(common::RecordingClipboard::default()),
+        renderers: None,
+    }
+}
+
+/// The delta fix: a content-pane width change reflows a changed file's (compact) diff at the new
+/// pane width too, not just markdown — delta's own `-w` tracks the pane width unconditionally
+/// (see `diff_render_width`'s doc on the controller), since its stdout is a pipe and it can never
+/// auto-detect the real terminal size the way it would when attached to one.
+#[test]
+fn a_width_change_reflows_a_diff_at_the_new_width() {
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("c.rs"), "fn main() {}\n").unwrap();
+    let widths = Arc::new(Mutex::new(Vec::new()));
+    let mut ctrl = Controller::new(
+        common::resolved(dir.path().to_path_buf(), true),
+        Baseline::Head,
+        changed_width_probe_components(Path::new("c.rs"), Arc::clone(&widths), 5),
+    );
+    await_contains(&mut ctrl, "w=None:c.rs"); // initial: pane not measured yet
+
+    ctrl.set_content_viewport(120, 10);
+    await_contains(&mut ctrl, "w=Some(120):c.rs");
+    assert!(
+        widths.lock().unwrap().contains(&Some(120)),
+        "a resize must thread the new pane width into the diff render: {:?}",
+        widths.lock().unwrap()
+    );
+
+    // A height-only change (same width) must NOT reflow — no further render is dispatched.
+    let before = widths.lock().unwrap().len();
+    ctrl.set_content_viewport(120, 14);
+    std::thread::sleep(Duration::from_millis(50));
+    ctrl.poll();
+    assert_eq!(
+        widths.lock().unwrap().len(),
+        before,
+        "a height-only change must not re-render a diff"
+    );
+}
+
+/// `w` (the wrap toggle) never resends a diff: delta's `-w` tracks the pane width unconditionally,
+/// not this toggle (only the Presenter's h-scroll layout of the already-rendered diff changes), so
+/// resending would be pure waste. Mirrors `toggle_wrap_on_a_code_file_dispatches_no_render`.
+#[test]
+fn toggle_wrap_on_a_diff_dispatches_no_render() {
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("c.rs"), "fn main() {}\n").unwrap();
+    let widths = Arc::new(Mutex::new(Vec::new()));
+    let mut ctrl = Controller::new(
+        common::resolved(dir.path().to_path_buf(), true),
+        Baseline::Head,
+        changed_width_probe_components(Path::new("c.rs"), Arc::clone(&widths), 5),
+    );
+    await_contains(&mut ctrl, "w=None:c.rs");
+    ctrl.set_content_viewport(120, 10);
+    await_contains(&mut ctrl, "w=Some(120):c.rs");
+
+    let before = widths.lock().unwrap().len();
+    ctrl.handle(Intent::ToggleWrap);
+    std::thread::sleep(Duration::from_millis(50)); // give any (wrong) dispatch time to land
+    ctrl.poll();
+    assert_eq!(
+        widths.lock().unwrap().len(),
+        before,
+        "toggling wrap on a diff must not dispatch a render"
     );
 }
 


### PR DESCRIPTION
## Summary

`delta`'s stdout is a plain OS pipe when this app spawns it (`Stdio::piped()`, not a tty), so
delta's own terminal-width auto-detection always fails and it falls back to a fixed, tty-less
width instead (observed as 80 columns for bare delta). `glow` already gets an explicit
`-w <pane_width>` for the same reason; `delta` (compact diff and full-file diff) never did,
based on the assumption that it "manages its own width" the way it would when attached to a
real terminal. This PR threads the measured pane width into delta's `-w` on every diff render,
and keeps it in sync across resizes.

**Verified against the real delta 0.19.2 binary** (not assumed from its docs) through the app's
actual render pipeline, at two pane sizes and both of delta's layout modes, before vs. after this
change: https://claude.ai/code/artifact/ed35d7fe-734c-4a71-a642-d8f7a631aafc

The effect is conditional on delta's own mode, which this app doesn't control (delta reads
`side-by-side` from the user's `~/.gitconfig` `[delta]` section directly — this app never passes
`--no-gitconfig`):
- **`side-by-side` on:** `-w` genuinely governs each column's wrap width. Confirmed by measuring
  the rendered column width directly: before, it's stuck at 40 (half of the 80-column fallback)
  regardless of pane size; after, it tracks the pane (~53 at a 140-wide pane, 30 at 90-wide).
- **`side-by-side` off (delta's default):** `-w` only changes the width of the decorative
  underline/overline rule (per `delta --help`); the diff content itself is never wrapped by it
  either way, on either side of this change — confirmed with a 175-character fixture line that
  stays on one row and is simply cut off at the pane edge in every capture.

## Changes

- `render_at_width` (`src/app.rs`) now injects `-w <width>` for `Diff`/`FullDiff`, reusing the
  same `with_wrap_width` helper already used for markdown/glow. `bat` is left alone (no `-w` flag,
  genuinely width-independent).
- Splits `diff_render_width()` (unconditional on the wrap toggle) from `md_wrap_width()` (gated on
  `effective_wrap()`), since delta's `-w` has nothing to do with the Presenter's wrap/h-scroll axis
  — a diff's wrap default is `false`, so reusing the gated helper meant the width never actually
  reached delta in practice.
- Adds `rerender_diff_reflow()` so a pane resize re-renders an open diff too, mirroring the
  existing markdown reflow path (and reusing the same worker backlog-collapse, so a rapid resize
  doesn't spawn a delta process per event).
- `toggle_wrap` (the `w` key) intentionally still only re-renders markdown: a diff's `-w` is
  independent of that toggle, so resending would be pure waste.
- Documents the `side-by-side` dependency in `docs/configuration.md`'s Known limitation note, and
  adds a `CHANGELOG.md` entry.

## Test plan

- [x] `cargo test` is green, including new tests: `render_at_width_points_diff_wrap_at_the_pane_width`,
      `render_at_width_points_full_diff_wrap_at_the_pane_width`,
      `render_at_width_leaves_diff_unmodified_without_a_pane_width`,
      `a_width_change_reflows_a_diff_at_the_new_width`, `toggle_wrap_on_a_diff_dispatches_no_render`
- [x] `cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, `cargo audit` pass
      (`cargo audit` reports only the repository's existing allowed `RUSTSEC-2026-0190` warning,
      same as PR #105)
- [x] Docs updated in this PR (`CHANGELOG.md` + `docs/configuration.md`)
- [x] Manual verification against the real `delta` binary: built both `main` (before) and this
      branch (after), same repo/fixture, at 140×40 and 90×35, in both delta layout modes — capture
      matrix and measured rule/column widths linked above

## Related

No issue filed; found while testing the diff pane at a wide split.
