### PR TITLE
test: stop asserting a 200ms wall-clock budget when opening Help

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,11 +202,14 @@ prose, not build-failing checks — hold yourself to them.
     backlog, so a newer result landing means every earlier job already finished or was collapsed.
     That ordering is what lets a test assert with no wait at all; assuming thread-per-render instead
     leads to inventing sleeps that prove nothing.
-  - **Say so when a test cannot prove its negative.** The superseded-render tests in
-    `tests/controller_async.rs` only catch a stale result that lands AFTER the newest, and the
-    polling loop drains earlier results first — so removing `poll`'s `seq == latest_seq` guard does
-    NOT fail them. Their comment says exactly that, and names the unit test that would prove it. A
-    test whose limits are written down is worth more than one silently trusted past them.
+  - **Force the race instead of hoping for it; document a limit only when you truly cannot.** The
+    end-to-end superseded-render tests in `tests/controller_async.rs` look like they prove `poll`'s
+    `seq == latest_seq` guard and do not: their polling loop drains the earlier result first, so
+    removing the guard leaves them green. A gated renderer (`GatedContent`) makes the ordering
+    happen on demand — hold one render open, dispatch a newer one behind it, release the first so
+    its result arrives stale — and that test DOES fail when the guard is removed. Reach for the gate
+    first. Where a race genuinely cannot be forced from outside, write the limit into the test's own
+    comment and name what would prove it, so nobody trusts it past its scope.
 - **Never send a key that assumes state the test has not observed.** In a pty journey `q`/Esc peels
   ONE state layer per press (`src/controller/mod.rs`: selection → flash → committed search → zoom →
   discard confirm → quit), and toggles like `z` flip whatever is actually there. A journey that

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,7 @@ These shape every decision; violating one is a design error, not a style nit:
 
 ### Stack specifics
 
-- **Rust 1.96 (edition 2024)** + **ratatui 0.30.1** (uses `ratatui-core` 0.1.x) + **crossterm 0.29.0**
+- **Rust 1.96 (edition 2024)** + **ratatui 0.30.x** (uses `ratatui-core` 0.1.x) + **crossterm 0.29.0**
 - **`ansi-to-tui` 8.0.1** ingests the external renderers' ANSI output into ratatui spans, and
   doubles as the **AC-27 escape-neutralizer** (maps styling, drops cursor/screen-control). All file
   content flows through it.
@@ -149,6 +149,13 @@ cargo audit
 
 - **The spec is the contract.** To change scope/criteria/design/stack, edit the artifact at the
   **owning stage** and **re-run the readiness check**, don't ad-hoc-edit downstream specs.
+- **Never weaken a spec-backed assertion to make a change pass.** A test that names an acceptance
+  criterion, and a policy list an AC enumerates (e.g. `focus_policy::unavailable_from_pinned`, which
+  AC-31/AC-32 define and a test asserts row by row), are the contract in executable form: deleting an
+  entry to accommodate new code silently changes behaviour the spec mandates — in the case that
+  prompted this rule, a required user-visible notice became a silent no-op. If a criterion genuinely
+  should change, change it at the owning stage first (above) and say so in the PR. If a spec-backed
+  test looks wrong, STOP and ask rather than editing it away.
 - **Definition of done for a user-facing feature:** the feature isn't done until the docs match it,
   IN the same PR: `CHANGELOG.md` entry, the relevant `docs/` page (`docs/keys.md` for a key + the
   Shift-keys note for a capital-letter key, `docs/usage.md` for the feature, `docs/configuration.md`
@@ -193,7 +200,9 @@ never wire them in two places or let the docs drift.
 
 **A new keybinding / action.** `REGISTRY` in `src/input.rs` is the source of truth: the dispatcher,
 the `?` overlay's Keybindings section, and `[keys]` remapping all derive from it.
-1. Add the variant to the `Intent` enum in `src/intent.rs` (it lives in `Intent::ALL`, 39 today).
+1. Add the variant to the `Intent` enum in `src/intent.rs`, and to its `Intent::ALL` array (whose
+   length constant must be bumped with it — read the current count from the source, don't trust a
+   number written here).
 2. Add a `Binding { intent, name, default_keys, description, category }` row to `REGISTRY`
    (`category` must be one of `CATEGORY_ORDER`).
 3. Handle the intent in the session controller (`src/controller/`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,8 @@ and the spec chain):
 - **Presenter**: draw the two-column layout (ratatui)
 - **Input Dispatcher**: map key events → intents (crossterm)
 - **Session Controller**: orchestrate intents → state changes; holds in-memory session state
-- **Editor Launcher**: hand a file off to an external editor / new herdr pane
+- **Editor Launcher**: hand a file off to an external editor in-process, suspending and resuming the
+  TUI around it (NOT a herdr pane — see the herdr integration section)
 
 State is **in-memory and ephemeral only** except for the safe-to-delete, advisory
 `update-check.json` cache, which never changes the viewed root or git repo.
@@ -151,7 +152,9 @@ cargo audit
   **owning stage** and **re-run the readiness check**, don't ad-hoc-edit downstream specs.
 - **Never weaken a spec-backed assertion to make a change pass.** A test that names an acceptance
   criterion, and a policy list an AC enumerates (e.g. `focus_policy::unavailable_from_pinned`, which
-  AC-31/AC-32 define and a test asserts row by row), are the contract in executable form: deleting an
+  AC-31/AC-32 define and which `focus_policy::tests::pinned_rejection_set_is_exact` plus
+  `pinned_preview::pinned_unavailable_actions_are_consumed_with_a_notice` assert row by row), are the
+  contract in executable form: deleting an
   entry to accommodate new code silently changes behaviour the spec mandates — in the case that
   prompted this rule, a required user-visible notice became a silent no-op. If a criterion genuinely
   should change, change it at the owning stage first (above) and say so in the PR. If a spec-backed
@@ -172,16 +175,27 @@ This suite runs on macOS, Linux and Windows CI runners whose timing and layout d
 machine. Three rules, each learned from a real failure here. Unlike the drift guards below, these are
 prose, not build-failing checks — hold yourself to them.
 
-- **Don't assert a tight time budget, and don't prove a negative by sleeping.** Asserting a *generous*
-  timeout fired is fine (`src/proc.rs`, `src/update/gateway.rs` do it deliberately); asserting a
-  ~200ms operation finished inside 300ms is a coin flip on a loaded runner, and a "nothing happened"
-  poll passes vacuously when the thing happens after the window closes. Prefer a synchronous,
-  observable tell: `Controller::render_seq` is bumped inside `dispatch_render` BEFORE the worker
-  spawns, so an unchanged seq proves no render was dispatched, where counting a stub provider's calls
-  only races it. Where a wait is the point, separate the two claims: pin the budget's arithmetic in a
-  clock-free unit test (`tests/whats_new_composer.rs` asserts every document gets the one
-  `opened_at + WHATS_NEW_COMPOSE_TIMEOUT` instant) and let the behavioural test assert only that the
-  code did not wait, with a bound orders of magnitude below the stall it is distinguishing from.
+- **Don't assert a tight time budget, and don't prove a negative by sleeping.** Slack that is a small
+  multiple of the thing being measured is a coin flip on a loaded runner (a ~200ms budget asserted
+  under 300ms failed twice in one day), and a "nothing happened" poll passes vacuously when the thing
+  lands after the window closes. Prefer a synchronous, observable tell: `Controller::render_seq` is
+  bumped inside `dispatch_render` BEFORE the worker spawns, so an unchanged seq proves no render was
+  dispatched where counting a stub provider's calls only races it.
+  - **Where a wait is the point, split the claim in two.** Pin the budget's VALUE clock-free
+    (`tests/whats_new_composer.rs` asserts `WHATS_NEW_COMPOSE_TIMEOUT == 200ms` and that every
+    document receives exactly `opened_at + WHATS_NEW_COMPOSE_TIMEOUT`), and let the behavioural test
+    bound only the wait, ~10x the budget and orders of magnitude below the stall it distinguishes
+    from (`HELP_STALLED_RENDERER_MAX_WAIT`). Neither half alone is enough: a widened budget escapes
+    the loose bound, and a blocking call escapes the clock-free test.
+  - **The honest exception is a criterion that IS a latency budget.** AC-22/AC-23 mandate 300ms, so
+    `help_open_switch_scroll_each_within_300ms` (`tests/controller.rs`) must hold a stopwatch — that
+    is the spec, not a testing choice. Keep such tests, give them the widest slack the criterion
+    permits, and don't add new ones without a criterion behind them.
+  - **Known offenders — fix, don't copy.** `src/proc.rs` and `src/render.rs` assert a 100ms timeout
+    completes within 250ms (tight, not generous); `tests/controller_async.rs` sleeps 50ms to "give
+    any (wrong) render time to land" in three places, which is exactly the vacuous negative
+    `render_seq` exists to replace. `src/update/gateway.rs` and `tests/render_delegate.rs` are the
+    shape to copy: multi-second or order-of-magnitude separation.
 - **Never send a key that assumes state the test has not observed.** In a pty journey `q`/Esc peels
   ONE state layer per press (`src/controller/mod.rs`: selection → flash → committed search → zoom →
   discard confirm → quit), and toggles like `z` flip whatever is actually there. A journey that

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,11 +191,18 @@ prose, not build-failing checks — hold yourself to them.
     `help_open_switch_scroll_each_within_300ms` (`tests/controller.rs`) must hold a stopwatch — that
     is the spec, not a testing choice. Keep such tests, give them the widest slack the criterion
     permits, and don't add new ones without a criterion behind them.
