### PR TITLE
docs: add file viewer agent skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project are documented here. The format is based on
 ## [Unreleased]
 
 ### Added
+- Bundled `herdr-file-viewer` agent skill: agents can resolve a file, source location, or function definition and open it in a fresh Files pane. Includes safe target handling, an explicit user-confirmation prompt for proactive offers, and platform guidance. → [agent skill](skills/herdr-file-viewer/SKILL.md) · [usage](docs/usage.md#teach-your-agent)
 - `show_ignored`: show gitignored (and git-excluded) files at startup, exactly as if the `i` key had already been pressed once. `.git/` stays hidden regardless, and the `i` key still toggles the state during the session. Off by default. Thanks @leonfox28 for the suggestion (#119) → [configuration](docs/configuration.md)
 - `compact_dirs`: draw a chain of single-child directories as one row (`src/main/java/br/com` instead of six indented rows), in both the full tree and the changed-only view. Off by default; worth turning on when your paths are deeper than your pane is wide. → [configuration](docs/configuration.md) · [usage](docs/usage.md#the-tree)
 - `]` / `[` jump the tree cursor to the next / previous changed file, wrapping at the ends with a notice — `n`/`N` for the tree instead of arrowing past directory rows. Walks the set the tree is filtered by (working-tree status under `d`, else the baseline-aware set behind `c` / `b`) and expands a collapsed directory to reach a changed file inside it. → [usage](docs/usage.md#git-awareness) · [keys](docs/keys.md)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -94,9 +94,11 @@ finder in a narrow split.
 
 ### Teach your agent
 
-Agents do **not** know this surface by default. Paste a short block into your project’s
-`AGENTS.md` (preferred: every agent reads it) or `CLAUDE.md` / agent skill so “open in the file
-viewer” means something concrete:
+Agents do **not** know this surface by default. This repository includes a
+[ready-to-copy agent skill](../skills/herdr-file-viewer/SKILL.md) with the target-resolution,
+launch, and conversation rules. Use it where your agent runner supports skills, or paste the short
+block below into your project’s `AGENTS.md` (preferred: every agent reads it) or `CLAUDE.md` so
+“open in the file viewer” means something concrete:
 
 ````markdown
 ## File viewer (herdr-file-viewer)
@@ -110,12 +112,20 @@ herdr plugin pane open \
   --plugin herdr-file-viewer \
   --entrypoint file-viewer \
   --placement split \
+  --direction right \
+  --cwd "$PWD" \
   --focus \
-  --env HERDR_FILE_VIEWER_OPEN=<path>[:line]
+  --env "HERDR_FILE_VIEWER_OPEN=<path>[:line]"
 ```
 
-Examples: `src/app.rs`, `src/app.rs:42`, `src/app.rs:10-20`.
-Outside herdr: `herdr-file-viewer --open <path>[:line]`.
+Examples: `src/app.rs`, `src/app.rs:42`, `src/app.rs:10-20`. Treat the target as one data value,
+not shell source: prefer a structured argv or process API, or shell-escape it before assigning and
+expanding it only within double quotes.
+
+The Herdr pane command applies to Linux, macOS, and WSL. On native Windows preview, the Files action
+cannot accept an open target, so use WSL for this flow or, if the binary is on `PATH`, run
+`herdr-file-viewer.exe --open "<target>"` in a terminal devoted to the viewer. Outside herdr, with
+the binary on `PATH`: `herdr-file-viewer --open <path>[:line]`.
 ````
 
 Without that (or an equivalent skill), a vague “open it in the file viewer” is only a wish: the

--- a/skills/herdr-file-viewer/SKILL.md
+++ b/skills/herdr-file-viewer/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: herdr-file-viewer
+description: Open a known repository file, source line, or source range in a Herdr Files pane for the user to inspect.
+---
+
+# Herdr File Viewer
+
+Use this skill when the user asks to open, show, or reveal a file, source line, range, or function
+in the Herdr file viewer (also called "Files"). Use it when you have identified a likely change
+and offer to show the user where it is.
+
+## Resolve the location
+
+Resolve the request to a repository-relative target before launching the viewer:
+
+- File: `src/app.rs`
+- One source line: `src/app.rs:42`
+- Inclusive source range: `src/app.rs:42-58`
+
+For a function or helper, locate its definition and use its definition line, not a call site. If
+there are materially different matches and context does not identify one, ask a short question
+instead of guessing. For a suspected bug line, distinguish an observed failure location from a
+hypothesis; do not present a guessed location as certain.
+
+## Open it in Herdr (Linux, macOS, or WSL)
+
+From the target repository or worktree, launch a fresh Files pane. Set `--cwd` to the agent's
+current working directory so the viewer resolves the correct worktree root.
+
+```bash
+herdr plugin pane open --plugin herdr-file-viewer --entrypoint file-viewer --placement split --direction right --cwd "$PWD" --focus --env "HERDR_FILE_VIEWER_OPEN=src/app.rs:42"
+```
+
+Replace the example target with the resolved file, line, or range. The viewer loads the file and
+scrolls to the requested location. A range receives a brief highlight.
+
+Treat the target as data, never shell source. Prefer a structured argv or process API that passes
+`HERDR_FILE_VIEWER_OPEN=<target>` as one argument. In a shell, do not interpolate a raw path into
+command text: shell-escape it when assigning it, then expand the variable only inside double quotes.
+
+Do not key-script the TUI. Do not close, focus, or try to retarget an existing Files pane: launch
+open targets are applied only when a new viewer starts, and an existing pane may contain the user's
+annotations or navigation state.
+
+## Native Windows preview
+
+The Windows launcher can open Files, but it does not accept an open target, and `herdr plugin pane
+open` cannot start the manifest entrypoint on native Windows. For a targeted request, use WSL with
+the command above. If the binary is already on `PATH`, run
+`herdr-file-viewer.exe --open "<target>"` in a terminal you intend to devote to the viewer. Do not
+say a generic Windows Files action opened the requested location.
+
+Outside Herdr, if the binary is on `PATH`, run it directly:
+
+```bash
+herdr-file-viewer --open src/app.rs:42
+```
+
+## Conversation behavior
+
+When the user directly asks to see a location, open it after resolving the target. When you have
+identified a likely location while explaining a diagnosis or change, offer a short question such as
+"Want me to show you where to change that setting?" Open it after the user confirms.
+
+After launching, state the exact target you opened. If the target cannot be resolved to a real file
+under the viewer root, explain that rather than opening an arbitrary or outside-root path.

--- a/tests/e2e_keyboard.rs
+++ b/tests/e2e_keyboard.rs
@@ -538,17 +538,17 @@ fn search_routes_keys_to_query_and_n_cycles_and_esc_restores() {
     // Step 7: `N` cycles backward (liveness proof — clean exit is the secondary assertion).
     s.send("N").expect("send `N` to go to previous match");
 
-    // Step 8: a bare Esc outside the prompt is inert (maps to no intent — must not crash).
-    // Settle before Esc so crossterm reads a lone ESC (not Alt+char) — inter-byte gap.
+    // Step 8: in a narrow pty, `/` auto-zooms the file. The close stack after a committed search
+    // is therefore: clear the search, un-zoom, then quit. Step 4 already exercises Esc closing a
+    // search prompt; controller tests cover Esc's identical close-stack behavior. Use q here so a
+    // standalone ESC cannot be coalesced with a following character by the pty as Alt+q.
+    s.send("q").expect("clear committed search");
     std::thread::sleep(Duration::from_millis(150));
-    s.send("\u{1b}")
-        .expect("send Esc outside the prompt (inert)");
-    // Settle after the inert Esc before `q` — keeps Esc and `q` apart (lone-ESC, not Alt+char)
-    // and lets the inert Esc be consumed before the quit key arrives. Stays a short sleep.
+    s.send("q").expect("un-zoom the file");
     std::thread::sleep(Duration::from_millis(150));
 
     // Step 9: clean exit — no search key crashed the run loop (AC-21).
-    s.send("q").expect("send close");
+    s.send("q").expect("quit");
     s.expect(Eof)
         .expect("the viewer terminates cleanly after the search flow");
     match s.get_process().wait().expect("reap the viewer") {


### PR DESCRIPTION
## Summary
- add a ready-to-copy `herdr-file-viewer` agent skill for opening files, source locations, and function definitions in Files
- document safe target handling, explicit worktree cwd, Windows limitations, and proactive user offers
- fix the narrow-pty search e2e cleanup to follow the committed-search, unzoom, and quit close stack

## Verification
- `cargo test`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo audit --file Cargo.lock` (passes with one existing allowed `anyhow` unsoundness warning, `RUSTSEC-2026-0190`)

## Review
- Sol re-review: pass
- Fable re-review findings addressed
