### PR TITLE
fix: treat AltGr as typing so its characters reach their action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project are documented here. The format is based on
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Entries are short on purpose; follow the
 `→` links for the full detail.
 
+## [Unreleased]
+
+### Fixed
+- Keys typed with **AltGr** now reach their action instead of being dropped. Windows reports AltGr as `Ctrl+Alt`, which the dispatcher discarded as a chord, so a character that needs AltGr on your layout was a dead key — `?` (help) on a Brazilian ABNT2 keyboard, `[` / `]` on German and Spanish ones. Only `Ctrl+Alt` on a character key is accepted; `Ctrl` alone, `Alt` alone, and `Ctrl+Alt+↑` stay inert. → [keys](docs/keys.md)
+
 ## [1.14.0] - 2026-07-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project are documented here. The format is based on
 ## [Unreleased]
 
 ### Fixed
-- Keys typed with **AltGr** now reach their action instead of being dropped. Windows reports AltGr as `Ctrl+Alt`, which the dispatcher discarded as a chord, so a character that needs AltGr on your layout was a dead key — `?` (help) on a Brazilian ABNT2 keyboard, `[` / `]` on German and Spanish ones. Only `Ctrl+Alt` on a character key is accepted; `Ctrl` alone, `Alt` alone, and `Ctrl+Alt+↑` stay inert. → [keys](docs/keys.md)
+- **Windows only:** AltGr characters now trigger their bound actions; only `Ctrl+Alt` plus optional `Shift` on character keys is inferred as AltGr. → [keys](docs/keys.md)
 
 ## [1.14.0] - 2026-07-20
 

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -65,18 +65,22 @@ changes you make outside it (a merge, pull, or commit in another pane) show up a
 forces a full refresh on demand. (Focus-refresh updates the tree's status without disturbing your
 content scroll.)
 
-Character keys act only when no control chord is held (so terminal chords like `Ctrl+C` are
-never intercepted); `Shift` is permitted, for keys such as `<` and `>` (and `a`/`A`, `y`/`Y`,
-`W`, `N`, `O`, `R`, `Z`, `?`, `H`/`L`, `J`/`K` in line-select mode, and `d`/`D` in the annotation
-overview).
+Character keys with a control modifier are normally inert, so terminal chords such as `Ctrl+C` do
+not trigger a viewer action; `Shift` is permitted for keys such as `<` and `>` (and `a`/`A`,
+`y`/`Y`, `W`, `N`, `O`, `R`, `Z`, `?`, `H`/`L`, `J`/`K` in line-select mode, and `d`/`D` in the
+annotation overview).
 