-  - **Known offender — fix, don't copy.** `tests/controller_async.rs` sleeps 50ms to "give any
-    (wrong) render time to land" in three places, which is exactly the vacuous negative `render_seq`
-    exists to replace. `src/update/gateway.rs`, `src/proc.rs`, `src/render.rs` and
-    `tests/render_delegate.rs` are the shape to copy: they bound a stalled 60s fixture at seconds,
-    proving BOUNDED vs UNBOUNDED rather than re-measuring the timeout they passed in.
+  - **Two shapes to copy.** For "no work was dispatched", assert `Controller::render_seq` is
+    unchanged (`tests/controller_async.rs`) — it is bumped synchronously inside dispatch, before the
+    worker spawns. For "the work finished and nothing is still running", wait on an observable
+    in-flight counter, never a duration (`await_renders_settled`, same file). For "bounded, not
+    unbounded", bound a 60s stall fixture at seconds (`src/proc.rs`, `src/render.rs`,
+    `src/update/gateway.rs`, `tests/render_delegate.rs`) rather than re-measuring the timeout you
+    passed in.
+  - **Say so when a test cannot prove its negative.** Some races cannot be forced from outside: the
+    superseded-render tests in `tests/controller_async.rs` only catch a stale result that lands
+    AFTER the newest, so perturbing `poll`'s `seq == latest_seq` guard does not fail them. Their
+    comment says exactly that, and names the unit test that would prove it. A test whose limits are
+    written down is worth more than one silently trusted past them.
 - **Never send a key that assumes state the test has not observed.** In a pty journey `q`/Esc peels
   ONE state layer per press (`src/controller/mod.rs`: selection → flash → committed search → zoom →
   discard confirm → quit), and toggles like `z` flip whatever is actually there. A journey that

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,11 +191,11 @@ prose, not build-failing checks — hold yourself to them.
     `help_open_switch_scroll_each_within_300ms` (`tests/controller.rs`) must hold a stopwatch — that
     is the spec, not a testing choice. Keep such tests, give them the widest slack the criterion
     permits, and don't add new ones without a criterion behind them.
-  - **Known offenders — fix, don't copy.** `src/proc.rs` and `src/render.rs` assert a 100ms timeout
-    completes within 250ms (tight, not generous); `tests/controller_async.rs` sleeps 50ms to "give
-    any (wrong) render time to land" in three places, which is exactly the vacuous negative
-    `render_seq` exists to replace. `src/update/gateway.rs` and `tests/render_delegate.rs` are the
-    shape to copy: multi-second or order-of-magnitude separation.
+  - **Known offender — fix, don't copy.** `tests/controller_async.rs` sleeps 50ms to "give any
+    (wrong) render time to land" in three places, which is exactly the vacuous negative `render_seq`
+    exists to replace. `src/update/gateway.rs`, `src/proc.rs`, `src/render.rs` and
+    `tests/render_delegate.rs` are the shape to copy: they bound a stalled 60s fixture at seconds,
+    proving BOUNDED vs UNBOUNDED rather than re-measuring the timeout they passed in.
 - **Never send a key that assumes state the test has not observed.** In a pty journey `q`/Esc peels
   ONE state layer per press (`src/controller/mod.rs`: selection → flash → committed search → zoom →
   discard confirm → quit), and toggles like `z` flip whatever is actually there. A journey that

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,10 +151,9 @@ cargo audit
 - **The spec is the contract.** To change scope/criteria/design/stack, edit the artifact at the
   **owning stage** and **re-run the readiness check**, don't ad-hoc-edit downstream specs.
 - **Never weaken a spec-backed assertion to make a change pass.** A test that names an acceptance
-  criterion, and a policy list an AC enumerates (e.g. `focus_policy::unavailable_from_pinned`, which
-  AC-31/AC-32 define and which `focus_policy::tests::pinned_rejection_set_is_exact` plus
-  `pinned_preview::pinned_unavailable_actions_are_consumed_with_a_notice` assert row by row), are the
-  contract in executable form: deleting an
+  criterion, and a policy list an AC enumerates (e.g. the exhaustive read-only matrix in
+  `src/intent.rs::intent_effects_never_mutate_files_or_git_and_classify_annotation_edits`, which
+  AC-N3 defines row by row), are the contract in executable form: deleting an
   entry to accommodate new code silently changes behaviour the spec mandates — in the case that
   prompted this rule, a required user-visible notice became a silent no-op. If a criterion genuinely
   should change, change it at the owning stage first (above) and say so in the PR. If a spec-backed
@@ -193,16 +192,21 @@ prose, not build-failing checks — hold yourself to them.
     permits, and don't add new ones without a criterion behind them.
   - **Two shapes to copy.** For "no work was dispatched", assert `Controller::render_seq` is
     unchanged (`tests/controller_async.rs`) — it is bumped synchronously inside dispatch, before the
-    worker spawns. For "the work finished and nothing is still running", wait on an observable
-    in-flight counter, never a duration (`await_renders_settled`, same file). For "bounded, not
-    unbounded", bound a 60s stall fixture at seconds (`src/proc.rs`, `src/render.rs`,
-    `src/update/gateway.rs`, `tests/render_delegate.rs`) rather than re-measuring the timeout you
-    passed in.
-  - **Say so when a test cannot prove its negative.** Some races cannot be forced from outside: the
-    superseded-render tests in `tests/controller_async.rs` only catch a stale result that lands
-    AFTER the newest, so perturbing `poll`'s `seq == latest_seq` guard does not fail them. Their
-    comment says exactly that, and names the unit test that would prove it. A test whose limits are
-    written down is worth more than one silently trusted past them.
+    job reaches the render worker. For "bounded, not unbounded", bound a long-stalling fixture (60s
+    in `src/proc.rs` / `src/render.rs` / `src/update/gateway.rs`, 30s and an endless loop in
+    `tests/render_delegate.rs`) at a couple of seconds, rather than re-measuring the timeout you
+    passed in — generous enough for a loaded runner, tight enough to still reject a multi-second
+    tail.
+  - **Know the render worker's shape before reasoning about ordering.** There is ONE long-lived
+    worker (`Controller::spawn_worker`) that takes jobs over a channel in order and collapses a
+    backlog, so a newer result landing means every earlier job already finished or was collapsed.
+    That ordering is what lets a test assert with no wait at all; assuming thread-per-render instead
+    leads to inventing sleeps that prove nothing.
+  - **Say so when a test cannot prove its negative.** The superseded-render tests in
+    `tests/controller_async.rs` only catch a stale result that lands AFTER the newest, and the
+    polling loop drains earlier results first — so removing `poll`'s `seq == latest_seq` guard does
+    NOT fail them. Their comment says exactly that, and names the unit test that would prove it. A
+    test whose limits are written down is worth more than one silently trusted past them.
 - **Never send a key that assumes state the test has not observed.** In a pty journey `q`/Esc peels
   ONE state layer per press (`src/controller/mod.rs`: selection → flash → committed search → zoom →
   discard confirm → quit), and toggles like `z` flip whatever is actually there. A journey that

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,6 +159,33 @@ cargo audit
   not `main`; always `git log main..HEAD` before committing/opening a PR, or strays get swept in.
 - Keep the deterministic tier green (fmt/clippy/`cargo audit`) and tests hermetic.
 
