### PR TITLE
Minor key bindings configuration snippet improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,12 @@ Then **bind a key** in your herdr config (`~/.config/herdr/config.toml`) so one 
 ```toml
 [[keys.command]]              # open in a split beside your work
 key = "prefix+f"
-type = "shell"
+type = "plugin_action"
 command = "herdr plugin action invoke open-file-viewer --plugin herdr-file-viewer"
 
 [[keys.command]]              # …or in its own tab
 key = "prefix+shift+f"
-type = "shell"
+type = "plugin_action"
 command = "herdr plugin action invoke open-file-viewer-tab --plugin herdr-file-viewer"
 ```
 

--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ help overlay's **Settings** section.
 ## Windows
 
 Native Windows is supported as a **preview** (install works the same way; the open actions use
-`-windows` action ids and a `prefix+f` keybinding needs herdr v0.7.2+). WSL works today with zero
-extra setup. See [docs/windows.md](docs/windows.md).
+`-windows` action ids and herdr's preview channel). WSL works today with zero extra setup. See
+[docs/windows.md](docs/windows.md).
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -70,13 +70,13 @@ Then **bind a key** in your herdr config (`~/.config/herdr/config.toml`) so one 
 [[keys.command]]
 key = "prefix+f"
 type = "plugin_action"
-command = "herdr plugin action invoke open-file-viewer --plugin herdr-file-viewer"
+command = "herdr-file-viewer.open-file-viewer"
 description = "open file viewer in split"
 
 [[keys.command]]
 key = "prefix+shift+f"
 type = "plugin_action"
-command = "herdr plugin action invoke open-file-viewer-tab --plugin herdr-file-viewer"
+command = "herdr-file-viewer.open-file-viewer-tab"
 description = "open file viewer in tab"
 ```
 

--- a/README.md
+++ b/README.md
@@ -67,15 +67,17 @@ brew install glow git-delta bat     # macOS, or use your package manager
 Then **bind a key** in your herdr config (`~/.config/herdr/config.toml`) so one press summons it:
 
 ```toml
-[[keys.command]]              # open in a split beside your work
+[[keys.command]]
 key = "prefix+f"
 type = "plugin_action"
 command = "herdr plugin action invoke open-file-viewer --plugin herdr-file-viewer"
+description = "open file viewer in split"
 
-[[keys.command]]              # …or in its own tab
+[[keys.command]]
 key = "prefix+shift+f"
 type = "plugin_action"
 command = "herdr plugin action invoke open-file-viewer-tab --plugin herdr-file-viewer"
+description = "open file viewer in tab"
 ```
 
 Run `herdr server reload-config`, then press your key. That's the whole setup: the split-pane

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ TUI pane. New here? Start with the [README](../README.md) for what it is and a q
 | [Keys & mouse](keys.md) | The complete key table, mouse gestures, and the editor hand-off (`$EDITOR` troubleshooting). |
 | [Configuration](configuration.md) | The full `config.toml` reference — editor/renderer/opener commands, startup toggles, tree layout, and `[keys]` remapping. |
 | [External renderers](renderers.md) | The optional `glow` / `delta` / `bat` integrations and the plain-text fallback when they're absent. |
-| [Windows (preview)](windows.md) | Native-Windows specifics: the `-windows` action ids, the herdr v0.7.2 keybinding requirement, and WSL. |
+| [Windows (preview)](windows.md) | Native-Windows specifics: the `-windows` action ids, preview-channel requirement, and WSL. |
 
 ## Beyond the essentials
 

--- a/docs/summoning.md
+++ b/docs/summoning.md
@@ -35,19 +35,20 @@ scoped to the current tab, so invoking it repeatedly is *launch-or-focus-or-togg
 - the viewer pane already focused → close it (herdr has no hide-without-close; reopening just
   re-walks the tree)
 
-**One-press access: bind a key.** herdr's `config.toml` binds keys to commands; point one at the
-action so it runs with the plugin's working directory (no hard-coded paths):
+**One-press access: bind a key.** herdr's `config.toml` binds keys to commands; point a
+`plugin_action` binding at the installed plugin's qualified action id. herdr invokes the action
+directly, so no detached shell or hard-coded path is involved:
 
 ```toml
 [[keys.command]]
 key = "prefix+f"   # any herdr key syntax, e.g. ctrl+b then f
