### PR TITLE
release: v1.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,16 @@ All notable changes to this project are documented here. The format is based on
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Entries are short on purpose; follow the
 `→` links for the full detail.
 
-## [Unreleased]
+## [1.14.0] - 2026-07-20
 
 ### Added
-- Double-click the content pane title (filename border) to toggle zoom / show or hide the tree (same as `z`). Complements double-clicking a file in the tree to open zoomed. Thanks @nullbio (#106). → [keys](docs/keys.md#mouse)
-- Launch open target: open straight to a file (and optional line) via `--open <path>[:line]` or `HERDR_FILE_VIEWER_OPEN` (flag wins). Same `path:line` shape as a copied line reference. → [usage](docs/usage.md#open-at-a-known-file)
-- `D` cycles changed-file diffs through Delta unified, Delta side-by-side, and plain git diff presentation. → [usage](docs/usage.md#git-awareness) · [keys](docs/keys.md)
-- Git-status mode (`d`): filter the tree to current working-tree status and force working-tree diffs (file or directory-scoped); sticky until `d` again, mutually exclusive with baseline-aware `c`. → [usage](docs/usage.md#git-awareness) · [keys](docs/keys.md)
+- Launch open target: open straight to a file (and optional line) via `--open <path>[:line]` or `HERDR_FILE_VIEWER_OPEN` (flag wins). Same `path:line` shape as a copied line reference. Teach your agent the flag and you can just ask it to open a file, jump to a line, or show a function in the viewer. Thanks @tieubao for the suggestion (#109). → [usage](docs/usage.md#open-at-a-known-file) · [teach your agent](docs/usage.md#teach-your-agent)
+- Double-click the content pane title (filename border) to toggle zoom / show or hide the tree (same as `z`). Complements double-clicking a file in the tree to open zoomed. Thanks @nullbio for the suggestion (#106). → [keys](docs/keys.md#mouse)
+- `D` cycles changed-file diffs through Delta unified, Delta side-by-side, and plain git diff presentation. Thanks @rrrrnmtsu (#111). → [usage](docs/usage.md#git-awareness) · [keys](docs/keys.md)
+- Git-status mode (`d`): filter the tree to current working-tree status and force working-tree diffs (file or directory-scoped); sticky until `d` again, mutually exclusive with baseline-aware `c`. Thanks @jellydn (#110). → [usage](docs/usage.md#git-awareness) · [keys](docs/keys.md)
+
+### Fixed
+- Diff and full-file-diff panes now pass the pane width to Delta, so side-by-side diffs size their columns to the pane instead of a fixed fallback, and re-render on resize. Thanks @rrrrnmtsu (#111).
 
 ## [1.13.0] - 2026-07-16
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -574,7 +574,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "herdr-file-viewer"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "ansi-to-tui",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "herdr-file-viewer"
-version = "1.13.0"
+version = "1.14.0"
 edition = "2024"
 rust-version = "1.96"
 description = "A git-aware, read-only file viewer that runs as a herdr TUI pane"

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -24,7 +24,7 @@
 
 id = "herdr-file-viewer"
 name = "herdr-file-viewer"
-version = "1.13.0"
+version = "1.14.0"
 description = "A git-aware, read-only file viewer: a keyboard-driven TUI in a herdr split pane."
 min_herdr_version = "0.7.0"
 platforms = ["linux", "macos", "windows"]


### PR DESCRIPTION
Cuts **v1.14.0**, batching four features merged since v1.13.0 (2026-07-16).

## Release notes (from CHANGELOG)

### Added
- Launch open target: open straight to a file (and optional line) via `--open <path>[:line]` or `HERDR_FILE_VIEWER_OPEN` (flag wins). Teach your agent the flag and you can just ask it to open a file, jump to a line, or show a function in the viewer. Thanks @tieubao for the suggestion (#109).
- Double-click the content pane title to toggle zoom / show or hide the tree (same as `z`). Thanks @nullbio for the suggestion (#106).
- `D` cycles changed-file diffs through Delta unified, Delta side-by-side, and plain git diff presentation. Thanks @rrrrnmtsu (#111).
- Git-status mode (`d`): filter the tree to working-tree status and force working-tree diffs. Thanks @jellydn (#110).

### Fixed
- Diff panes pass the pane width to Delta, so side-by-side diffs size their columns to the pane instead of a fixed fallback, and re-render on resize. Thanks @rrrrnmtsu (#111).

## Bumps
- `Cargo.toml`, `Cargo.lock`, `herdr-plugin.toml` → 1.14.0
- CHANGELOG `[Unreleased]` → `## [1.14.0] - 2026-07-20`

## Notes
- The Delta pane-width `Fixed` entry was previously undocumented: it shipped inside #111 alongside the `D` key, and is separately user-visible.
- PR #114 proposed the same Delta width fix independently and is superseded by #111; still open, to be closed separately.