+### Tests prove things deterministically, or they don't count
+
+This suite runs on macOS, Linux and Windows CI runners whose timing and layout differ from any dev
+machine. Three rules, each learned from a real failure here. Unlike the drift guards below, these are
+prose, not build-failing checks — hold yourself to them.
+
+- **Don't assert a tight time budget, and don't prove a negative by sleeping.** Asserting a *generous*
+  timeout fired is fine (`src/proc.rs`, `src/update/gateway.rs` do it deliberately); asserting a
+  ~200ms operation finished inside 300ms is a coin flip on a loaded runner, and a "nothing happened"
+  poll passes vacuously when the thing happens after the window closes. Prefer a synchronous,
+  observable tell: `Controller::render_seq` is bumped inside `dispatch_render` BEFORE the worker
+  spawns, so an unchanged seq proves no render was dispatched, where counting a stub provider's calls
+  only races it. Where a wait is the point, separate the two claims: pin the budget's arithmetic in a
+  clock-free unit test (`tests/whats_new_composer.rs` asserts every document gets the one
+  `opened_at + WHATS_NEW_COMPOSE_TIMEOUT` instant) and let the behavioural test assert only that the
+  code did not wait, with a bound orders of magnitude below the stall it is distinguishing from.
+- **Never send a key that assumes state the test has not observed.** In a pty journey `q`/Esc peels
+  ONE state layer per press (`src/controller/mod.rs`: selection → flash → committed search → zoom →
+  discard confirm → quit), and toggles like `z` flip whatever is actually there. A journey that
+  presses a toggle "to undo" a state it never asserted will break on the runner whose layout decided
+  otherwise — which is exactly how a pinned-preview e2e went red 4/4 on ubuntu while green everywhere
+  else. Drive the state you depend on, or make the tail independent of it, and say which in a comment.
+- **A negative that cannot be reproduced locally is not verified.** macOS-only green means nothing for
+  a Linux-only failure: reproduce in a Linux container (`rust:1.96-trixie`, mount the worktree
+  read-only, cache `CARGO_TARGET_DIR` in a volume) before claiming a fix, and say plainly when you
+  could not.
+
 ### Adding a keybinding or a config key (touchpoints + drift guards)
 
 Both surfaces are single-source-of-truth in code, with a build-failing test guarding the docs, so you
@@ -176,6 +203,17 @@ the `?` overlay's Keybindings section, and `[keys]` remapping all derive from it
    fail the build if you skip a doc: `keys_doc_table_documents_every_registry_action_ac21` (every
    registry key is in `docs/keys.md`) and `configuration_doc_lists_every_remappable_intent` (every
    registry name is in `docs/configuration.md`).
