### PR TITLE
feat: configurable file and folder icons (Unicode and Nerd Font)

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -140,6 +140,13 @@
 # unrecognized value falls back to "left". Default:
 #tree_position = "left"
 
+# file_icons: the file/folder icon style in the tree and file finder:
+#   "unicode"   - standard Unicode glyphs (default; works without a patched font)
+#   "nerd"      - rich glyphs (requires a Nerd Font in your terminal)
+#   "off"       - plain text-only tree with no file icons
+# Default:
+#file_icons = "unicode"
+
 # --- Content preview ---------------------------------------------------------
 #
 # A file is shown in FULL until it exceeds one of two caps, then the content pane

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,7 +48,7 @@ config key and above the built-in default — `editor` (`$EDITOR`) and `update_c
 (`$HERDR_FILE_VIEWER_NO_UPDATE_CHECK`) — giving those two a `config > env > default` chain. Every
 other key (`markdown`, `diff`, `syntax`, `open`, `reveal`, `hide_dotfiles`, `show_ignored`,
 `compact_dirs`, `changed_file_view`, `confirm_discard`, `scroll_lines`, `tree_width`,
-`tree_position`, `tree_max_cols`, `preview_max_lines`, `preview_max_kib`) has no
+`tree_position`, `tree_max_cols`, `file_icons`, `preview_max_lines`, `preview_max_kib`) has no
 applicable environment variable; for those it's `config > default` only.
 
 ## Keys
@@ -75,6 +75,7 @@ scroll_lines = 3            # mouse-wheel step (content/search/help), a 1 to 10 
 tree_width = 30             # tree column's share of the viewer pane, percent 20-80 (content takes the rest)
 tree_max_cols = 30          # HARD CAP in columns; the SMALLER of this and tree_width% wins (raise both to widen)
 tree_position = "left"      # which side the directory tree sits on: "left" (default) or "right"
+file_icons = "unicode"      # "unicode" (default), "nerd" (Nerd Font required), or "off"
 
 preview_max_lines = 10000   # show at most this many lines before a truncated preview (100–100000)
 preview_max_kib = 1024      # ...or this size before truncating, in KiB (1024 = 1 MB; 64–65536)
@@ -84,6 +85,10 @@ preview_max_kib = 1024      # ...or this size before truncating, in KiB (1024 = 
 and their display. When the key is unset, `$HERDR_FILE_VIEWER_NO_UPDATE_CHECK` also disables it.
 No separate spotlight setting exists.
 The system `curl` is optional: without it, document retrieval is unavailable without an error.
+
+`file_icons` controls the glyphs before file-tree entries and file-finder results: `"unicode"` (default)
+uses standard, single-cell Unicode symbols that render cleanly on any terminal without requiring a
+patched font; `"nerd"` uses rich Nerd Font glyphs; `"off"` (or `"none"`) uses plain text-only indentation.
 
 `changed_file_view` controls only the automatic initial view for Git-changed files. Its default,
 `"diff"`, preserves the existing diff-first policy. Set it to `"content"` to apply the same normal

--- a/src/app.rs
+++ b/src/app.rs
@@ -137,6 +137,7 @@ pub fn run(open_flag: Option<String>) -> io::Result<()> {
     controller.apply_tree_width(eff.tree_width);
     controller.apply_tree_position(eff.tree_position);
     controller.apply_tree_max_cols(eff.tree_max_cols);
+    controller.apply_tree_icons(eff.file_icons);
     // Launch open target (GH #109): CLI `--open` wins over `HERDR_FILE_VIEWER_OPEN`. Applied
     // after layout/config wiring so reveal + render see the same filters as a live session.
     // Soft-fails with an action notice; never aborts startup.

--- a/src/config.rs
+++ b/src/config.rs
@@ -91,6 +91,25 @@ impl TreePosition {
     }
 }
 
+/// File-tree icon style.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum TreeIcons {
+    Off,
+    #[default]
+    Unicode,
+    Nerd,
+}
+
+impl TreeIcons {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Off => "off",
+            Self::Unicode => "unicode",
+            Self::Nerd => "nerd",
+        }
+    }
+}
+
 /// A `[keys]` entry's value: the key(s) an intent binds to, written **either** as a single string
 /// (`refresh = "g"`) **or** as a TOML array of strings (`nav_up = ["w", "Up"]`). `#[serde(untagged)]`
 /// tries the variants in order, so `One(String)` must come first: a bare string deserializes to