-**AltGr** is treated as typing, not as a chord. On many layouts AltGr is how you produce a character
-the viewer binds — `?` on a Brazilian ABNT2 keyboard, `[` and `]` on German and Spanish ones — so an
-`AltGr`+character event runs its action normally. Windows reports AltGr as `Ctrl+Alt`, which means a
-genuine `Ctrl+Alt`+character chord is indistinguishable from it and will also fire that action;
-`Ctrl` alone, `Alt` alone, and `Ctrl+Alt` on a non-character key (`Ctrl+Alt+↑`) all stay inert. If
-you need a particular `Ctrl+Alt` chord left to your terminal, rebind the action off that character
-in [`[keys]`](configuration.md#keybindings).
+**On Windows only**, `Ctrl+Alt`+character (with optional `Shift`) is treated as typing (AltGr), not
+as a chord. Crossterm 0.29's Windows input path reports AltGr as the generic `Ctrl+Alt` combination,
+so a genuine Windows `Ctrl+Alt`+character chord is ambiguous with AltGr typing a bound character:
+pressing AltGr+`?` on a Brazilian ABNT2 keyboard still opens (or closes) the help overlay, and the
+same applies to whatever character any of your bindings use, including a custom `[keys]` remap.
+(Some layouts produce other characters via AltGr too, e.g. `[`/`]` on German and Spanish ones; those
+are unbound by default, so they trigger nothing unless you bind them yourself.) `Ctrl` alone, `Alt`
+alone, `Ctrl+Alt` on a non-character key (`Ctrl+Alt+↑`), and `Ctrl+Alt` plus any modifier other than
+optional `Shift` stay inert. Linux and macOS decoding is unchanged. To prevent a particular Windows
+`Ctrl+Alt` chord from triggering its viewer action, rebind that action off the character in
+[`[keys]`](configuration.md#keybindings).
 
 ### Copy a path (`y` / `Y`)
 

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -70,6 +70,14 @@ never intercepted); `Shift` is permitted, for keys such as `<` and `>` (and `a`/
 `W`, `N`, `O`, `R`, `Z`, `?`, `H`/`L`, `J`/`K` in line-select mode, and `d`/`D` in the annotation
 overview).
 
+**AltGr** is treated as typing, not as a chord. On many layouts AltGr is how you produce a character
+the viewer binds — `?` on a Brazilian ABNT2 keyboard, `[` and `]` on German and Spanish ones — so an
+`AltGr`+character event runs its action normally. Windows reports AltGr as `Ctrl+Alt`, which means a
+genuine `Ctrl+Alt`+character chord is indistinguishable from it and will also fire that action;
+`Ctrl` alone, `Alt` alone, and `Ctrl+Alt` on a non-character key (`Ctrl+Alt+↑`) all stay inert. If
+you need a particular `Ctrl+Alt` chord left to your terminal, rebind the action off that character
+in [`[keys]`](configuration.md#keybindings).
+
 ### Copy a path (`y` / `Y`)
 
 `y` copies the selected file's repo-relative path; `Y` copies its absolute path, handy for pasting

--- a/src/controller/help.rs
+++ b/src/controller/help.rs
@@ -225,6 +225,10 @@ impl Controller {
     ///
     /// When the overlay is not open, all keys are a defensive no-op.
     pub fn handle_help_key(&mut self, key: KeyEvent) -> Effects {
+        // Normalize a Windows AltGr chord (Ctrl+Alt(+Shift)+Char) via the SAME seam `input::decode`
+        // uses, so AltGr+`?` closes an already-open overlay on Windows exactly as it opens one;
+        // opening and closing can never drift apart. On non-Windows hosts this is a no-op passthrough.
+        let key = crate::input::normalize_altgr(key, cfg!(windows));
         // Ignore Ctrl/Alt chords (mirrors input::map_key): Shift is allowed (Shift+Tab = BackTab
         // retreats), but a Ctrl+'?' / Alt+1 must NOT close or switch — consume it as a no-op so it
         // neither acts here nor leaks past the modal. (R3 item 3, consistency with map_key.)

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -3856,4 +3856,71 @@ mod tests {
             "the appended Keybindings section body must carry the registry descriptions, got: {body}"
         );
     }
+
+    // ---- AltGr closes an already-open help overlay on Windows (matches opening) ----------
+
+    #[test]
+    fn normalized_altgr_question_mark_closes_open_help_overlay() {
+        let mut ctrl = wiring_controller();
+        ctrl.open_help();
+        let altgr = crate::input::normalize_altgr(
+            KeyEvent::new(
+                KeyCode::Char('?'),
+                KeyModifiers::CONTROL | KeyModifiers::ALT,
+            ),
+            true,
+        );
+
+        ctrl.handle_help_key(altgr);
+
+        assert!(ctrl.help_state().is_none());
+    }
+
+    /// Ctrl+Alt(+Shift)+`?` while help is open: on Windows this must close the overlay, exactly
+    /// mirroring how it opens one via `Intent::ShowHelp` (AC parity, no drift between open/close).
+    #[test]
+    #[cfg(windows)]
+    fn altgr_question_mark_closes_open_help_overlay_on_windows() {
+        let mut ctrl = wiring_controller();
+        ctrl.open_help();
+        assert!(
+            ctrl.help_state().is_some(),
+            "help must be open before the AltGr key"
+        );
+
+        let altgr_close = KeyEvent::new(
+            KeyCode::Char('?'),
+            KeyModifiers::CONTROL | KeyModifiers::ALT,
+        );
+        ctrl.handle_help_key(altgr_close);
+
+        assert!(
+            ctrl.help_state().is_none(),
+            "AltGr+? must close the open help overlay on Windows"
+        );
+    }
+
+    /// Off Windows the same chord is a genuine Ctrl+Alt chord, not AltGr typing, so it must stay
+    /// inert and leave the overlay open (consumed no-op, nothing leaks past the modal).
+    #[test]
+    #[cfg(not(windows))]
+    fn ctrl_alt_question_mark_leaves_help_overlay_open_off_windows() {
+        let mut ctrl = wiring_controller();
+        ctrl.open_help();
+        assert!(
+            ctrl.help_state().is_some(),
+            "help must be open before the chord"
+        );
+
+        let ctrl_alt = KeyEvent::new(
+            KeyCode::Char('?'),
+            KeyModifiers::CONTROL | KeyModifiers::ALT,
+        );
+        ctrl.handle_help_key(ctrl_alt);
+
+        assert!(
+            ctrl.help_state().is_some(),
+            "off Windows, Ctrl+Alt+? must not close the help overlay"
+        );
+    }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -2,8 +2,11 @@
 //!
 //! Keyboard-complete: every viewer function has at least one key. Unbound keys are a no-op
 //! (`None`). Char bindings fire only with no active modifier, so a chord like Ctrl+C (the
-//! terminal interrupt) never trips an intent. No key yields a file/git mutation action; annotation
-//! actions edit session-only in-memory state (AC-N3).
+//! terminal interrupt) never trips an intent. The one exception is Windows-only: a
+//! `Ctrl+Alt`+character chord (with optional `Shift`) is inferred as AltGr typing and still
+//! decodes (see [`decode`]); Ctrl+C carries no `Alt`, so it is unaffected and stays clear on
+//! every platform. No key yields a file/git mutation action; annotation actions edit
+//! session-only in-memory state (AC-N3).
 
 use crate::config::KeySpec;
 use crate::intent::Intent;
@@ -71,37 +74,65 @@ pub(crate) fn default_bindings() -> EffectiveBindings {
 /// Decode a key event into an [`Intent`] against a set of effective bindings, or `None` if the
 /// key is unbound.
 ///
-/// Pure (AC-24). Control-style chords (Ctrl/Alt/Super/…) never fire an intent so reserved combos
-/// (e.g. Ctrl+C) stay clear; Shift is allowed, because shifted characters (`<` / `>`) are ordinary
-/// typing — not a chord. Some Windows terminals report `Shift+d` as lowercase `d` plus the Shift
-/// modifier, so lowercase ASCII is normalized before the lookup.
+/// Pure (AC-24). Control-style chords normally do not fire an intent, so reserved combos (for
+/// example Ctrl+C) stay clear; Shift is allowed because shifted characters (`<` / `>`) are ordinary
+/// typing. Some Windows terminals report `Shift+d` as lowercase `d` plus the Shift modifier, so
+/// lowercase ASCII is normalized before lookup. Rejected events decode to `None` and stay inert.
 ///
-/// **AltGr is typing, not a chord.** Windows reports AltGr as `Ctrl+Alt`, and on many keyboard
-/// layouts AltGr is how you type a character the viewer binds: `?` on a Brazilian ABNT2 layout, `[`
-/// and `]` on German and Spanish ones. The event still carries the resolved character, so a
-/// `Ctrl+Alt` **character** event is accepted and those two modifiers are dropped before the
-/// lookup. Without this the affected keys are silently dead for everyone on such a layout, with no
-/// way to tell a broken binding from a broken keyboard.
+/// **Windows-only: infer AltGr from `Ctrl+Alt+Char`.** Crossterm 0.29's Windows input path reports
+/// AltGr as the generic `CONTROL|ALT` combination. A genuine Windows `Ctrl+Alt+<char>` chord is
+/// therefore ambiguous with AltGr typing a bound character (`?` on Brazilian ABNT2 keyboards, or
+/// any character a custom `[keys]` binding uses), and also fires that action. Production
+/// normalization is gated by `cfg!(windows)`; non-Windows decoding is unchanged.
 ///
-/// The exception is deliberately narrow. It applies only to [`KeyCode::Char`], so `Ctrl+Alt+Up`
-/// stays inert, and a chord carrying only Ctrl **or** only Alt is still ignored — every reserved
-/// terminal combo (`Ctrl+C`) passes straight through as before. Windows cannot distinguish a real
-/// `Ctrl+Alt+x` from `AltGr+x`, so anyone who wants that chord left alone can rebind the action off
-/// that character.
+/// [`decode_with_altgr_policy`] is the private pure seam that tests both policies on every host.
 pub(crate) fn decode(key: KeyEvent, bindings: &EffectiveBindings) -> Option<Intent> {
-    let altgr = matches!(key.code, KeyCode::Char(_))
+    decode_with_altgr_policy(key, bindings, cfg!(windows))
+}
+
+/// Normalize a Windows AltGr chord so [`decode`] and the help overlay's key handler
+/// ([`crate::controller::Controller::handle_help_key`]) treat it identically: with
+/// `windows_altgr` set and `key` an exact [`KeyCode::Char`] carrying `CONTROL|ALT` (optionally also
+/// `SHIFT`, and no other modifier), strip the `CONTROL`/`ALT` bits so downstream code sees only the
+/// character (plus any `Shift`), matching ordinary typing on every other host. Any other shape (a
+/// non-char code, a bare `Ctrl` or `Alt`, `Super`, `Ctrl+Alt` on a non-char key, or an extra
+/// modifier) is returned unchanged, and so is every event when `windows_altgr` is `false`.
+///
+/// Pure and total (AC-24): the single event-normalization seam both call sites reuse, so "open help
+/// with AltGr" and "close help with AltGr" can never drift apart.
+pub(crate) fn normalize_altgr(key: KeyEvent, windows_altgr: bool) -> KeyEvent {
+    let exact_ctrl_alt_char = matches!(key.code, KeyCode::Char(_))
         && key.modifiers.contains(KeyModifiers::CONTROL)
-        && key.modifiers.contains(KeyModifiers::ALT);
-    let modifiers = if altgr {
-        key.modifiers
-            .difference(KeyModifiers::CONTROL | KeyModifiers::ALT)
+        && key.modifiers.contains(KeyModifiers::ALT)
+        && key
+            .modifiers
+            .difference(KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SHIFT)
+            == KeyModifiers::NONE;
+    if windows_altgr && exact_ctrl_alt_char {
+        KeyEvent {
+            modifiers: key
+                .modifiers
+                .difference(KeyModifiers::CONTROL | KeyModifiers::ALT),
+            ..key
+        }
     } else {
-        key.modifiers
-    };
-    if modifiers.difference(KeyModifiers::SHIFT) != KeyModifiers::NONE {
+        key
+    }
+}
+
+/// The pure decode seam behind [`decode`]. With `windows_altgr`, only [`KeyCode::Char`] events
+/// carrying `CONTROL|ALT`, optional `SHIFT`, and no other modifiers are normalized as AltGr (via
+/// [`normalize_altgr`]).
+fn decode_with_altgr_policy(
+    key: KeyEvent,
+    bindings: &EffectiveBindings,
+    windows_altgr: bool,
+) -> Option<Intent> {
+    let key = normalize_altgr(key, windows_altgr);
+    if key.modifiers.difference(KeyModifiers::SHIFT) != KeyModifiers::NONE {
         return None;
     }
-    let code = if modifiers.contains(KeyModifiers::SHIFT) {
+    let code = if key.modifiers.contains(KeyModifiers::SHIFT) {
         match key.code {
             KeyCode::Char(c) if c.is_ascii_lowercase() => KeyCode::Char(c.to_ascii_uppercase()),
             other => other,
@@ -869,43 +900,154 @@ mod tests {
     }
 
     #[test]
-    fn altgr_typed_characters_reach_their_action() {
-        // Windows reports AltGr as Ctrl+Alt. On a Brazilian ABNT2 layout `?` IS AltGr+w, and on
-        // German/Spanish layouts `[` and `]` are AltGr keys too — dropping those events makes the
-        // bound actions unreachable, with no feedback at all.
-        let altgr =
-            |c: char| KeyEvent::new(KeyCode::Char(c), KeyModifiers::CONTROL | KeyModifiers::ALT);
-        assert_eq!(
-            map_key(altgr('?')),
-            Some(Intent::ShowHelp),
-            "AltGr+? must open the help overlay"
+    fn altgr_policy_only_normalizes_exact_ctrl_alt_char() {
+        let bindings = default_bindings();
+        for (windows_altgr, expected) in [(true, Some(Intent::ShowHelp)), (false, None)] {
+            for modifiers in [
+                KeyModifiers::CONTROL | KeyModifiers::ALT,
+                KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SHIFT,
+            ] {
+                assert_eq!(
+                    decode_with_altgr_policy(
+                        KeyEvent::new(KeyCode::Char('?'), modifiers),
+                        &bindings,
+                        windows_altgr,
+                    ),
+                    expected,
+                    "Ctrl+Alt(+Shift)+Char, policy={windows_altgr}"
+                );
+            }
+            for (code, modifiers) in [
+                (KeyCode::Char('c'), KeyModifiers::CONTROL),
+                (KeyCode::Char('q'), KeyModifiers::ALT),
+                (KeyCode::Char('j'), KeyModifiers::SUPER),
+                (KeyCode::Up, KeyModifiers::CONTROL | KeyModifiers::ALT),
+                (
+                    KeyCode::Char('?'),
+                    KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SUPER,
+                ),
+            ] {
+                assert_eq!(
+                    decode_with_altgr_policy(
+                        KeyEvent::new(code, modifiers),
+                        &bindings,
+                        windows_altgr,
+                    ),
+                    None,
+                    "non-AltGr modifier shape, policy={windows_altgr}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn altgr_policy_applies_to_custom_bindings() {
+        // The AltGr inference policy applies to a customized binding, not just registry defaults:
+        // enabled normalizes Ctrl+Alt+<custom key> to the remapped intent; disabled leaves the same
+        // chord inert (None), on the identical bindings and event.
+        let (bindings, out) = resolve_with(&[("refresh", one("g"))]);
+        assert!(out.is_empty());
+        let event = KeyEvent::new(
+            KeyCode::Char('g'),
+            KeyModifiers::CONTROL | KeyModifiers::ALT,
         );
-        // With Shift also held (some layouts need it), the character still decodes.
+        assert_eq!(
+            decode_with_altgr_policy(event, &bindings, true),
+            Some(Intent::Refresh),
+            "enabled: Ctrl+Alt+g decodes to the customized Refresh binding"
+        );
+        assert_eq!(
+            decode_with_altgr_policy(event, &bindings, false),
+            None,
+            "disabled: the same Ctrl+Alt+g chord stays inert"
+        );
+    }
+
+    #[test]
+    fn normalize_altgr_is_a_cross_host_pure_seam() {
+        // normalize_altgr is the single event-normalization helper decode_with_altgr_policy and
+        // handle_help_key both reuse; test it directly, on every host, via its explicit bool param.
+        let chord = KeyEvent::new(
+            KeyCode::Char('?'),
+            KeyModifiers::CONTROL | KeyModifiers::ALT,
+        );
+        let shifted_chord = KeyEvent::new(
+            KeyCode::Char('?'),
+            KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SHIFT,
+        );
+
+        // Enabled: an exact Ctrl+Alt(+Shift)+Char chord is stripped down to the bare character.
+        assert_eq!(
+            normalize_altgr(chord, true),
+            KeyEvent::new(KeyCode::Char('?'), KeyModifiers::NONE)
+        );
+        assert_eq!(
+            normalize_altgr(shifted_chord, true),
+            KeyEvent::new(KeyCode::Char('?'), KeyModifiers::SHIFT)
+        );
+
+        // Disabled: the identical events pass through untouched.
+        assert_eq!(normalize_altgr(chord, false), chord);
+        assert_eq!(normalize_altgr(shifted_chord, false), shifted_chord);
+
+        // Normalization changes only modifiers; event kind/state survive intact.
+        let repeated = KeyEvent {
+            code: KeyCode::Char('?'),
+            modifiers: KeyModifiers::CONTROL | KeyModifiers::ALT,
+            kind: crossterm::event::KeyEventKind::Repeat,
+            state: crossterm::event::KeyEventState::CAPS_LOCK,
+        };
+        assert_eq!(
+            normalize_altgr(repeated, true),
+            KeyEvent {
+                modifiers: KeyModifiers::NONE,
+                ..repeated
+            }
+        );
+
+        // Enabled, but not the exact AltGr shape: passes through untouched (inert modifier shapes
+        // are preserved: Ctrl-only, Alt-only, Super, Ctrl+Alt on a non-char key, and an extra
+        // modifier alongside Ctrl+Alt).
+        let inert = [
+            KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL),
+            KeyEvent::new(KeyCode::Char('q'), KeyModifiers::ALT),
+            KeyEvent::new(KeyCode::Char('j'), KeyModifiers::SUPER),
+            KeyEvent::new(KeyCode::Up, KeyModifiers::CONTROL | KeyModifiers::ALT),
+            KeyEvent::new(
+                KeyCode::Char('?'),
+                KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SUPER,
+            ),
+        ];
+        for event in inert {
+            assert_eq!(
+                normalize_altgr(event, true),
+                event,
+                "{event:?} must pass through"
+            );
+        }
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn map_key_enables_altgr_inference_on_windows() {
         assert_eq!(
             map_key(KeyEvent::new(
                 KeyCode::Char('?'),
-                KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SHIFT,
+                KeyModifiers::CONTROL | KeyModifiers::ALT,
             )),
             Some(Intent::ShowHelp)
         );
     }
 
     #[test]
-    fn real_control_and_alt_chords_stay_inert() {
-        // The AltGr exception must not open the door to ordinary chords: only Ctrl AND Alt
-        // together, and only on a character key.
-        let m = |code, mods| map_key(KeyEvent::new(code, mods));
+    #[cfg(not(windows))]
+    fn map_key_leaves_ctrl_alt_char_inert_off_windows() {
         assert_eq!(
-            m(KeyCode::Char('c'), KeyModifiers::CONTROL),
-            None,
-            "Ctrl+C must still pass through to the terminal"
-        );
-        assert_eq!(m(KeyCode::Char('q'), KeyModifiers::ALT), None, "Alt+q");
-        assert_eq!(m(KeyCode::Char('j'), KeyModifiers::SUPER), None, "Super+j");
-        assert_eq!(
-            m(KeyCode::Up, KeyModifiers::CONTROL | KeyModifiers::ALT),
-            None,
-            "Ctrl+Alt on a NON-character key is a chord, not typing"
+            map_key(KeyEvent::new(
+                KeyCode::Char('?'),
+                KeyModifiers::CONTROL | KeyModifiers::ALT,
+            )),
+            None
         );
     }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -75,11 +75,33 @@ pub(crate) fn default_bindings() -> EffectiveBindings {
 /// (e.g. Ctrl+C) stay clear; Shift is allowed, because shifted characters (`<` / `>`) are ordinary
 /// typing — not a chord. Some Windows terminals report `Shift+d` as lowercase `d` plus the Shift
 /// modifier, so lowercase ASCII is normalized before the lookup.
+///
+/// **AltGr is typing, not a chord.** Windows reports AltGr as `Ctrl+Alt`, and on many keyboard
+/// layouts AltGr is how you type a character the viewer binds: `?` on a Brazilian ABNT2 layout, `[`
+/// and `]` on German and Spanish ones. The event still carries the resolved character, so a
+/// `Ctrl+Alt` **character** event is accepted and those two modifiers are dropped before the
+/// lookup. Without this the affected keys are silently dead for everyone on such a layout, with no
+/// way to tell a broken binding from a broken keyboard.
+///
+/// The exception is deliberately narrow. It applies only to [`KeyCode::Char`], so `Ctrl+Alt+Up`
+/// stays inert, and a chord carrying only Ctrl **or** only Alt is still ignored — every reserved
+/// terminal combo (`Ctrl+C`) passes straight through as before. Windows cannot distinguish a real
+/// `Ctrl+Alt+x` from `AltGr+x`, so anyone who wants that chord left alone can rebind the action off
+/// that character.
 pub(crate) fn decode(key: KeyEvent, bindings: &EffectiveBindings) -> Option<Intent> {
-    if key.modifiers.difference(KeyModifiers::SHIFT) != KeyModifiers::NONE {
+    let altgr = matches!(key.code, KeyCode::Char(_))
+        && key.modifiers.contains(KeyModifiers::CONTROL)
+        && key.modifiers.contains(KeyModifiers::ALT);
+    let modifiers = if altgr {
+        key.modifiers
+            .difference(KeyModifiers::CONTROL | KeyModifiers::ALT)
+    } else {
+        key.modifiers
+    };
+    if modifiers.difference(KeyModifiers::SHIFT) != KeyModifiers::NONE {
         return None;
     }
-    let code = if key.modifiers.contains(KeyModifiers::SHIFT) {
+    let code = if modifiers.contains(KeyModifiers::SHIFT) {
         match key.code {
             KeyCode::Char(c) if c.is_ascii_lowercase() => KeyCode::Char(c.to_ascii_uppercase()),
             other => other,
@@ -844,6 +866,47 @@ mod tests {
         assert_eq!(map_key(k(KeyCode::Char('x'))), None);
         assert_eq!(map_key(k(KeyCode::F(1))), None);
         assert_eq!(map_key(k(KeyCode::Backspace)), None);
+    }
+
+    #[test]
+    fn altgr_typed_characters_reach_their_action() {
+        // Windows reports AltGr as Ctrl+Alt. On a Brazilian ABNT2 layout `?` IS AltGr+w, and on
+        // German/Spanish layouts `[` and `]` are AltGr keys too — dropping those events makes the
+        // bound actions unreachable, with no feedback at all.
+        let altgr =
+            |c: char| KeyEvent::new(KeyCode::Char(c), KeyModifiers::CONTROL | KeyModifiers::ALT);
+        assert_eq!(
+            map_key(altgr('?')),
+            Some(Intent::ShowHelp),
+            "AltGr+? must open the help overlay"
+        );
+        // With Shift also held (some layouts need it), the character still decodes.
+        assert_eq!(
+            map_key(KeyEvent::new(
+                KeyCode::Char('?'),
+                KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SHIFT,
+            )),
+            Some(Intent::ShowHelp)
+        );
+    }
+
+    #[test]
+    fn real_control_and_alt_chords_stay_inert() {
+        // The AltGr exception must not open the door to ordinary chords: only Ctrl AND Alt
+        // together, and only on a character key.
+        let m = |code, mods| map_key(KeyEvent::new(code, mods));
+        assert_eq!(
+            m(KeyCode::Char('c'), KeyModifiers::CONTROL),
+            None,
+            "Ctrl+C must still pass through to the terminal"
+        );
+        assert_eq!(m(KeyCode::Char('q'), KeyModifiers::ALT), None, "Alt+q");
+        assert_eq!(m(KeyCode::Char('j'), KeyModifiers::SUPER), None, "Super+j");
+        assert_eq!(
+            m(KeyCode::Up, KeyModifiers::CONTROL | KeyModifiers::ALT),
+            None,
+            "Ctrl+Alt on a NON-character key is a chord, not typing"
+        );
     }
 
     #[test]

--- a/tests/docs_consistency.rs
+++ b/tests/docs_consistency.rs
@@ -271,6 +271,28 @@ fn readme_links_to_the_reference_docs() {
 }
 
 #[test]
+fn keys_doc_documents_altgr_windows_scope() {
+    // The AltGr explanation must retain: the term "AltGr" itself, that the inference is
+    // Windows-only in scope, and the Crossterm 0.29 Windows-input rationale for why the chord is
+    // ambiguous: the three facts a reader needs to trust the behavior on their platform. A
+    // positive-content check (not a negative/brittle prose assertion), so future wording edits are
+    // free as long as these three facts stay documented.
+    assert!(
+        KEYS_DOC.contains("AltGr"),
+        "docs/keys.md must mention AltGr"
+    );
+    assert!(
+        KEYS_DOC.contains("On Windows only") || KEYS_DOC.contains("Windows only"),
+        "docs/keys.md must state the AltGr inference is Windows-only in scope"
+    );
+    assert!(
+        KEYS_DOC.contains("Crossterm 0.29"),
+        "docs/keys.md must explain the Crossterm 0.29 Windows-input behavior behind the AltGr \
+         ambiguity"
+    );
+}
+
+#[test]
 fn changelog_documents_line_reference_release() {
     // The feature shipped in `[1.9.0]`; that section is its permanent CHANGELOG home. Slice from
     // its heading to the next release heading so the check stays anchored to this release's block.


### PR DESCRIPTION
## Summary

Accept a character typed with AltGr instead of discarding it as a chord.

Windows reports AltGr as Ctrl+Alt. `decode` dropped any event carrying a modifier other than Shift,
so on a layout where a bound character IS an AltGr key, that key did nothing at all: `?` on a
Brazilian ABNT2 keyboard, `[` and `]` on German and Spanish ones. The event still carried the
resolved character, so nothing was ambiguous about what the user typed. It was thrown away one step
before the lookup, and silently, which leaves no way to tell a broken binding from a broken
keyboard.

The exception is narrow. Only Ctrl and Alt together, and only on `KeyCode::Char`. Ctrl alone, Alt
alone, and Ctrl+Alt on a non-character key such as `Ctrl+Alt+↑` all stay inert, so every reserved
terminal combo still passes straight through.

One trade-off, and it is yours to accept or reject. Windows cannot distinguish a real `Ctrl+Alt+x`
chord from `AltGr+x`, so that chord now fires the bound action too. A user who wants the chord left
to their terminal can rebind the action off that character in `[keys]`. I could not find a way to
separate the two on Windows; if you know one I will use it instead.

## Changes

- `src/input.rs`: `decode` treats Ctrl+Alt on a character key as typing and drops those two
  modifiers before the binding lookup.
- Two tests: AltGr characters reach their action (with and without Shift), and Ctrl alone, Alt
  alone, Super, and Ctrl+Alt on a non-character key stay inert.
- `docs/keys.md` and a `CHANGELOG.md` entry.

## Test plan

- [x] `cargo test` is green
- [x] `cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, `cargo audit` pass
      (audit reports the one pre-existing allowed advisory, unchanged by this PR)
- [x] Docs updated in this PR (CHANGELOG + `docs/keys.md`)
- [x] Verified live on Windows 11 with an ABNT2 layout: AltGr+W opens the help overlay, where
      before it did nothing

## Related

Closes #123