+
+**A change to how an agent or a launcher invokes the viewer.** The bundled skill
+(`skills/herdr-file-viewer/SKILL.md`), the paste-in block in `docs/usage.md`, and the launcher scripts
+(`scripts/open-file-viewer*.sh`) all teach the same launch, and they have drifted apart before: the
+skill told agents to pass `--cwd` to `herdr plugin pane open`, which cannot spawn the manifest's
+RELATIVE pane command (and inside a built plugin checkout silently runs *that* checkout's binary),
+while the shipped launcher never passed it (#139). Change all of them together, and keep
+`no_documented_launch_passes_cwd_to_plugin_pane_open` (`tests/docs_consistency.rs`) honest — it holds
+the docs and the scripts to one rule so this divergence fails the build instead of reaching a user.
+The viewed root comes from the FOCUSED herdr pane's cwd (resolved to its worktree top level), never
+from a flag.
 
 **A new config key.** `src/config.rs` owns it: add the field to `Config`, resolve it in `resolve`
 into `EffectiveSettings`, and apply it at wiring time. **Docs (same PR):** document it in

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -1621,8 +1621,9 @@ impl Controller {
     /// The most recently dispatched render's sequence number.
     ///
     /// A read-only observability seam for tests: both [`dispatch_render`](Self::dispatch_render)
-    /// and [`dispatch_reflow`](Self::dispatch_reflow) bump this SYNCHRONOUSLY before spawning the
-    /// worker, so an unchanged value proves no render was dispatched. That is the deterministic
+    /// and [`dispatch_reflow`](Self::dispatch_reflow) bump this SYNCHRONOUSLY before the job is
+    /// sent to the (already running, single) render worker, so an unchanged value proves no render
+    /// was dispatched. That is the deterministic
     /// way to assert a negative here — sleeping to "give a wrong render time to land" passes
     /// vacuously whenever the render lands after the window (see AGENTS.md, "Tests prove things
     /// deterministically").

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -1618,6 +1618,18 @@ impl Controller {
         self.content_scroll
     }
 
+    /// The most recently dispatched render's sequence number.
+    ///
+    /// A read-only observability seam for tests: both [`dispatch_render`](Self::dispatch_render)
+    /// and [`dispatch_reflow`](Self::dispatch_reflow) bump this SYNCHRONOUSLY before spawning the
+    /// worker, so an unchanged value proves no render was dispatched. That is the deterministic
+    /// way to assert a negative here — sleeping to "give a wrong render time to land" passes
+    /// vacuously whenever the render lands after the window (see AGENTS.md, "Tests prove things
+    /// deterministically").
+    pub fn render_seq(&self) -> u64 {
+        self.latest_seq
+    }
+
     /// Assemble the [`ViewState`] the Presenter draws from: the visible tree rows + cursor,
     /// the current content and notices, focus, and the observed width (the narrow-split
     /// input, AC-21).

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -107,11 +107,13 @@ mod tests {
 
         assert_eq!(wait_bounded(&mut child, Duration::from_millis(100)), None);
         // Bounded vs unbounded: the fixture child stalls for 60s, so this proves termination and
-        // reaping returned rather than waiting on it. Not `timeout + small slack` (100ms asserted
-        // under 250ms), which is a coin flip on a loaded runner — see AGENTS.md, "Tests prove
-        // things deterministically".
+        // reaping returned rather than waiting on it. 2s is 20x the requested timeout — ample for a
+        // loaded runner (the flakes this replaced were 314-340ms) while still rejecting a
+        // multi-second reap tail, which a 5s bound let through. Not `timeout + small slack` (100ms
+        // asserted under 250ms): that is a coin flip. See AGENTS.md, "Tests prove things
+        // deterministically".
         assert!(
-            started.elapsed() < Duration::from_secs(5),
+            started.elapsed() < Duration::from_secs(2),
             "termination and reaping must return rather than wait out the stalled child: {:?}",
             started.elapsed()
         );

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -106,9 +106,14 @@ mod tests {
         let started = Instant::now();
 
         assert_eq!(wait_bounded(&mut child, Duration::from_millis(100)), None);
+        // Bounded vs unbounded: the fixture child stalls for 60s, so this proves termination and
+        // reaping returned rather than waiting on it. Not `timeout + small slack` (100ms asserted
+        // under 250ms), which is a coin flip on a loaded runner — see AGENTS.md, "Tests prove
+        // things deterministically".
         assert!(
-            started.elapsed() < Duration::from_millis(250),
-            "termination and reaping stay inside the renderer grace period"
+            started.elapsed() < Duration::from_secs(5),
+            "termination and reaping must return rather than wait out the stalled child: {:?}",
+            started.elapsed()
         );
         assert!(
             child.try_wait().unwrap().is_some(),

--- a/src/render.rs
+++ b/src/render.rs
@@ -1024,13 +1024,14 @@ mod tests {
         );
 
         assert!(matches!(result, Err(RendererError::Timeout)));
-        // The claim is BOUNDED vs UNBOUNDED, and the fixture stalls for 60s, so this separates the
-        // two with an order of magnitude to spare. It is deliberately NOT `timeout + small slack`:
-        // that shape (100ms asserted under 250ms) flaked on a loaded macOS runner and blocked an
-        // unrelated PR. The timeout's exact value is the caller's argument above, not a stopwatch's
-        // job. See AGENTS.md, "Tests prove things deterministically".
+        // The claim is BOUNDED vs UNBOUNDED, and the fixture stalls for 60s. 2s is 20x the
+        // requested timeout — ample for a loaded runner (the flakes this replaced were 314-340ms)
+        // while still rejecting a multi-second reap tail, which a 5s bound let through. It is
+        // deliberately NOT `timeout + small slack`: that shape (100ms asserted under 250ms) flaked
+        // on a loaded macOS runner and blocked an unrelated PR. The timeout's exact value is the
+        // caller's argument above, not a stopwatch's job. See AGENTS.md.
         assert!(
-            started.elapsed() < Duration::from_secs(5),
+            started.elapsed() < Duration::from_secs(2),
             "the full capture window plus bounded reap tail must not become an unbounded wait: {:?}",
             started.elapsed()
         );

--- a/src/render.rs
+++ b/src/render.rs
@@ -1024,9 +1024,15 @@ mod tests {
         );
 
         assert!(matches!(result, Err(RendererError::Timeout)));
+        // The claim is BOUNDED vs UNBOUNDED, and the fixture stalls for 60s, so this separates the
+        // two with an order of magnitude to spare. It is deliberately NOT `timeout + small slack`:
+        // that shape (100ms asserted under 250ms) flaked on a loaded macOS runner and blocked an
+        // unrelated PR. The timeout's exact value is the caller's argument above, not a stopwatch's
+        // job. See AGENTS.md, "Tests prove things deterministically".
         assert!(
-            started.elapsed() < Duration::from_millis(250),
-            "the full capture window plus bounded reap tail must not become an unbounded wait"
+            started.elapsed() < Duration::from_secs(5),
+            "the full capture window plus bounded reap tail must not become an unbounded wait: {:?}",
+            started.elapsed()
         );
     }
 

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -9324,6 +9324,13 @@ fn slow_markdown_renderers(marker: &std::path::Path) -> Renderers {
     }
 }
 
+/// How long the stalled-renderer fixture holds once it has written its handshake.
+///
+/// The gap between this and Help's own 200 ms budget is what makes the wait assertion below
+/// robust: the test only has to separate "fell back on the deadline" from "waited for the
+/// renderer", and those are two orders of magnitude apart.
+const STALLED_RENDERER_WAIT: Duration = Duration::from_secs(60);
+
 #[test]
 fn help_stalled_markdown_renderer_fixture() {
     if let Some(marker) = std::env::args().find_map(|argument| {
@@ -9332,14 +9339,25 @@ fn help_stalled_markdown_renderer_fixture() {
             .map(std::path::PathBuf::from)
     }) {
         std::fs::write(marker, "started").expect("fixture writes stall handshake");
-        std::thread::sleep(Duration::from_secs(60));
+        std::thread::sleep(STALLED_RENDERER_WAIT);
     }
 }
 
 #[test]
-fn open_help_uses_the_composers_single_200ms_budget() {
+fn open_help_falls_back_instead_of_waiting_for_a_stalled_renderer() {
     // T-29: a current-exe fixture writes its handshake before stalling. The handshake rules out a
     // missing/malformed renderer false positive before this test accepts Help's deadline fallback.
+    //
+    // This test owns ONE claim: opening Help does not wait on the renderer. The fixture stalls for
+    // 60s, so any bound far below that proves the deadline fired — no tight budget assertion is
+    // needed, and none belongs here: `elapsed < 300ms` for a 200ms budget is a coin flip on a loaded
+    // CI runner, and it failed twice in one day on unrelated PRs before this was widened.
+    //
+    // The 200ms budget ITSELF is pinned deterministically, without a clock, by the composer tests in
+    // `tests/whats_new_composer.rs`: `one_absolute_deadline_is_shared_and_observed_remaining_decreases`
+    // asserts every document receives the single `opened_at + WHATS_NEW_COMPOSE_TIMEOUT` instant
+    // rather than a fresh timeout each, and `already_expired_open_uses_precomputed_fallbacks_without_delegation`
+    // asserts an expired deadline skips delegation entirely. Keep the budget's arithmetic there.
     let dir = TempDir::new();
     let marker = std::env::temp_dir().join(format!(
         "hfv-help-stall-{}-{}",
@@ -9360,8 +9378,9 @@ fn open_help_uses_the_composers_single_200ms_budget() {
         "the current-exe renderer fixture must start and stall before Help falls back"
     );
     assert!(
-        elapsed < Duration::from_millis(300),
-        "T-29: Help must stay within its 200 ms budget plus bounded scheduling/reap slack: {elapsed:?}"
+        elapsed < STALLED_RENDERER_WAIT / 6,
+        "T-29: Help must fall back on its own deadline, not wait for the stalled renderer \
+         (which holds for {STALLED_RENDERER_WAIT:?}): {elapsed:?}"
     );
     assert!(
         ctrl.help_open(),

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -9325,11 +9325,17 @@ fn slow_markdown_renderers(marker: &std::path::Path) -> Renderers {
 }
 
 /// How long the stalled-renderer fixture holds once it has written its handshake.
-///
-/// The gap between this and Help's own 200 ms budget is what makes the wait assertion below
-/// robust: the test only has to separate "fell back on the deadline" from "waited for the
-/// renderer", and those are two orders of magnitude apart.
 const STALLED_RENDERER_WAIT: Duration = Duration::from_secs(60);
+
+/// The longest Help may take with a stalled renderer before this test calls it a regression.
+///
+/// Deliberately its own constant rather than a fraction of [`STALLED_RENDERER_WAIT`]: those two
+/// numbers answer different questions, and deriving one from the other silently changed the
+/// tolerated latency whenever the fixture's lifetime moved. 2 s is ~10x Help's own 200 ms budget
+/// (loaded-runner slack) and 30x below the stall, so it separates "fell back on the deadline" from
+/// "waited for the renderer" without measuring the runner's mood. It bounds only the WAIT; the
+/// budget's exact value is pinned clock-free in `tests/whats_new_composer.rs`.
+const HELP_STALLED_RENDERER_MAX_WAIT: Duration = Duration::from_secs(2);
 
 #[test]
 fn help_stalled_markdown_renderer_fixture() {
@@ -9348,16 +9354,17 @@ fn open_help_falls_back_instead_of_waiting_for_a_stalled_renderer() {
     // T-29: a current-exe fixture writes its handshake before stalling. The handshake rules out a
     // missing/malformed renderer false positive before this test accepts Help's deadline fallback.
     //
-    // This test owns ONE claim: opening Help does not wait on the renderer. The fixture stalls for
-    // 60s, so any bound far below that proves the deadline fired — no tight budget assertion is
-    // needed, and none belongs here: `elapsed < 300ms` for a 200ms budget is a coin flip on a loaded
-    // CI runner, and it failed twice in one day on unrelated PRs before this was widened.
+    // This test owns ONE claim: opening Help does not wait on the renderer. A tight budget assertion
+    // does not belong here — `elapsed < 300ms` for a 200ms budget is a coin flip on a loaded CI
+    // runner, and it failed twice in one day on unrelated PRs before this was widened.
     //
-    // The 200ms budget ITSELF is pinned deterministically, without a clock, by the composer tests in
-    // `tests/whats_new_composer.rs`: `one_absolute_deadline_is_shared_and_observed_remaining_decreases`
-    // asserts every document receives the single `opened_at + WHATS_NEW_COMPOSE_TIMEOUT` instant
-    // rather than a fresh timeout each, and `already_expired_open_uses_precomputed_fallbacks_without_delegation`
-    // asserts an expired deadline skips delegation entirely. Keep the budget's arithmetic there.
+    // The budget's VALUE is pinned clock-free in `tests/whats_new_composer.rs`:
+    // `one_absolute_deadline_is_shared_and_observed_remaining_decreases` asserts
+    // `WHATS_NEW_COMPOSE_TIMEOUT == 200ms` AND that every document receives exactly
+    // `opened_at + WHATS_NEW_COMPOSE_TIMEOUT` rather than a fresh timeout each, and
+    // `already_expired_open_uses_precomputed_fallbacks_without_delegation` asserts an expired
+    // deadline skips delegation entirely. Keep the budget's arithmetic there and the wait here:
+    // together they catch a widened budget (there) and a Help that blocks anyway (here).
     let dir = TempDir::new();
     let marker = std::env::temp_dir().join(format!(
         "hfv-help-stall-{}-{}",
@@ -9378,9 +9385,10 @@ fn open_help_falls_back_instead_of_waiting_for_a_stalled_renderer() {
         "the current-exe renderer fixture must start and stall before Help falls back"
     );
     assert!(
-        elapsed < STALLED_RENDERER_WAIT / 6,
+        elapsed < HELP_STALLED_RENDERER_MAX_WAIT,
         "T-29: Help must fall back on its own deadline, not wait for the stalled renderer \
-         (which holds for {STALLED_RENDERER_WAIT:?}): {elapsed:?}"
+         (fixture holds {STALLED_RENDERER_WAIT:?}; this test tolerates \
+         {HELP_STALLED_RENDERER_MAX_WAIT:?}): {elapsed:?}"
     );
     assert!(
         ctrl.help_open(),

--- a/tests/controller_async.rs
+++ b/tests/controller_async.rs
@@ -17,7 +17,6 @@ use herdr_file_viewer::view_policy::ViewMode;
 use ratatui::text::Text;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -29,54 +28,16 @@ const LOADING_PLACEHOLDER: &str = "Rendering\u{2026}";
 /// A renderer that sleeps before producing output — the stand-in for a slow external CLI.
 struct SlowContent {
     delay: Duration,
-    /// Renders currently executing: incremented on entry, decremented on exit. Renders run on a
-    /// thread each, so results can arrive in any order and a superseded one may still be in flight
-    /// when the newest lands. A test that must prove "the stale result never overwrote" waits for
-    /// this to reach zero — once no render is running and no new one has been dispatched, nothing
-    /// can land later. Sleeping instead is a vacuous negative: if the stale result finishes after
-    /// the window, the assertion passes and the bug ships.
-    in_flight: Option<Arc<AtomicUsize>>,
 }
 impl ContentProvider for SlowContent {
     fn render(&self, path: &Path, _mode: ViewMode, _raw_diff: Option<&str>) -> RenderResult {
-        if let Some(in_flight) = &self.in_flight {
-            in_flight.fetch_add(1, Ordering::SeqCst);
-        }
         std::thread::sleep(self.delay);
         let name = path.file_name().unwrap().to_string_lossy().into_owned();
-        if let Some(in_flight) = &self.in_flight {
-            in_flight.fetch_sub(1, Ordering::SeqCst);
-        }
         RenderResult {
             content: Text::raw(format!("rendered:{name}")),
             notices: Vec::new(),
             source: None,
         }
-    }
-}
-
-/// Block until no render is executing, so any superseded result has already been produced.
-///
-/// Deterministic where a fixed sleep is not: it waits for the observable event (the worker
-/// finishing) rather than guessing how long that takes on this machine. With no dispatch after the
-/// one under test, in-flight reaching zero is permanent — nothing can land afterwards.
-///
-/// HONEST LIMIT, do not over-trust the callers below: this makes the WAIT deterministic, not the
-/// detection. Renders run a thread each, and the caller's polling loop drains earlier results while
-/// waiting for the newest, so a stale result that finishes BEFORE the newest is applied and
-/// superseded harmlessly. Verified: perturbing `poll` to apply stale results (dropping its
-/// `seq == latest_seq` guard) does NOT fail those tests. The seq guard's real proof would be a
-/// direct unit test feeding `poll` a stale-seq result; these two remain end-to-end sanity checks.
-fn await_renders_settled(ctrl: &mut Controller, in_flight: &AtomicUsize) {
-    let deadline = Instant::now() + Duration::from_secs(10);
-    while in_flight.load(Ordering::SeqCst) > 0 {
-        ctrl.poll();
-        assert!(
-            Instant::now() < deadline,
-            "renders never settled: {} still in flight",
-            in_flight.load(Ordering::SeqCst)
-        );
-        std::thread::sleep(Duration::from_millis(5));
     }
 }
 
@@ -221,10 +182,7 @@ fn a_select_intent_does_not_block_on_a_slow_render_and_content_arrives_later() {
     let components = Components {
         providers: Box::new(move |_resolved| RootProviders {
             git: Arc::new(NoGit),
-            content: Box::new(SlowContent {
-                delay,
-                in_flight: None,
-            }), // `delay` is Copy → fresh each call
+            content: Box::new(SlowContent { delay }), // `delay` is Copy → fresh each call
         }),
         editor: Box::new(NoEditor),
         clipboard: Box::new(common::RecordingClipboard::default()),
@@ -296,7 +254,6 @@ fn full_diff_mode_asks_git_for_whole_file_context() {
             git: Arc::clone(&git),
             content: Box::new(SlowContent {
                 delay: Duration::from_millis(0),
-                in_flight: None,
             }),
         }),
         editor: Box::new(NoEditor),
@@ -340,14 +297,11 @@ fn a_superseded_render_does_not_overwrite_a_newer_selection() {
     std::fs::write(dir.path().join("b.rs"), "2\n").unwrap();
     std::fs::write(dir.path().join("c.rs"), "3\n").unwrap();
 
-    let in_flight = Arc::new(AtomicUsize::new(0));
-    let in_flight_probe = Arc::clone(&in_flight);
     let components = Components {
         providers: Box::new(move |_resolved| RootProviders {
             git: Arc::new(NoGit),
             content: Box::new(SlowContent {
                 delay: Duration::from_millis(80),
-                in_flight: Some(Arc::clone(&in_flight_probe)),
             }),
         }),
         editor: Box::new(NoEditor),
@@ -373,10 +327,9 @@ fn a_superseded_render_does_not_overwrite_a_newer_selection() {
         assert!(Instant::now() < deadline, "final selection never rendered");
         std::thread::sleep(Duration::from_millis(5));
     }
-    // Wait until no render is still executing, so any stale (a.rs/b.rs) result has been produced
-    // and had its real chance to wrongly land. A fixed sleep would pass vacuously whenever the
-    // stale render finished after the window.
-    await_renders_settled(&mut ctrl, &in_flight);
+    // No sleep, and none needed: renders run on ONE worker thread (`Controller::spawn_worker`) that
+    // takes jobs in order and collapses a backlog, so c.rs's result having landed means every
+    // earlier job already completed or was collapsed away. Nothing can arrive afterwards.
     ctrl.poll();
     assert_eq!(
         flatten(ctrl.content()),
@@ -455,10 +408,7 @@ fn a_slow_render_shows_a_loading_placeholder_and_switches_title_with_body() {
     let components = Components {
         providers: Box::new(move |_resolved| RootProviders {
             git: Arc::new(NoGit),
-            content: Box::new(SlowContent {
-                delay,
-                in_flight: None,
-            }),
+            content: Box::new(SlowContent { delay }),
         }),
         editor: Box::new(NoEditor),
         clipboard: Box::new(common::RecordingClipboard::default()),
@@ -556,10 +506,7 @@ fn the_left_gap_follows_the_displayed_file_not_the_selection_during_a_slow_rende
     let components = Components {
         providers: Box::new(move |_resolved| RootProviders {
             git: Arc::new(NoGit),
-            content: Box::new(SlowContent {
-                delay,
-                in_flight: None,
-            }),
+            content: Box::new(SlowContent { delay }),
         }),
         editor: Box::new(NoEditor),
         clipboard: Box::new(common::RecordingClipboard::default()),
@@ -628,14 +575,11 @@ fn a_superseded_render_does_not_overwrite_the_loading_placeholder_nor_the_pane()
     std::fs::write(dir.path().join("b.rs"), "2\n").unwrap();
     std::fs::write(dir.path().join("c.rs"), "3\n").unwrap();
 
-    let in_flight = Arc::new(AtomicUsize::new(0));
-    let in_flight_probe = Arc::clone(&in_flight);
     let components = Components {
         providers: Box::new(move |_resolved| RootProviders {
             git: Arc::new(NoGit),
             content: Box::new(SlowContent {
                 delay: Duration::from_millis(80),
-                in_flight: Some(Arc::clone(&in_flight_probe)),
             }),
         }),
         editor: Box::new(NoEditor),
@@ -687,9 +631,13 @@ fn a_superseded_render_does_not_overwrite_the_loading_placeholder_nor_the_pane()
         assert!(Instant::now() < deadline, "c.rs render never landed");
         std::thread::sleep(Duration::from_millis(5));
     }
-    // Wait until no render is still executing, so b.rs's superseded result has been produced and
-    // had its chance to land, rather than sleeping and hoping it arrived in time.
-    await_renders_settled(&mut ctrl, &in_flight);
+    // No sleep: the single ordered worker means c.rs landing implies b.rs's job already completed
+    // or was collapsed, so no stale result can arrive after this point.
+    //
+    // HONEST LIMIT, do not over-trust this test: it does not prove `poll`'s `seq == latest_seq`
+    // guard. Removing that guard does NOT fail it, because the polling loop above drains b.rs's
+    // earlier result while waiting for c.rs. Proving the guard needs a direct unit test feeding
+    // `poll` a stale-seq result; this stays an end-to-end sanity check.
     ctrl.poll();
     assert_eq!(
         flatten(ctrl.content()),

--- a/tests/controller_async.rs
+++ b/tests/controller_async.rs
@@ -17,6 +17,7 @@ use herdr_file_viewer::view_policy::ViewMode;
 use ratatui::text::Text;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
+use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -38,6 +39,118 @@ impl ContentProvider for SlowContent {
             notices: Vec::new(),
             source: None,
         }
+    }
+}
+
+/// A renderer whose every render blocks until the test releases it, and which reports when each
+/// render has actually STARTED.
+///
+/// This is what makes the superseded-result race forceable instead of hoped for: the test can hold
+/// a render open, dispatch a newer one behind it, then release the first so its result reaches
+/// `poll` while a newer seq is current — the exact ordering `poll`'s `seq == latest_seq` guard
+/// exists to reject, which no amount of sleeping can reliably produce.
+struct GatedContent {
+    started_tx: mpsc::Sender<String>,
+    release_rx: Arc<Mutex<mpsc::Receiver<()>>>,
+}
+impl ContentProvider for GatedContent {
+    fn render(&self, path: &Path, _mode: ViewMode, _raw_diff: Option<&str>) -> RenderResult {
+        let name = path.file_name().unwrap().to_string_lossy().into_owned();
+        self.started_tx
+            .send(name.clone())
+            .expect("test observes render start");
+        self.release_rx
+            .lock()
+            .expect("release gate")
+            .recv()
+            .expect("test releases the render");
+        RenderResult {
+            content: Text::raw(format!("rendered:{name}")),
+            notices: Vec::new(),
+            source: None,
+        }
+    }
+}
+
+/// AC-23 / the `seq == latest_seq` guard in `poll`: a render result that is SUPERSEDED before it
+/// lands must be dropped, never applied.
+///
+/// The two end-to-end superseded-render tests below cannot prove this — their polling loop drains
+/// the earlier result while waiting for the newest, so removing the guard does not fail them. This
+/// one forces the ordering directly: `a.rs` is held mid-render while `b.rs` is dispatched behind
+/// it, so when `a.rs` is released its result arrives carrying a stale seq. Verified to fail when
+/// the guard is removed.
+#[test]
+fn a_result_superseded_before_it_lands_is_dropped_by_poll() {
+    let dir = TempDir::new();
+    std::fs::write(dir.path().join("a.rs"), "1\n").unwrap();
+    std::fs::write(dir.path().join("b.rs"), "2\n").unwrap();
+
+    let (started_tx, started_rx) = mpsc::channel::<String>();
+    let (release_tx, release_rx) = mpsc::channel::<()>();
+    let release_rx = Arc::new(Mutex::new(release_rx));
+    let components = Components {
+        providers: Box::new(move |_resolved| RootProviders {
+            git: Arc::new(NoGit),
+            content: Box::new(GatedContent {
+                started_tx: started_tx.clone(),
+                release_rx: Arc::clone(&release_rx),
+            }),
+        }),
+        editor: Box::new(NoEditor),
+        clipboard: Box::new(common::RecordingClipboard::default()),
+        renderers: None,
+    };
+    let mut ctrl = Controller::new(
+        common::resolved(dir.path().to_path_buf(), false),
+        Baseline::Head,
+        components,
+    );
+
+    // a.rs's render is now RUNNING and blocked inside the provider (observed, not assumed).
+    assert_eq!(
+        started_rx.recv().expect("a.rs render starts"),
+        "a.rs",
+        "the initial selection renders first"
+    );
+
+    // Dispatch b.rs behind it: `latest_seq` moves on while a.rs's result does not yet exist.
+    ctrl.handle(Intent::NavDown);
+    assert_eq!(
+        flatten(ctrl.content()),
+        LOADING_PLACEHOLDER,
+        "precondition: b.rs is selected and still rendering"
+    );
+
+    // Release a.rs: its result is produced and sent NOW, carrying the superseded seq.
+    release_tx.send(()).expect("release a.rs");
+    // b.rs's render starting is proof the worker has finished sending a.rs's result — the ordered
+    // worker takes the next job only after the previous one is sent. So the stale result is
+    // already sitting in the channel, waiting for `poll`, with no sleeping involved.
+    assert_eq!(
+        started_rx.recv().expect("b.rs render starts"),
+        "b.rs",
+        "the worker moved on to b.rs, so a.rs's stale result has been sent"
+    );
+
+    ctrl.poll();
+    assert_eq!(
+        flatten(ctrl.content()),
+        LOADING_PLACEHOLDER,
+        "a superseded result must be DROPPED by poll, not applied to the newer selection"
+    );
+
+    // And the newest result still lands normally, so the guard drops stale work without breaking
+    // the live path.
+    release_tx.send(()).expect("release b.rs");
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        ctrl.poll();
+        if flatten(ctrl.content()) == "rendered:b.rs" {
+            break;
+        }
+        assert!(Instant::now() < deadline, "b.rs never landed");
+        std::thread::sleep(Duration::from_millis(5));
     }
 }
 
@@ -634,10 +747,11 @@ fn a_superseded_render_does_not_overwrite_the_loading_placeholder_nor_the_pane()
     // No sleep: the single ordered worker means c.rs landing implies b.rs's job already completed
     // or was collapsed, so no stale result can arrive after this point.
     //
-    // HONEST LIMIT, do not over-trust this test: it does not prove `poll`'s `seq == latest_seq`
-    // guard. Removing that guard does NOT fail it, because the polling loop above drains b.rs's
-    // earlier result while waiting for c.rs. Proving the guard needs a direct unit test feeding
-    // `poll` a stale-seq result; this stays an end-to-end sanity check.
+    // Scope, so this is not over-trusted: it does NOT prove `poll`'s `seq == latest_seq` guard.
+    // Removing that guard does not fail it, because the polling loop above drains b.rs's earlier
+    // result while waiting for c.rs. The guard is proved separately, by forcing the ordering with a
+    // gated renderer, in `a_result_superseded_before_it_lands_is_dropped_by_poll`. This stays an
+    // end-to-end sanity check of the happy path.
     ctrl.poll();
     assert_eq!(
         flatten(ctrl.content()),

--- a/tests/controller_async.rs
+++ b/tests/controller_async.rs
@@ -17,6 +17,7 @@ use herdr_file_viewer::view_policy::ViewMode;
 use ratatui::text::Text;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -28,16 +29,54 @@ const LOADING_PLACEHOLDER: &str = "Rendering\u{2026}";
 /// A renderer that sleeps before producing output — the stand-in for a slow external CLI.
 struct SlowContent {
     delay: Duration,
+    /// Renders currently executing: incremented on entry, decremented on exit. Renders run on a
+    /// thread each, so results can arrive in any order and a superseded one may still be in flight
+    /// when the newest lands. A test that must prove "the stale result never overwrote" waits for
+    /// this to reach zero — once no render is running and no new one has been dispatched, nothing
+    /// can land later. Sleeping instead is a vacuous negative: if the stale result finishes after
+    /// the window, the assertion passes and the bug ships.
+    in_flight: Option<Arc<AtomicUsize>>,
 }
 impl ContentProvider for SlowContent {
     fn render(&self, path: &Path, _mode: ViewMode, _raw_diff: Option<&str>) -> RenderResult {
+        if let Some(in_flight) = &self.in_flight {
+            in_flight.fetch_add(1, Ordering::SeqCst);
+        }
         std::thread::sleep(self.delay);
         let name = path.file_name().unwrap().to_string_lossy().into_owned();
+        if let Some(in_flight) = &self.in_flight {
+            in_flight.fetch_sub(1, Ordering::SeqCst);
+        }
         RenderResult {
             content: Text::raw(format!("rendered:{name}")),
             notices: Vec::new(),
             source: None,
         }
+    }
+}
+
+/// Block until no render is executing, so any superseded result has already been produced.
+///
+/// Deterministic where a fixed sleep is not: it waits for the observable event (the worker
+/// finishing) rather than guessing how long that takes on this machine. With no dispatch after the
+/// one under test, in-flight reaching zero is permanent — nothing can land afterwards.
+///
+/// HONEST LIMIT, do not over-trust the callers below: this makes the WAIT deterministic, not the
+/// detection. Renders run a thread each, and the caller's polling loop drains earlier results while
+/// waiting for the newest, so a stale result that finishes BEFORE the newest is applied and
+/// superseded harmlessly. Verified: perturbing `poll` to apply stale results (dropping its
+/// `seq == latest_seq` guard) does NOT fail those tests. The seq guard's real proof would be a
+/// direct unit test feeding `poll` a stale-seq result; these two remain end-to-end sanity checks.
+fn await_renders_settled(ctrl: &mut Controller, in_flight: &AtomicUsize) {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while in_flight.load(Ordering::SeqCst) > 0 {
+        ctrl.poll();
+        assert!(
+            Instant::now() < deadline,
+            "renders never settled: {} still in flight",
+            in_flight.load(Ordering::SeqCst)
+        );
+        std::thread::sleep(Duration::from_millis(5));
     }
 }
 
@@ -182,7 +221,10 @@ fn a_select_intent_does_not_block_on_a_slow_render_and_content_arrives_later() {
     let components = Components {
         providers: Box::new(move |_resolved| RootProviders {
             git: Arc::new(NoGit),
-            content: Box::new(SlowContent { delay }), // `delay` is Copy → fresh each call
+            content: Box::new(SlowContent {
+                delay,
+                in_flight: None,
+            }), // `delay` is Copy → fresh each call
         }),
         editor: Box::new(NoEditor),
         clipboard: Box::new(common::RecordingClipboard::default()),
@@ -254,6 +296,7 @@ fn full_diff_mode_asks_git_for_whole_file_context() {
             git: Arc::clone(&git),
             content: Box::new(SlowContent {
                 delay: Duration::from_millis(0),
+                in_flight: None,
             }),
         }),
         editor: Box::new(NoEditor),
@@ -297,11 +340,14 @@ fn a_superseded_render_does_not_overwrite_a_newer_selection() {
     std::fs::write(dir.path().join("b.rs"), "2\n").unwrap();
     std::fs::write(dir.path().join("c.rs"), "3\n").unwrap();
 
+    let in_flight = Arc::new(AtomicUsize::new(0));
+    let in_flight_probe = Arc::clone(&in_flight);
     let components = Components {
         providers: Box::new(move |_resolved| RootProviders {
             git: Arc::new(NoGit),
             content: Box::new(SlowContent {
                 delay: Duration::from_millis(80),
+                in_flight: Some(Arc::clone(&in_flight_probe)),
             }),
         }),
         editor: Box::new(NoEditor),
@@ -327,8 +373,10 @@ fn a_superseded_render_does_not_overwrite_a_newer_selection() {
         assert!(Instant::now() < deadline, "final selection never rendered");
         std::thread::sleep(Duration::from_millis(5));
     }
-    // Give any stale (a.rs/b.rs) results a chance to wrongly land, then re-check.
-    std::thread::sleep(Duration::from_millis(50));
+    // Wait until no render is still executing, so any stale (a.rs/b.rs) result has been produced
+    // and had its real chance to wrongly land. A fixed sleep would pass vacuously whenever the
+    // stale render finished after the window.
+    await_renders_settled(&mut ctrl, &in_flight);
     ctrl.poll();
     assert_eq!(
         flatten(ctrl.content()),
@@ -407,7 +455,10 @@ fn a_slow_render_shows_a_loading_placeholder_and_switches_title_with_body() {
     let components = Components {
         providers: Box::new(move |_resolved| RootProviders {
             git: Arc::new(NoGit),
-            content: Box::new(SlowContent { delay }),
+            content: Box::new(SlowContent {
+                delay,
+                in_flight: None,
+            }),
         }),
         editor: Box::new(NoEditor),
         clipboard: Box::new(common::RecordingClipboard::default()),
@@ -505,7 +556,10 @@ fn the_left_gap_follows_the_displayed_file_not_the_selection_during_a_slow_rende
     let components = Components {
         providers: Box::new(move |_resolved| RootProviders {
             git: Arc::new(NoGit),
-            content: Box::new(SlowContent { delay }),
+            content: Box::new(SlowContent {
+                delay,
+                in_flight: None,
+            }),
         }),
         editor: Box::new(NoEditor),
         clipboard: Box::new(common::RecordingClipboard::default()),
@@ -574,11 +628,14 @@ fn a_superseded_render_does_not_overwrite_the_loading_placeholder_nor_the_pane()
     std::fs::write(dir.path().join("b.rs"), "2\n").unwrap();
     std::fs::write(dir.path().join("c.rs"), "3\n").unwrap();
 
+    let in_flight = Arc::new(AtomicUsize::new(0));
+    let in_flight_probe = Arc::clone(&in_flight);
     let components = Components {
         providers: Box::new(move |_resolved| RootProviders {
             git: Arc::new(NoGit),
             content: Box::new(SlowContent {
                 delay: Duration::from_millis(80),
+                in_flight: Some(Arc::clone(&in_flight_probe)),
             }),
         }),
         editor: Box::new(NoEditor),
@@ -630,7 +687,9 @@ fn a_superseded_render_does_not_overwrite_the_loading_placeholder_nor_the_pane()
         assert!(Instant::now() < deadline, "c.rs render never landed");
         std::thread::sleep(Duration::from_millis(5));
     }
-    std::thread::sleep(Duration::from_millis(50));
+    // Wait until no render is still executing, so b.rs's superseded result has been produced and
+    // had its chance to land, rather than sleeping and hoping it arrived in time.
+    await_renders_settled(&mut ctrl, &in_flight);
     ctrl.poll();
     assert_eq!(
         flatten(ctrl.content()),
@@ -745,9 +804,17 @@ fn a_width_change_reflows_markdown_at_the_new_width_but_a_height_change_does_not
     );
 
     // A height-only change (same width) must NOT reflow — no further render is dispatched.
+    // `render_seq` is bumped synchronously inside dispatch, BEFORE the worker spawns, so an
+    // unchanged seq proves the absence outright; the delegate count is corroboration, not the
+    // oracle (it lags the dispatch by a thread hop, so on its own it would pass vacuously).
     let before = widths.lock().unwrap().len();
+    let seq_before = ctrl.render_seq();
     ctrl.set_content_viewport(50, 14);
-    std::thread::sleep(Duration::from_millis(50)); // give any (wrong) reflow time to land
+    assert_eq!(
+        ctrl.render_seq(),
+        seq_before,
+        "a height-only change must not dispatch a re-render"
+    );
     ctrl.poll();
     assert_eq!(
         widths.lock().unwrap().len(),
@@ -825,8 +892,15 @@ fn a_width_change_does_not_reflow_non_markdown() {
     await_contains(&mut ctrl, "w=None:a.rs");
 
     let before = widths.lock().unwrap().len();
+    let seq_before = ctrl.render_seq();
     ctrl.set_content_viewport(50, 10); // width change, but the selection is code, not markdown
-    std::thread::sleep(Duration::from_millis(50));
+    // Synchronous proof of absence; see the height-only case above for why the count alone is not
+    // the oracle.
+    assert_eq!(
+        ctrl.render_seq(),
+        seq_before,
+        "a resize must not dispatch a re-render for a width-independent view"
+    );
     ctrl.poll();
     assert_eq!(
         widths.lock().unwrap().len(),
@@ -879,13 +953,19 @@ fn toggle_wrap_on_a_code_file_dispatches_no_render() {
     await_contains(&mut ctrl, "w=None:a.rs");
     ctrl.set_content_viewport(50, 10); // code view is width-independent → no reflow
     let before = widths.lock().unwrap().len();
+    let seq_before = ctrl.render_seq();
     ctrl.handle(Intent::ToggleWrap); // toggle wrap on a code file
-    std::thread::sleep(Duration::from_millis(50)); // give any (wrong) dispatch time to land
+    // Synchronous proof of absence: the seq is bumped inside dispatch before the worker spawns.
+    assert_eq!(
+        ctrl.render_seq(),
+        seq_before,
+        "toggling wrap on a code file must not dispatch a render"
+    );
     ctrl.poll();
     assert_eq!(
         widths.lock().unwrap().len(),
         before,
-        "toggling wrap on a code file must not dispatch a render"
+        "and no delegate call may land afterwards"
     );
 }
 

--- a/tests/whats_new_composer.rs
+++ b/tests/whats_new_composer.rs
@@ -363,11 +363,14 @@ fn one_absolute_deadline_is_shared_and_observed_remaining_decreases() {
         ..RecordingRenderer::default()
     };
 
+    // Captured so the deadline can be checked against its ORIGIN, not just against itself: without
+    // this, a composer that handed out one shared but differently-sized budget still passed.
+    let opened_at = Instant::now();
     let _ = compose_whats_new(
         &snapshot(true, true, true),
         EMBEDDED,
         &install_guidance(),
-        Instant::now(),
+        opened_at,
         71,
         &mut renderer,
     );
@@ -381,6 +384,19 @@ fn one_absolute_deadline_is_shared_and_observed_remaining_decreases() {
     assert!(
         renderer.calls.iter().all(|call| call.deadline == deadline),
         "every document receives the one Help-open absolute deadline, never a fresh timeout"
+    );
+    // The VALUE of the budget, not merely its sharing. `tests/controller.rs`'s stalled-renderer test
+    // deliberately allows generous slack, so this is the only place the 200 ms figure is pinned:
+    // without it a budget silently widened to seconds would pass the whole suite.
+    assert_eq!(
+        WHATS_NEW_COMPOSE_TIMEOUT,
+        Duration::from_millis(200),
+        "the Help-open composition budget is 200 ms (T-29); widening it is a spec change"
+    );
+    assert_eq!(
+        deadline,
+        opened_at + WHATS_NEW_COMPOSE_TIMEOUT,
+        "the shared deadline is exactly one budget after the Help-open instant"
     );
     assert!(
         renderer.calls.iter().all(|call| {


### PR DESCRIPTION
Removes the wall-clock flake that has been failing unrelated PRs, and records the rule it came from.

## The flake

`open_help_uses_the_composers_single_200ms_budget` asserted that opening Help with a deliberately stalled markdown renderer finished in under 300ms. On a shared CI runner that is a coin flip: it failed **twice in one day** on unrelated PRs — 314ms on #141 and 340ms on the v1.15.0 release PR — passing on re-run both times.

## Why the bound existed, and why it can go

The tight bound was proving two things at once, and only one of them needs a clock:

- **The budget's arithmetic** is already pinned deterministically in `tests/whats_new_composer.rs`: `one_absolute_deadline_is_shared_and_observed_remaining_decreases` asserts every document receives the single `opened_at + WHATS_NEW_COMPOSE_TIMEOUT` instant rather than a fresh timeout each, and `already_expired_open_uses_precomputed_fallbacks_without_delegation` asserts an expired deadline skips delegation. Neither needs wall-clock tolerance.
- **What the controller test uniquely proves** is that Help does not *wait* on the renderer. The fixture stalls for 60s, so a bound of a tenth of that separates "fell back on its deadline" from "waited for the renderer" with two orders of magnitude of headroom.

So the test keeps its real claim, loses the flaky one, and is renamed to `open_help_falls_back_instead_of_waiting_for_a_stalled_renderer`. The wait is bounded by its own named constant (`HELP_STALLED_RENDERER_MAX_WAIT` = 2s, ~10x Help's budget and 30x below the 60s stall), separate from `STALLED_RENDERER_WAIT` which is only the fixture's lifetime — two numbers answering different questions should not be derived from each other.

Every other assertion in the test is unchanged: the fixture handshake, `help_open()`, and the non-empty plain-text fallback body.

## Verification

- Budget perturbed to 5s **and** 1.5s: the composer test fails on the literal-value assertion, and at 5s the controller test fails too. Budget left at 200ms with a 2.5s delay injected into `open_help`: the controller test fails. The two halves catch a widened budget and a blocking Help independently.
- The three `render_seq` absence assertions were each perturbed (unconditional height reflow, reflow for syntax content, wrap-toggle on code): each fails.
- A 4s sleep injected between `child.kill()` and `child.wait()` fails the two reap-tail tests at 4.11s, which the earlier 5s bound allowed.
- `cargo test`, `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` green.

## AGENTS.md

Adds the standing rule this came from, plus the two other determinism lessons this repo learned the hard way today (the pinned-preview e2e that was red 4/4 on ubuntu because it pressed a toggle against unobserved state, and the "reproduce a Linux-only failure in a Linux container before claiming a fix" rule). Generous timeout assertions — `src/proc.rs`, `src/update/gateway.rs` — are explicitly called out as legitimate, so the rule bans the coin flip rather than all timing tests.

No CHANGELOG entry: test and contributor-doc only, no user-facing behaviour.

## Beyond the original flake

Reviewed twice by `gpt-5.6-sol`. Round 1 found a blocker: the first relaxation left nothing catching a budget widened to 5s, because the composer tests were self-referential about its value. Round 2 confirmed that closed and found three more, all fixed here: a wrong worker model in my comments (there is one ordered worker with backlog collapse, not a thread per render), 5s reap bounds that let a 4s regression through, and AGENTS.md citing tests that exist only on an unmerged branch.

The PR now also removes the last blind 50ms sleeps from `tests/controller_async.rs`, adds `Controller::render_seq` as the synchronous no-dispatch tell, and records in code and in AGENTS.md the one limit that cannot be fixed from outside: the superseded-render tests do not prove `poll`'s seq guard, and the unit test that would is named.

**Note for PR #137:** it adds an identical `render_seq` on its branch and will need its copy dropped when it rebases.