@@ -162,6 +181,8 @@ pub struct Config {
     /// out-of-`u16` number clamps into range instead of tripping the parse; only a negative /
     /// non-integer value fails to parse and degrades the whole config to defaults.
     pub tree_max_cols: Option<u32>,
+    /// The **file and folder icon style**: `"unicode"` (default), `"nerd"`, or `"off"` / `"none"`.
+    pub file_icons: Option<String>,
     /// The **content preview line cap**: past this many lines a file (or a large diff) is shown as a
     /// truncated preview plus a notice, not whole (AC-13). `None` falls back to
     /// [`DEFAULT_PREVIEW_MAX_LINES`]; the resolver clamps a present value into
@@ -320,6 +341,9 @@ pub struct EffectiveSettings {
     /// `MIN_TREE_MAX_COLS..=MAX_TREE_MAX_COLS` when present, else [`DEFAULT_TREE_MAX_COLS`]. The tree
     /// is drawn at `min(tree_width% of the pane, tree_max_cols)`. Config-or-default (no env var).
     pub tree_max_cols: u16,
+    /// The effective **file and folder icon style**: the config `file_icons` mapped to
+    /// `Unicode`/`Nerd`/`Off`, defaulting to [`TreeIcons::Unicode`]. Config-or-default (no env var).
+    pub file_icons: TreeIcons,
     /// The effective **content preview line cap**: the config `preview_max_lines` clamped to
     /// `MIN_PREVIEW_MAX_LINES..=MAX_PREVIEW_MAX_LINES` when present, else [`DEFAULT_PREVIEW_MAX_LINES`].
     /// Wired into the Content Renderer's [`crate::render::Caps`] via [`Self::preview_caps`].
@@ -446,6 +470,18 @@ pub fn resolve(config: &Config, get_env: impl Fn(&str) -> Option<String>) -> Eff
         .map(|n| n.clamp(MIN_TREE_MAX_COLS as u32, MAX_TREE_MAX_COLS as u32) as u16)
         .unwrap_or(DEFAULT_TREE_MAX_COLS);
 
+    // Config > default; no env var. Lenient string match (trimmed, case-insensitive).
+    let file_icons = match config
+        .file_icons
+        .as_deref()
+        .map(|s| s.trim().to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("off") | Some("none") => TreeIcons::Off,
+        Some("nerd") | Some("nerd-font") => TreeIcons::Nerd,
+        _ => TreeIcons::Unicode,
+    };
+
     // Config > default; no env var. Clamp to `MIN_PREVIEW_MAX_LINES..=MAX_PREVIEW_MAX_LINES` so a
     // preview can never truncate to near-nothing, and a huge cap can't wedge the render pipeline. A
     // non-representable value degraded the whole config to defaults and arrived as `None`.
@@ -479,6 +515,7 @@ pub fn resolve(config: &Config, get_env: impl Fn(&str) -> Option<String>) -> Eff
         tree_width,
         tree_position,
         tree_max_cols,
+        file_icons,
         preview_max_lines,
         preview_max_kib,
     }
@@ -1613,5 +1650,27 @@ mod tests {
         assert!(!should_start_update_check(&eff));
         eff.update_check = true;
         assert!(should_start_update_check(&eff));
+    }
+
+    #[test]
+    fn resolve_file_icons_supports_all_modes_and_safe_default() {
+        for (value, expected) in [
+            ("off", TreeIcons::Off),
+            ("none", TreeIcons::Off),
+            (" Unicode ", TreeIcons::Unicode),
+            ("NERD", TreeIcons::Nerd),
+            ("nerd-font", TreeIcons::Nerd),
+            ("unknown", TreeIcons::Unicode),
+        ] {
+            let cfg = Config {
+                file_icons: Some(value.to_string()),
+                ..Config::default()
+            };
+            assert_eq!(resolve(&cfg, |_| None).file_icons, expected);
+        }
+        assert_eq!(
+            resolve(&Config::default(), |_| None).file_icons,
+            TreeIcons::Unicode
+        );
     }
 }

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -812,6 +812,8 @@ pub struct Controller {
     /// Seeded at startup via [`apply_tree_max_cols`](Self::apply_tree_max_cols); read by the
     /// Presenter through the view state. Carried across a re-root (like `split_pct`).
     tree_max_cols: u16,
+    /// File/folder icon style used by the tree presenter.
+    tree_icons: crate::config::TreeIcons,
     /// Whether the user has resized the split by hand this session (grow/shrink keys or a divider
     /// drag). `tree_max_cols` caps the tree only while this is `false`; the first manual resize seeds
     /// `split_pct` from the currently-displayed width and lifts the cap, so the resize is honoured
@@ -1067,6 +1069,7 @@ impl Controller {
             split_pct: SPLIT_DEFAULT,
             tree_position: crate::config::TreePosition::Left,
             tree_max_cols: crate::config::DEFAULT_TREE_MAX_COLS,
+            tree_icons: crate::config::TreeIcons::default(),
             split_manual: false,
             wrap_override: None,
             zoomed: false,
@@ -1755,6 +1758,11 @@ impl Controller {
         self.tree_max_cols = cols.max(crate::config::MIN_TREE_MAX_COLS);
     }
 
+    /// Seed the startup file/folder icon style from config.
+    pub fn apply_tree_icons(&mut self, icons: crate::config::TreeIcons) {
+        self.tree_icons = icons;
+    }
+
     /// Record the active content viewport `(width, height)` the Presenter last drew into, so content
     /// scrolling can be clamped to it. Called by the run loop after each draw.
     ///
@@ -1990,6 +1998,7 @@ impl Controller {
             split_pct: self.split_pct,
             tree_position: self.tree_position,
             tree_max_cols: self.tree_max_cols,
+            tree_icons: self.tree_icons,
             split_manual: self.split_manual,
             zoomed: self.zoomed,
             remote_notice_status: self.remote_notice_status(),

--- a/src/help.rs
+++ b/src/help.rs
@@ -287,6 +287,7 @@ pub fn settings_text(
          tree_width        = {tree_width}\n\
          tree_position     = {tree_position}\n\
          tree_max_cols     = {tree_max_cols}\n\
+         file_icons        = {file_icons}\n\
          preview_max_lines = {preview_max_lines}\n\
          preview_max_kib   = {preview_max_kib}",
         open = open,
@@ -301,6 +302,7 @@ pub fn settings_text(
         tree_width = eff.tree_width,
         tree_position = eff.tree_position.label(),
         tree_max_cols = eff.tree_max_cols,
+        file_icons = eff.file_icons.label(),
         preview_max_lines = eff.preview_max_lines,
         preview_max_kib = eff.preview_max_kib,
     )
@@ -809,6 +811,7 @@ mod tests {
             tree_width: 25,
             tree_position: crate::config::TreePosition::Right,
             tree_max_cols: 50,
+            file_icons: crate::config::TreeIcons::Unicode,
             preview_max_lines: 8000,
             preview_max_kib: 2048,
         }
@@ -848,6 +851,7 @@ mod tests {
             "tree_width",
             "tree_position",
             "tree_max_cols",
+            "file_icons",
             "preview_max_lines",
             "preview_max_kib",
         ] {
@@ -1002,6 +1006,7 @@ mod tests {
                 "tree_max_cols     = {}",
                 crate::config::DEFAULT_TREE_MAX_COLS
             ),
+            "file_icons        = unicode",
             &format!(
                 "preview_max_lines = {}",
                 crate::config::DEFAULT_PREVIEW_MAX_LINES

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -134,6 +134,8 @@ pub struct ViewState {
     /// drawn at `min(split_pct% of the pane, tree_max_cols)`, so on a very wide pane it stops
     /// growing instead of over-allocating. Used only in the wide two-column layout.
     pub tree_max_cols: u16,
+    /// File/folder icon style used by the tree presenter.
+    pub tree_icons: crate::config::TreeIcons,
     /// Whether the user has resized the split by hand this session (a divider drag or the
     /// grow/shrink keys). While `false`, `tree_max_cols` caps the tree; once `true` the cap is
     /// lifted so an explicit resize is honoured exactly (otherwise the resize would look frozen on a
@@ -471,10 +473,10 @@ fn row_color(node: &Node) -> Option<Color> {
 /// the controller's horizontal-scroll clamp. Computed from the same [`tree_row`] the tree draws
 /// (selection-independent: the REVERSED highlight doesn't change a row's width), so the drawn
 /// rows and the hit-test/clamp can never disagree.
-fn tree_rows_max_width(nodes: &[Node]) -> usize {
+fn tree_rows_max_width(nodes: &[Node], icons: crate::config::TreeIcons) -> usize {
     nodes
         .iter()
-        .map(|n| tree_row(n, false, false).width())
+        .map(|n| tree_row(n, false, false, icons).width())
         .max()
         .unwrap_or(0)
 }
@@ -484,19 +486,168 @@ const ANNOTATION_STYLE: Style = Style::new().bg(Color::DarkGray);
 
 /// Render one tree row: `<git><annotation><indent><glyph><name>`. The annotation marker replaces
 /// the reserved blank prefix cell, so git coexistence and row geometry stay unchanged.
-///
-/// A file's glyph is two BLANKS, not an empty string. The expand arrow is two columns wide, so
-/// without that placeholder a file's name starts two columns left of where a directory's name
-/// starts at the same depth — which puts a file at depth `d+1` in exactly the column of its parent
-/// directory at depth `d`, and puts a top-level file two columns left of the directory it sits
-/// beside. Reserving the width makes the column a node's name starts in a true function of its
-/// depth, so siblings line up and a child is always one level in from its parent.
-fn tree_row(node: &Node, selected: bool, annotated: bool) -> Line<'static> {
-    let glyph = match node.kind {
-        NodeKind::Dir if node.expanded => "▾ ",
-        NodeKind::Dir => "▸ ",
-        NodeKind::File => "  ",
+fn tree_icon(node: &Node, mode: crate::config::TreeIcons) -> (&'static str, Option<Color>) {
+    use crate::config::TreeIcons;
+    if mode == TreeIcons::Off {
+        return match node.kind {
+            NodeKind::Dir if node.expanded => ("▾ ", None),
+            NodeKind::Dir => ("▸ ", None),
+            NodeKind::File => ("  ", None),
+        };
+    }
+    if node.kind == NodeKind::Dir {
+        return match mode {
+            TreeIcons::Unicode if node.expanded => ("▾ ▣ ", Some(Color::LightBlue)),
+            TreeIcons::Unicode => ("▸ ▣ ", Some(Color::LightBlue)),
+            TreeIcons::Nerd if node.expanded => ("▾  ", Some(Color::LightBlue)),
+            TreeIcons::Nerd => ("▸  ", Some(Color::LightBlue)),
+            TreeIcons::Off => unreachable!(),
+        };
+    }
+    file_icon(&node.path, mode)
+}
+
+/// File glyph shared by tree rows and finder results, so `file_icons` has one visual vocabulary
+/// everywhere a file path is listed.
+fn file_icon(
+    path: &std::path::Path,
+    mode: crate::config::TreeIcons,
+) -> (&'static str, Option<Color>) {
+    use crate::config::TreeIcons;
+    if mode == TreeIcons::Off {
+        return ("  ", None);
+    }
+    let name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("");
+    let name_lower = name.to_ascii_lowercase();
+    let ext = path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    // Standard Unicode approximations of common DevOps Nerd Font glyphs. Keep these to
+    // single-cell, text-font characters: Windows Terminal + Cascadia Mono renders them reliably
+    // and ratatui keeps every tree/search row aligned without a bundled font.
+    let path_lower = path
+        .to_string_lossy()
+        .replace('\\', "/")
+        .to_ascii_lowercase();
+    let is_yaml = matches!(ext.as_str(), "yaml" | "yml");
+    let in_dir = |dir: &str| path_lower.starts_with(dir) || path_lower.contains(&format!("/{dir}"));
+    let is_github_workflow = in_dir(".github/workflows/");
+    let is_helm_chart = matches!(name_lower.as_str(), "chart.yaml" | "chart.yml")
+        || (is_yaml && in_dir("templates/"));
+    let is_kubernetes_manifest = is_yaml
+        && (in_dir("k8s/")
+            || in_dir("kubernetes/")
+            || in_dir("manifests/")
+            || matches!(
+                path.file_stem()
+                    .and_then(|stem| stem.to_str())
+                    .unwrap_or("")
+                    .to_ascii_lowercase()
+                    .as_str(),
+                "deployment"
+                    | "service"
+                    | "ingress"
+                    | "configmap"
+                    | "secret"
+                    | "daemonset"
+                    | "statefulset"
+                    | "namespace"
+                    | "kustomization"
+            ));
+    match mode {
+        TreeIcons::Unicode
+            if name_lower == "jenkinsfile"
+                || name_lower.starts_with("jenkinsfile.")
+                || name_lower.ends_with(".jenkinsfile") =>
+        {
+            ("⚙ ", Some(Color::LightRed))
+        }
+        TreeIcons::Unicode
+            if name_lower == "dockerfile"
+                || name_lower.starts_with("dockerfile.")
+                || name_lower.starts_with("docker-compose")
+                || name_lower.starts_with("compose.") =>
+        {
+            ("▰ ", Some(Color::LightCyan))
+        }
+        TreeIcons::Unicode if is_helm_chart => ("⎈ ", Some(Color::LightCyan)),
+        TreeIcons::Unicode if is_github_workflow => ("↻ ", Some(Color::LightBlue)),
+        TreeIcons::Unicode if is_kubernetes_manifest => ("☸ ", Some(Color::LightBlue)),
+        TreeIcons::Unicode => match ext.as_str() {
+            "yaml" | "yml" => ("≋ ", Some(Color::Yellow)),
+            "tf" | "hcl" => ("△ ", Some(Color::LightMagenta)),
+            "tfvars" => ("◇ ", Some(Color::LightMagenta)),
+            "rs" => ("◆ ", Some(Color::LightRed)),
+            "md" | "mdx" => ("≡ ", Some(Color::LightBlue)),
+            "json" => ("▦ ", Some(Color::Yellow)),
+            "toml" | "ini" | "conf" | "cfg" => ("⚙ ", Some(Color::Yellow)),
+            "js" | "jsx" => ("■ ", Some(Color::Yellow)),
+            "ts" | "tsx" => ("■ ", Some(Color::LightBlue)),
+            "py" => ("● ", Some(Color::Yellow)),
+            "sh" | "bash" | "zsh" | "fish" | "ps1" | "bat" | "cmd" => {
+                ("❯ ", Some(Color::LightGreen))
+            }
+            "html" | "htm" | "css" | "scss" | "sass" | "less" => ("◆ ", Some(Color::LightMagenta)),
+            "png" | "jpg" | "jpeg" | "gif" | "webp" | "svg" | "ico" => {
+                ("▧ ", Some(Color::LightMagenta))
+            }
+            "zip" | "gz" | "tgz" | "bz2" | "xz" | "7z" | "rar" | "tar" => {
+                ("▤ ", Some(Color::LightRed))
+            }
+            _ => ("· ", Some(Color::DarkGray)),
+        },
+        TreeIcons::Nerd => match (name, ext.as_str()) {
+            (_, "rs") => (" ", Some(Color::LightRed)),
+            (_, "md" | "mdx") => (" ", Some(Color::LightBlue)),
+            (_, "json") => (" ", Some(Color::Yellow)),
+            (_, "toml") => (" ", Some(Color::Yellow)),
+            (_, "yaml" | "yml") => (" ", Some(Color::Yellow)),
+            (".gitignore" | ".gitattributes" | ".gitmodules", _) => (" ", Some(Color::LightRed)),
+            ("Cargo.lock" | "Cargo.toml", _) => (" ", Some(Color::LightRed)),
+            _ => (" ", Some(Color::Gray)),
+        },
+        TreeIcons::Off => unreachable!(),
+    }
+}
+
+/// Render one finder result with the configured file glyph. The selection modifier is patched
+/// onto both spans, while the icon keeps its type-specific foreground color.
+fn finder_match_line(path: &str, selected: bool, icons: crate::config::TreeIcons) -> Line<'static> {
+    let row_style = if selected {
+        Style::new().add_modifier(Modifier::REVERSED)
+    } else {
+        Style::new()
     };
+    let path_obj = std::path::Path::new(path);
+    let (glyph, glyph_color) = file_icon(path_obj, icons);
+    let text = sanitize_control(path);
+    if icons == crate::config::TreeIcons::Off || glyph.trim().is_empty() {
+        Line::styled(text, row_style)
+    } else {
+        let glyph_style = if selected {
+            row_style
+        } else {
+            glyph_color.map_or(row_style, |color| row_style.fg(color))
+        };
+        Line::from(vec![
+            Span::styled(glyph, glyph_style),
+            Span::styled(text, row_style),
+        ])
+    }
+}
+
+fn tree_row(
+    node: &Node,
+    selected: bool,
+    annotated: bool,
+    icons: crate::config::TreeIcons,
+) -> Line<'static> {
+    let (glyph, glyph_color) = tree_icon(node, icons);
     let annotated = annotated && node.kind == NodeKind::File;
     let mut row_style = Style::new();
     if let Some(color) = row_color(node) {
@@ -506,18 +657,25 @@ fn tree_row(node: &Node, selected: bool, annotated: bool) -> Line<'static> {
         row_style = row_style.add_modifier(Modifier::REVERSED);
     }
     let prefix = format!(
-        "{}{}{}{}",
+        "{}{}{}",
         status_marker(node),
         if annotated { '@' } else { ' ' },
         "  ".repeat(node.depth),
-        glyph,
     );
     let name_style = if annotated && !selected {
         row_style.patch(ANNOTATION_STYLE)
     } else {
         row_style
     };
-    let mut spans = vec![Span::styled(prefix, row_style)];
+    let glyph_style = if selected {
+        row_style
+    } else {
+        glyph_color.map_or(row_style, |c| row_style.fg(c))
+    };
+    let mut spans = vec![
+        Span::styled(prefix, row_style),
+        Span::styled(glyph, glyph_style),
+    ];
     let name = sanitize_control(&node_name(node));
     // A compacted chain row (`src/main/java`) folds away the indentation that used to signal depth,
     // so the row needs its own anchor: draw the leading segments DIM and the last one at full
@@ -1033,6 +1191,7 @@ fn draw_tree(frame: &mut Frame, area: Rect, state: &ViewState) {
                     .annotation_indicators
                     .annotated_files
                     .contains(&node.path),
+                state.tree_icons,
             )
         })
         .collect();
@@ -1042,7 +1201,7 @@ fn draw_tree(frame: &mut Frame, area: Rect, state: &ViewState) {
     // lets long / deeply-nested rows be read sideways (`H`/`L` scroll the tree; ←/→ are
     // expand/collapse in the tree).
     // `geometry` recomputes the SAME layout + offset, so hit-testing agrees with what is drawn.
-    let max_width = tree_rows_max_width(&state.nodes);
+    let max_width = tree_rows_max_width(&state.nodes, state.tree_icons);
     let (text, vbar, hbar) = tree_bars(inner, state.nodes.len(), max_width);
     let offset = sticky_scroll_offset(
         state.selected,
@@ -1447,7 +1606,7 @@ pub fn geometry(area: Rect, state: &ViewState) -> PaneGeometry {
     // to the row actually drawn and a press lands on the bar actually shown. The scroll offset is
     // derived identically (over the reduced text height + last frame's offset). Saturating casts:
     // an absurd >65535 value clamps instead of wrapping.
-    let max_width = tree_rows_max_width(&state.nodes);
+    let max_width = tree_rows_max_width(&state.nodes, state.tree_icons);
     let (tree_inner, tree_vbar, tree_hbar) = match tree.map(inner) {
         Some(ti) => {
             let (text, v, h) = tree_bars(ti, state.nodes.len(), max_width);
@@ -1536,7 +1695,7 @@ pub fn geometry(area: Rect, state: &ViewState) -> PaneGeometry {
     // so the hit-test geometry agrees with what is drawn.
     let (finder_rows, finder_scroll, finder_max_hscroll, finder_vbar) = match &state.finder {
         Some(finder) => {
-            let fl = finder_overlay_layout(area, finder);
+            let fl = finder_overlay_layout(area, finder, state.tree_icons);
             (
                 fl.rows_area,
                 fl.offset.min(u16::MAX as usize) as u16,
@@ -1648,7 +1807,7 @@ pub fn draw(frame: &mut Frame, state: &ViewState) -> PreviewViewports {
     // The go-to-file finder is also a modal overlay (AC-1). Only one modal is ever open, but
     // an independent check is correct — if both are somehow set, both draw (last wins).
     if let Some(finder) = &state.finder {
-        draw_finder_overlay(frame, frame.area(), finder);
+        draw_finder_overlay(frame, frame.area(), finder, state.tree_icons);
     }
     // Annotation modals are keyboard-only overlays. They add no hit-test geometry; their owned,
     // typed draw models contain raw fields and the Presenter formats/sanitizes them here.
@@ -2052,7 +2211,11 @@ struct FinderLayout {
 /// model. This is the **single authoritative place** for all the sizing + centering + scroll
 /// math — both [`draw_finder_overlay`] and [`geometry`] call it, so the drawn rects and the
 /// hit-test geometry are guaranteed to agree.
-fn finder_overlay_layout(area: Rect, finder: &FinderView) -> FinderLayout {
+fn finder_overlay_layout(
+    area: Rect,
+    finder: &FinderView,
+    icons: crate::config::TreeIcons,
+) -> FinderLayout {
     // Build the query line for width measurement (same logic as draw).
     let query_line: Line<'static> = if finder.query.is_empty() {
         Line::styled(
@@ -2069,15 +2232,7 @@ fn finder_overlay_layout(area: Rect, finder: &FinderView) -> FinderLayout {
         .matches
         .iter()
         .enumerate()
-        .map(|(i, path)| {
-            let text = sanitize_control(path);
-            let style = if i == finder.cursor {
-                Style::new().add_modifier(Modifier::REVERSED)
-            } else {
-                Style::new()
-            };
-            Line::styled(text, style)
-        })
+        .map(|(i, path)| finder_match_line(path, i == finder.cursor, icons))
         .collect();
 
     // Chrome widths (same as draw_finder_overlay). No top-right chip — the footer is the single
@@ -2177,10 +2332,15 @@ fn finder_overlay_layout(area: Rect, finder: &FinderView) -> FinderLayout {
 ///
 /// Reuses [`centered_rect_sized`], [`scroll_offset`], `PICKER_PADDING`, and the Scrollbar/
 /// Block primitives from the picker overlay — no duplication of their internals.
-fn draw_finder_overlay(frame: &mut Frame, area: Rect, finder: &FinderView) {
+fn draw_finder_overlay(
+    frame: &mut Frame,
+    area: Rect,
+    finder: &FinderView,
+    icons: crate::config::TreeIcons,
+) {
     // Delegate all sizing + centering + scroll math to the shared layout helper, so this
     // function and `geometry()` can never drift from each other.
-    let layout = finder_overlay_layout(area, finder);
+    let layout = finder_overlay_layout(area, finder, icons);
 
     // Build the query line for rendering (same logic as the layout helper, which built it only
     // for measurement). Re-built here because `Line` is not `Copy` and the helper doesn't need
@@ -2201,15 +2361,7 @@ fn draw_finder_overlay(frame: &mut Frame, area: Rect, finder: &FinderView) {
         .matches
         .iter()
         .enumerate()
-        .map(|(i, path)| {
-            let text = sanitize_control(path);
-            let style = if i == finder.cursor {
-                Style::new().add_modifier(Modifier::REVERSED)
-            } else {
-                Style::new()
-            };
-            Line::styled(text, style)
-        })
+        .map(|(i, path)| finder_match_line(path, i == finder.cursor, icons))
         .collect();
 
     // Chrome: static strings, no sanitization needed. Only FINDER_TITLE on the top border —

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -10505,6 +10505,7 @@ fn open_help_orders_optional_sections_after_whats_new_and_keeps_independent_scro
         tree_width: 30,
         tree_position: herdr_file_viewer::config::TreePosition::Left,
         tree_max_cols: 45,
+        file_icons: herdr_file_viewer::config::TreeIcons::Unicode,
         preview_max_lines: 5000,
         preview_max_kib: 1024,
     };

--- a/tests/docs_consistency.rs
+++ b/tests/docs_consistency.rs
@@ -117,6 +117,7 @@ fn config_example_documents_every_config_key() {
         "tree_width",
         "tree_position",
         "tree_max_cols",
+        "file_icons",
         "preview_max_lines",
         "preview_max_kib",
     ] {

--- a/tests/presenter.rs
+++ b/tests/presenter.rs
@@ -86,6 +86,7 @@ fn sample_state() -> ViewState {
         // A high cap so the percentage governs in these fixtures (the cap only bites on very wide
         // panes; the cap's own behaviour is covered by dedicated tests).
         tree_max_cols: 1000,
+        tree_icons: herdr_file_viewer::config::TreeIcons::Off,
         split_manual: false,
         zoomed: false,
         remote_notice_status: None,
@@ -4681,5 +4682,44 @@ fn a_compacted_directory_row_renders_its_chain_label() {
     assert!(
         frame.contains("App.java"),
         "its child still renders one level in\n{frame}"
+    );
+}
+
+#[test]
+fn tree_icons_modes_render_expected_glyphs_in_tree_and_finder() {
+    let mut state = sample_state();
+    state.tree_icons = herdr_file_viewer::config::TreeIcons::Unicode;
+    let frame = render(&state, 100, 12);
+    assert!(
+        frame.contains("▾ ▣ src"),
+        "unicode expanded dir icon\n{frame}"
+    );
+    assert!(frame.contains("◆ main.rs"), "unicode rust icon\n{frame}");
+    assert!(
+        frame.contains("≡ README.md"),
+        "unicode markdown icon\n{frame}"
+    );
+
+    state.tree_icons = herdr_file_viewer::config::TreeIcons::Nerd;
+    let frame_nerd = render(&state, 100, 12);
+    assert!(
+        frame_nerd.contains("▾  src"),
+        "nerd expanded dir icon\n{frame_nerd}"
+    );
+    assert!(
+        frame_nerd.contains(" main.rs"),
+        "nerd rust icon\n{frame_nerd}"
+    );
+    assert!(
+        frame_nerd.contains(" README.md"),
+        "nerd markdown icon\n{frame_nerd}"
+    );
+
+    state.tree_icons = herdr_file_viewer::config::TreeIcons::Off;
+    let frame_off = render(&state, 100, 12);
+    assert!(frame_off.contains("▾ src"), "off dir icon\n{frame_off}");
+    assert!(
+        frame_off.contains("  main.rs"),
+        "off file icon\n{frame_off}"
     );
 }

--- a/tests/presenter_narrow.rs
+++ b/tests/presenter_narrow.rs
@@ -47,6 +47,7 @@ fn state(width: u16, focus: Focus) -> ViewState {
         split_pct: 40,
         tree_position: herdr_file_viewer::config::TreePosition::Left,
         tree_max_cols: 1000, // high cap: percentage governs (narrow-layout tests ignore it anyway)
+        tree_icons: herdr_file_viewer::config::TreeIcons::Off,
         split_manual: false,
         zoomed: false,
         remote_notice_status: None,

--- a/tests/presenter_pinned.rs
+++ b/tests/presenter_pinned.rs
@@ -45,6 +45,7 @@ fn state(pinned: PreviewProjection) -> ViewState {
         split_pct: 20,
         tree_position: herdr_file_viewer::config::TreePosition::Left,
         tree_max_cols: 20,
+        tree_icons: herdr_file_viewer::config::TreeIcons::Off,
         split_manual: false,
         zoomed: false,
         remote_notice_status: None,


### PR DESCRIPTION
Resolves #153

### Summary
Adds the `file_icons` configuration option to display file and folder icons in the directory tree and file finder.

### Features
- **3 Configurable Modes**:
  - `"unicode"` (default): Uses standard, single-cell Unicode symbols with type-specific colors that render cleanly on any terminal without requiring a patched font.
  - `"nerd"` / `"nerd-font"`: Uses rich Nerd Font glyphs (``, ``, ``, ``, ``, ``, ``, etc.).
  - `"off"` / `"none"`: Plain text-only display.
- **Consistent Visuals**: File glyphs and colors are applied identically across the tree pane and the go-to-file finder modal (`/`).
- **Settings Overlay Reflection**: The active `file_icons` mode is displayed in the Settings overlay (`?`).
- **Complete Documentation & Tests**: Updated `config.example.toml`, `docs/configuration.md`, and added unit and presenter tests.

### Verification
- `cargo test --lib`: 517 passed, 0 failed
- `cargo test --test presenter --test presenter_narrow --test presenter_pinned --test docs_consistency`: 141 passed, 0 failed
- `cargo clippy --all-targets -- -D warnings`: Clean
- `cargo fmt --all --check`: Clean