-type = "shell"     # run detached; do NOT use "pane" (it would close when the command exits)
-command = "herdr plugin action invoke open-file-viewer --plugin herdr-file-viewer"
+type = "plugin_action"
+command = "herdr-file-viewer.open-file-viewer"
+description = "open file viewer in split"
 ```
 
 Reload with `herdr server reload-config`. Pressing the key then opens / focuses / hides the
-viewer via the same idempotent launcher. (Alternatively, `command` may invoke
-`scripts/open-file-viewer.sh` directly using the absolute install path from `herdr plugin list`.)
+viewer via the same idempotent launcher.
 
 ## Open in a tab instead of a split
 
@@ -69,20 +70,20 @@ Bind it to its own key, e.g. `prefix+shift+f` alongside `prefix+f` for the split
 ```toml
 [[keys.command]]
 key = "prefix+shift+f"
-type = "shell"
-command = "herdr plugin action invoke open-file-viewer-tab --plugin herdr-file-viewer"
+type = "plugin_action"
+command = "herdr-file-viewer.open-file-viewer-tab"
+description = "open file viewer in tab"
 ```
 
 ## Limitation over `herdr --remote`
 
-`--remote` attaches with **local** keybindings by default, and herdr has no way to fire a plugin
-action into the *attached* (remote) session from a local key: a `type = "shell"` command runs
-against your **local** herdr (wrong session), and a `type = "pane"` command runs in a throwaway
-pane that closes the instant it exits (so the viewer doesn't persist). To drive the viewer on the
-remote, attach with **`herdr --remote <host> --remote-keybindings server`**. The binding then
-lives in the *server's* `config.toml` and behaves fully (open / focus / close-toggle).
+`--remote` attaches with **local** keybindings by default, but herdr does not send local custom
+command bindings, including `plugin_action`, to the remote host. To drive the viewer on the remote,
+put the binding in the remote server's `config.toml` and attach with
+**`herdr --remote <host> --remote-keybindings server`**. The qualified id then resolves against the
+plugin installed on that server.
 
-This is a herdr keybinding/remote limitation, not the plugin's. The action and launcher work
-the same locally and remotely; it's only *which* keymap fires them across `--remote` that differs.
+This is a herdr keybinding/remote limitation, not the plugin's. The action and launcher work the
+same locally and remotely; only which config supplies the binding differs.
 
 On Windows the action ids and keybinding requirements differ slightly — see [Windows](windows.md).

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -10,15 +10,21 @@ PowerShell launcher scripts.
 - **On Windows, bind the `-windows` action ids.** herdr requires every action id to be unique, so
   the Windows launchers register as **`open-file-viewer-windows`** and
   **`open-file-viewer-tab-windows`** (the unqualified `open-file-viewer` / `open-file-viewer-tab`
-  ids are the Linux/macOS variants). Point your herdr keybinding at the `-windows` id:
-  `command = "herdr plugin action invoke open-file-viewer-windows --plugin herdr-file-viewer"`.
-- **A `prefix+f` keybinding needs herdr v0.7.2 or newer.** herdr runs custom-command
-  (`[[keys.command]]`) keybindings through the platform shell; before v0.7.2 that was `/bin/sh`,
-  absent on Windows, so the binding silently did nothing there. herdr **v0.7.2** runs them through
-  `cmd.exe /d /c`, so the `prefix+f` binding fires normally. On older herdr, summon the viewer
-  by invoking the action **directly** (`herdr plugin action invoke open-file-viewer-windows
-  --plugin herdr-file-viewer` from a shell, or via herdr's action menu) rather than through a
-  keybinding.
+  ids are the Linux/macOS variants). Point `plugin_action` bindings at the qualified Windows ids:
+
+  ```toml
+  [[keys.command]]
+  key = "prefix+f"
+  type = "plugin_action"
+  command = "herdr-file-viewer.open-file-viewer-windows"
+  description = "open file viewer in split"
+
+  [[keys.command]]
+  key = "prefix+shift+f"
+  type = "plugin_action"
+  command = "herdr-file-viewer.open-file-viewer-tab-windows"
+  description = "open file viewer in tab"
+  ```
 - **Requires herdr's preview channel.** Windows herdr binaries ship only on herdr's pre-release
   update channel, so you need to be on it before installing this plugin on Windows.
 - **Non-ASCII paths and pane titles are supported.** The launchers force UTF-8 before parsing


### PR DESCRIPTION
## Summary

A minor improvement to the code snippet sample for the keybindings configuration is applied. This allows Herdr to better manage the output by calling into a specific installed plugin instead of spawning a detached shell in the background (see [documentation](https://herdr.dev/docs/configuration/#custom-command-keybindings)).

## Changes

- Replace the use of the `shell` type with the `plugin_action` type
- Include a description in the two key bindings configuration example and remove comments.

## Test plan

*No testing is needed as only documentation is here being changed.*
