### PR TITLE
feat: add open-file-viewer-overlay action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+### Added
+- `open-file-viewer-overlay` action (`open-file-viewer-overlay-windows` on Windows): open the viewer as an overlay over the current pane — a split with the tab zoomed onto it, so the layout underneath is untouched and closing it puts the tab back. Toggles like the split action: a repeat press brings an unfocused viewer back up, or closes a focused one. Bind it to e.g. `prefix+alt+f`. → [summoning](docs/summoning.md#open-as-an-overlay-over-the-current-pane) · [windows](docs/windows.md)
+
 ## [1.16.0] - 2026-08-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ key = "prefix+shift+f"
 type = "plugin_action"
 command = "herdr-file-viewer.open-file-viewer-tab"
 description = "open file viewer in tab"
+
+[[keys.command]]
+key = "prefix+alt+f"
+type = "plugin_action"
+command = "herdr-file-viewer.open-file-viewer-overlay"
+description = "open file viewer as overlay"
 ```
 
 Run `herdr server reload-config`, then press your key. That's the whole setup: the split-pane
@@ -95,7 +101,7 @@ viewer and its open actions ship **inside** the plugin and register automaticall
 you only add the keybinding.
 
 Deeper detail lives in the docs: [install & updating](docs/install.md),
-[summoning the viewer](docs/summoning.md) (split vs. tab, the launcher, `--remote`),
+[summoning the viewer](docs/summoning.md) (split vs. tab vs. overlay, the launcher, `--remote`),
 [external renderers](docs/renderers.md), and the [keys reference](docs/keys.md).
 
 ## Configuration

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ TUI pane. New here? Start with the [README](../README.md) for what it is and a q
 | Page | What's in it |
 | --- | --- |
 | [Install & updating](install.md) | Prebuilt vs. source, pinning a version, local-dev linking, and how updates surface (the in-app "update available" banner). |
-| [Summoning the viewer](summoning.md) | The open actions, the idempotent launcher, split vs. tab, and the `--remote` caveat. |
+| [Summoning the viewer](summoning.md) | The open actions, the idempotent launcher, split vs. tab vs. overlay, and the `--remote` caveat. |
 | [Usage guide](usage.md) | A feature-by-feature tour: the tree, open-at-launch, view modes, git awareness, find/search, copying, hand-offs, worktrees, help. |
 | [Keys & mouse](keys.md) | The complete key table, mouse gestures, and the editor hand-off (`$EDITOR` troubleshooting). |
 | [Configuration](configuration.md) | The full `config.toml` reference — editor/renderer/opener commands, startup toggles, tree layout, and `[keys]` remapping. |

--- a/docs/install.md
+++ b/docs/install.md
@@ -47,7 +47,7 @@ herdr's install output is intentionally terse (`Installed …` / `Config: …`) 
 so two quick steps remain:
 
 1. **Bind a key** to summon the viewer. See [Quick start](../README.md#quick-start) (or
-   [Summoning the viewer](summoning.md) for split-vs-tab and the `--remote` caveat). No key bound
+   [Summoning the viewer](summoning.md) for split vs. tab vs. overlay and the `--remote` caveat). No key bound
    yet? Open it once from the CLI:
    `herdr plugin action invoke open-file-viewer --plugin herdr-file-viewer`.
 2. **(Optional) install the renderers** (`glow` / `delta` / `bat`) so markdown, diffs, and code are

--- a/docs/summoning.md
+++ b/docs/summoning.md
@@ -1,7 +1,7 @@
 # Summoning the viewer
 
-How the viewer gets opened: the open actions, the idempotent launcher, split vs. tab, and the
-`--remote` caveat. For a quick "install then bind a key," see the [Quick start](../README.md#quick-start);
+How the viewer gets opened: the open actions, the idempotent launcher, split vs. tab vs. overlay,
+and the `--remote` caveat. For a quick "install then bind a key," see the [Quick start](../README.md#quick-start);
 once it's open, see the [usage guide](usage.md) and [keys reference](keys.md).
 
 The viewer opens **only** in response to an explicit action. There are no event hooks and no
@@ -73,6 +73,32 @@ key = "prefix+shift+f"
 type = "plugin_action"
 command = "herdr-file-viewer.open-file-viewer-tab"
 description = "open file viewer in tab"
+```
+
+## Open as an overlay over the current pane
+
+A third action, `open-file-viewer-overlay`, opens the viewer **over** the current pane instead of
+beside it or in another tab (`scripts/open-file-viewer-overlay.sh`, `--placement overlay`). herdr
+splits the viewer beside the active pane and zooms the tab onto it, so it fills the tab and the
+layout underneath is untouched; closing it puts the tab back the way it was.
+
+Its launcher is idempotent within the current tab, like the split one, *launch-or-focus-or-toggle*:
+
+- no viewer in this tab → open it as an overlay (focused)
+- a viewer in this tab, not focused (e.g. one opened as a split) → bring it up as the overlay
+- the viewer already focused → close it
+
+All three launchers look for the same viewer pane, so there is at most one per tab: pressing the
+overlay key over a tab that already has a split viewer zooms that one instead of opening a second.
+
+Bind it to its own key, e.g. `prefix+alt+f`:
+
+```toml
+[[keys.command]]
+key = "prefix+alt+f"
+type = "plugin_action"
+command = "herdr-file-viewer.open-file-viewer-overlay"
+description = "open file viewer as overlay"
 ```
 
 ## Limitation over `herdr --remote`

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -8,9 +8,10 @@ extra tooling required beyond the in-box Windows PowerShell 5.1. The open/toggle
 PowerShell launcher scripts.
 
 - **On Windows, bind the `-windows` action ids.** herdr requires every action id to be unique, so
-  the Windows launchers register as **`open-file-viewer-windows`** and
-  **`open-file-viewer-tab-windows`** (the unqualified `open-file-viewer` / `open-file-viewer-tab`
-  ids are the Linux/macOS variants). Point `plugin_action` bindings at the qualified Windows ids:
+  the Windows launchers register as **`open-file-viewer-windows`**,
+  **`open-file-viewer-tab-windows`** and **`open-file-viewer-overlay-windows`** (the unqualified
+  `open-file-viewer` / `open-file-viewer-tab` / `open-file-viewer-overlay` ids are the Linux/macOS
+  variants). Point `plugin_action` bindings at the qualified Windows ids:
 
   ```toml
   [[keys.command]]
@@ -24,7 +25,16 @@ PowerShell launcher scripts.
   type = "plugin_action"
   command = "herdr-file-viewer.open-file-viewer-tab-windows"
   description = "open file viewer in tab"
+
+  [[keys.command]]
+  key = "prefix+alt+f"
+  type = "plugin_action"
+  command = "herdr-file-viewer.open-file-viewer-overlay-windows"
+  description = "open file viewer as overlay"
   ```
+
+  On Windows the overlay launcher splits the viewer and then zooms the tab onto it (it can't use
+  herdr's `overlay` placement, for the same absolute-path reason as the other launchers).
 - **Requires herdr's preview channel.** Windows herdr binaries ship only on herdr's pre-release
   update channel, so you need to be on it before installing this plugin on Windows.
 - **Non-ASCII paths and pane titles are supported.** The launchers force UTF-8 before parsing

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -10,7 +10,8 @@
 #  - [[actions]] are gated the same way, but each carries a UNIQUE id — herdr rejects a
 #    duplicate action id at load time regardless of platform (verified against herdr 0.7.1),
 #    so the Windows launchers use the `-windows`-suffixed ids `open-file-viewer-windows` /
-#    `open-file-viewer-tab-windows`. On Windows, bind THOSE action ids.
+#    `open-file-viewer-tab-windows` / `open-file-viewer-overlay-windows`. On Windows, bind THOSE
+#    action ids.
 #  - Windows launch (verified on real hardware, herdr 0.7.1-preview, GH #58): herdr can NOT spawn the
 #    manifest's RELATIVE pane command on Windows — it passes the relative program to CreateProcessW,
 #    which resolves it against herdr's OWN directory (not any `--cwd` we set), failing with
@@ -96,4 +97,25 @@ description = "Open the git-aware file viewer in its own tab (switch to it if al
 command = [
   "powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command",
   '''$u=New-Object System.Text.UTF8Encoding($false); [Console]::OutputEncoding=$u; $OutputEncoding=$u; $b=$env:HERDR_BIN_PATH; if(-not $b){$b='herdr'}; $p=((& $b plugin list --json|ConvertFrom-Json).result.plugins|?{$_.plugin_id -eq 'herdr-file-viewer'}).plugin_root; if($p -and $p.StartsWith('\\?\')){$p=$p.Substring(4)}; & (Join-Path (Join-Path $p 'scripts') 'open-file-viewer-tab.ps1')''',
+]
+
+# The same viewer, opened as an overlay over the current pane (herdr's `overlay` placement: a split
+# with the tab zoomed onto it, so the layout underneath is untouched). Idempotent within the current
+# tab like the split action. Bind a key to it (e.g. `prefix+alt+f`) in ~/.config/herdr/config.toml.
+[[actions]]
+id = "open-file-viewer-overlay"
+platforms = ["linux", "macos"]
+title = "Open file viewer (overlay)"
+description = "Open the git-aware file viewer as an overlay over the current pane (toggle on repeat)."
+command = ["bash", "scripts/open-file-viewer-overlay.sh"]
+
+[[actions]]
+id = "open-file-viewer-overlay-windows"
+platforms = ["windows"]
+title = "Open file viewer (overlay)"
+description = "Open the git-aware file viewer as an overlay over the current pane (toggle on repeat)."
+# See open-file-viewer-windows: locate the launcher via herdr's own plugin root, not the cwd.
+command = [
+  "powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command",
+  '''$u=New-Object System.Text.UTF8Encoding($false); [Console]::OutputEncoding=$u; $OutputEncoding=$u; $b=$env:HERDR_BIN_PATH; if(-not $b){$b='herdr'}; $p=((& $b plugin list --json|ConvertFrom-Json).result.plugins|?{$_.plugin_id -eq 'herdr-file-viewer'}).plugin_root; if($p -and $p.StartsWith('\\?\')){$p=$p.Substring(4)}; & (Join-Path (Join-Path $p 'scripts') 'open-file-viewer-overlay.ps1')''',
 ]

--- a/scripts/open-file-viewer-overlay.ps1
+++ b/scripts/open-file-viewer-overlay.ps1
@@ -1,0 +1,103 @@
+# open-file-viewer-overlay.ps1 -- Windows sibling of scripts/open-file-viewer-overlay.sh.
+#
+# Idempotent launcher for the file viewer as an OVERLAY over the current pane -- used by the
+# `open-file-viewer-overlay-windows` action and a herdr keybinding (e.g. `prefix+alt+f`). Same
+# "launch-or-focus, toggle on repeat" as open-file-viewer.ps1, scoped to the current tab:
+#   - no Files pane in the current tab      -> open the viewer as an overlay (focused)
+#   - a Files pane exists but isn't focused -> bring it back up as the overlay
+#   - the focused pane IS the Files pane    -> close it (the tab goes back to its layout)
+#
+# Sibling of scripts/open-file-viewer.ps1 -- see its header for WHY the Windows launchers spawn the
+# viewer by ABSOLUTE path (`pane split` + `pane run`) instead of `plugin pane open --entrypoint`.
+# That also means we can't ask herdr for `--placement overlay`, so Open-Overlay builds the same
+# state by hand: an overlay is a split with the tab zoomed onto it, hence split, run the viewer,
+# then `pane zoom <id> --on`. For the same reason the FOCUS branch is `zoom --on` alone (no
+# trailing `--off`) -- see open-file-viewer-overlay.sh.
+#
+# The OPEN/FOCUS/CLOSE decision is the split launcher's (`herdr-file-viewer.exe --launch-decision`,
+# fed `pane list` JSON on stdin) -- unit-tested (src/launch.rs), pane id validated flag-safe. Any
+# failure degrades to OPEN.
+
+$ErrorActionPreference = 'Continue'
+
+# PowerShell 5.1 otherwise decodes herdr's UTF-8 JSON with the legacy console code page;
+# non-ASCII pane titles or paths can corrupt the JSON and trigger the plugin-root fallback.
+$Utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+[Console]::OutputEncoding = $Utf8NoBom
+$OutputEncoding = $Utf8NoBom
+
+$HerdrBin = if ($env:HERDR_BIN_PATH) { $env:HERDR_BIN_PATH } else { 'herdr' }
+
+function Strip-Verbatim([string]$p) {
+    if ($p -and $p.StartsWith('\\?\')) { return $p.Substring(4) }
+    return $p
+}
+$PluginRoot = Strip-Verbatim (Split-Path -Parent $PSScriptRoot)
+$ViewerBin = Join-Path $PluginRoot 'target\release\herdr-file-viewer.exe'
+
+# Root the tree at the focused pane's cwd (the user's work pane). `pane list` prints JSON by default.
+function Get-UserCwd {
+    try {
+        $focused = (& $HerdrBin pane list | ConvertFrom-Json).result.panes |
+            Where-Object { $_.focused } | Select-Object -First 1
+        if ($focused -and $focused.cwd) { return Strip-Verbatim $focused.cwd }
+    } catch {}
+    return $PluginRoot
+}
+
+function Get-PaneId([string]$json) {
+    return ([regex]'"pane_id":"([^"]+)"').Match($json).Groups[1].Value
+}
+
+# The plugin's config directory, to pass as HERDR_PLUGIN_CONFIG_DIR -- herdr injects it only into a
+# pane IT spawns from the manifest; these launchers spawn the viewer themselves. Empty on failure.
+function Get-ConfigDir {
+    try {
+        $d = (& $HerdrBin plugin config-dir herdr-file-viewer | Out-String).Trim()
+        if ($d) { return Strip-Verbatim $d }
+    } catch {}
+    return ''
+}
+
+function Open-Overlay {
+    $cwd = Get-UserCwd
+    $splitArgs = @('pane', 'split', '--direction', 'right', '--cwd', $cwd, '--focus')
+    $cfg = Get-ConfigDir
+    if ($cfg) { $splitArgs += @('--env', "HERDR_PLUGIN_CONFIG_DIR=$cfg") }
+    $out = (& $HerdrBin @splitArgs | Out-String)
+    $np = Get-PaneId $out
+    if ($np) {
+        # Call operator + quoted absolute path so a spaced install path still launches -- see
+        # open-file-viewer.ps1's Open-Pane for the full why. (GH #58 -- confirmed live on Windows.)
+        & $HerdrBin pane run $np "& \`"$ViewerBin\`""
+        # Label it so a later invocation's launch-decision recognises it (best-effort).
+        & $HerdrBin pane rename $np Files *> $null
+        # Zoom the tab onto it: that is what makes the split an overlay.
+        & $HerdrBin pane zoom $np --on *> $null
+    }
+    exit 0
+}
+
+$Decision = 'OPEN'
+if (Test-Path $ViewerBin) {
+    $panes = & $HerdrBin pane list 2>$null
+    if ($LASTEXITCODE -ne 0) { $panes = $null }
+    if ($panes) {
+        $panesText = ($panes -join "`n")
+        $Decision = ($panesText | & $ViewerBin --launch-decision 2>$null)
+        if ($LASTEXITCODE -ne 0 -or -not $Decision) { $Decision = 'OPEN' }
+    }
+}
+
+if ($Decision -like 'FOCUS *') {
+    # No `--off` here (see the header).
+    $PaneId = $Decision.Substring(6)
+    & $HerdrBin pane zoom $PaneId --on
+    exit $LASTEXITCODE
+} elseif ($Decision -like 'CLOSE *') {
+    $PaneId = $Decision.Substring(6)
+    & $HerdrBin pane close $PaneId
+    exit $LASTEXITCODE
+} else {
+    Open-Overlay
+}

--- a/scripts/open-file-viewer-overlay.sh
+++ b/scripts/open-file-viewer-overlay.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Idempotent launcher for the file viewer as an OVERLAY over the current pane — used by the
+# `open-file-viewer-overlay` action and a herdr keybinding (e.g. `prefix+alt+f`). Same
+# "launch-or-focus, toggle on repeat" as scripts/open-file-viewer.sh, scoped to the current tab:
+#   - no Files pane in the current tab      -> open the viewer as an overlay (focused)
+#   - a Files pane exists but isn't focused  -> bring it back up as the overlay
+#   - the focused pane IS the Files pane     -> close it (the tab goes back to its layout)
+#
+# herdr's `overlay` placement is a split beside the active pane with the tab zoomed onto it
+# (herdr 0.8.2). So the FOCUS branch is `zoom --on` alone: the split launcher follows it with
+# `zoom --off` to un-maximize back into the split, which here would flatten the overlay into a
+# plain 50/50 split.
+#
+# The OPEN/FOCUS/CLOSE decision is the split launcher's (`herdr-file-viewer --launch-decision`,
+# fed the `pane list` JSON on stdin). It only asks whether a "Files" pane exists in the focused
+# pane's tab, so it doesn't care how that pane was placed — a viewer opened by any launcher is
+# found, never duplicated. Unit-tested (src/launch.rs); the pane id it returns is validated
+# flag-safe. Any failure degrades to OPEN.
+set -uo pipefail
+
+herdr_bin="${HERDR_BIN_PATH:-herdr}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+viewer_bin="$script_dir/../target/release/herdr-file-viewer"
+
+open_overlay() {
+  exec "$herdr_bin" plugin pane open \
+    --plugin herdr-file-viewer \
+    --entrypoint file-viewer \
+    --placement overlay \
+    --focus
+}
+
+decision="OPEN"
+if [ -x "$viewer_bin" ]; then
+  panes="$("$herdr_bin" pane list 2>/dev/null || true)"
+  if [ -n "$panes" ]; then
+    decision="$(printf '%s' "$panes" | "$viewer_bin" --launch-decision 2>/dev/null || echo OPEN)"
+  fi
+fi
+
+case "$decision" in
+  "FOCUS "*)
+    # No `--off` here (see the header).
+    pid="${decision#FOCUS }"
+    exec "$herdr_bin" pane zoom "$pid" --on
+    ;;
+  "CLOSE "*)
+    pid="${decision#CLOSE }"
+    exec "$herdr_bin" pane close "$pid"
+    ;;
+  *)
+    open_overlay
+    ;;
+esac

--- a/tests/docs_consistency.rs
+++ b/tests/docs_consistency.rs
@@ -24,6 +24,10 @@ const ARCHITECTURE: &str = include_str!("../ARCHITECTURE.md");
 const AGENT_SKILL: &str = include_str!("../skills/herdr-file-viewer/SKILL.md");
 const OPEN_PANE_SCRIPT: &str = include_str!("../scripts/open-file-viewer.sh");
 const OPEN_TAB_SCRIPT: &str = include_str!("../scripts/open-file-viewer-tab.sh");
+const OPEN_OVERLAY_SCRIPT: &str = include_str!("../scripts/open-file-viewer-overlay.sh");
+const SUMMONING_DOC: &str = include_str!("../docs/summoning.md");
+const WINDOWS_DOC: &str = include_str!("../docs/windows.md");
+const MANIFEST: &str = include_str!("../herdr-plugin.toml");
 
 /// The `--cwd` drift guard (#139).
 ///
@@ -62,6 +66,7 @@ fn no_documented_launch_passes_cwd_to_plugin_pane_open() {
         ("docs/usage.md", USAGE_DOC),
         ("scripts/open-file-viewer.sh", OPEN_PANE_SCRIPT),
         ("scripts/open-file-viewer-tab.sh", OPEN_TAB_SCRIPT),
+        ("scripts/open-file-viewer-overlay.sh", OPEN_OVERLAY_SCRIPT),
     ] {
         for block in launch_blocks(doc) {
             assert!(
@@ -390,6 +395,39 @@ fn configuration_doc_documents_keys_remapping() {
         CONFIG_DOC.to_lowercase().contains("replace"),
         "docs/configuration.md must state a `[keys]` value replaces the default keys"
     );
+}
+
+#[test]
+fn summoning_docs_document_every_manifest_action() {
+    // Anti-drift for the open actions: every `[[actions]]` id the manifest declares must be
+    // documented where users learn to bind it — `docs/summoning.md` for the Linux/macOS ids and
+    // `docs/windows.md` for the `-windows` ids — so adding a launcher (split, tab, overlay, …)
+    // without teaching its keybinding fails the build. The manifest's `#` comments are stripped
+    // first so a mention in prose can't stand in for a real declaration.
+    let ids: Vec<&str> = MANIFEST
+        .lines()
+        .map(|l| l.find('#').map_or(l, |i| &l[..i]).trim())
+        .filter_map(|l| l.strip_prefix("id = \""))
+        .filter_map(|s| s.strip_suffix('"'))
+        .filter(|id| id.starts_with("open-file-viewer"))
+        .collect();
+    assert!(
+        ids.len() >= 6,
+        "expected the split, tab and overlay action pairs in the manifest, found {ids:?}"
+    );
+    for id in ids {
+        let qualified = format!("herdr-file-viewer.{id}");
+        let doc = if id.ends_with("-windows") {
+            ("docs/windows.md", WINDOWS_DOC)
+        } else {
+            ("docs/summoning.md", SUMMONING_DOC)
+        };
+        assert!(
+            doc.1.contains(&qualified),
+            "{} must show a `plugin_action` binding for `{qualified}`",
+            doc.0
+        );
+    }
 }
 
 #[test]

--- a/tests/launcher_content.rs
+++ b/tests/launcher_content.rs
@@ -22,7 +22,11 @@ fn read_script(name: &str) -> String {
 
 #[test]
 fn windows_launchers_spawn_via_call_operator_not_a_bare_path() {
-    for name in ["open-file-viewer.ps1", "open-file-viewer-tab.ps1"] {
+    for name in [
+        "open-file-viewer.ps1",
+        "open-file-viewer-tab.ps1",
+        "open-file-viewer-overlay.ps1",
+    ] {
         let s = read_script(name);
 
         // The bare form that splits on a space in the install path must be gone.
@@ -43,7 +47,11 @@ fn windows_launchers_spawn_via_call_operator_not_a_bare_path() {
 
 #[test]
 fn windows_json_consumers_force_utf8_before_convert_from_json() {
-    for name in ["open-file-viewer.ps1", "open-file-viewer-tab.ps1"] {
+    for name in [
+        "open-file-viewer.ps1",
+        "open-file-viewer-tab.ps1",
+        "open-file-viewer-overlay.ps1",
+    ] {
         let script = read_script(name);
         assert_utf8_before_json(name, &script);
     }
@@ -55,7 +63,11 @@ fn windows_json_consumers_force_utf8_before_convert_from_json() {
         .lines()
         .filter(|line| line.contains("ConvertFrom-Json"))
         .collect();
-    assert_eq!(actions.len(), 2, "expected both Windows action payloads");
+    assert_eq!(
+        actions.len(),
+        3,
+        "expected all three Windows action payloads"
+    );
     for action in actions {
         assert_utf8_before_json("manifest Windows action", action);
     }
@@ -87,7 +99,11 @@ fn windows_launchers_pass_the_plugin_config_dir() {
     // variable on, the viewer looks for config.toml under $XDG_CONFIG_HOME / $HOME — neither of
     // which Windows sets — resolves a RELATIVE path, and refuses to read it. The user's config
     // file is then ignored with no error, which reads as "the setting does nothing".
-    for name in ["open-file-viewer.ps1", "open-file-viewer-tab.ps1"] {
+    for name in [
+        "open-file-viewer.ps1",
+        "open-file-viewer-tab.ps1",
+        "open-file-viewer-overlay.ps1",
+    ] {
         let s = read_script(name);
         assert!(
             s.contains("plugin config-dir herdr-file-viewer"),

--- a/tests/launcher_overlay.rs
+++ b/tests/launcher_overlay.rs
@@ -1,0 +1,83 @@
+//! Content guards for the overlay launchers (`scripts/open-file-viewer-overlay.sh` / `.ps1`).
+//!
+//! Hermetic, like `launcher_content.rs`: they read the launcher text. An overlay is a split with
+//! the tab zoomed onto it, and `pane zoom <id> --off` flattens it back into a plain split — so the
+//! overlay launchers' FOCUS branch must be `zoom --on` alone, and the Windows one (which spawns
+//! the viewer by absolute path and so can't ask herdr for the placement, GH #58) must zoom the
+//! pane it splits. Copy-pasting the split launcher's `--on`/`--off` FOCUS branch would quietly
+//! turn this into a second split action; that is what these catch.
+
+use std::path::PathBuf;
+
+fn read_script(name: &str) -> String {
+    let p = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("scripts")
+        .join(name);
+    std::fs::read_to_string(&p).unwrap_or_else(|e| panic!("read {}: {e}", p.display()))
+}
+
+/// The script with `#` line-comments stripped, so assertions see commands, not prose.
+fn code_only(script: &str) -> String {
+    script
+        .lines()
+        .filter(|l| !l.trim_start().starts_with('#'))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[test]
+fn unix_overlay_launcher_requests_the_overlay_placement() {
+    let s = code_only(&read_script("open-file-viewer-overlay.sh"));
+    assert!(
+        s.contains("plugin pane open") && s.contains("--placement overlay"),
+        "the unix overlay launcher must open the manifest pane with `--placement overlay`"
+    );
+    assert!(
+        !s.contains("--placement split") && !s.contains("--placement tab"),
+        "the unix overlay launcher must not fall back to another placement"
+    );
+    // Same placement-agnostic decision as the split launcher (tab-scoped: is there a Files pane
+    // in the focused pane's tab?), so a viewer opened by any launcher is found, never duplicated.
+    assert!(
+        s.contains("--launch-decision") && !s.contains("--launch-decision-tab"),
+        "the unix overlay launcher must reuse the tab-scoped `--launch-decision` mode"
+    );
+}
+
+#[test]
+fn overlay_launchers_never_unzoom_the_pane() {
+    for name in [
+        "open-file-viewer-overlay.sh",
+        "open-file-viewer-overlay.ps1",
+    ] {
+        let s = code_only(&read_script(name));
+        assert!(
+            s.contains("--on"),
+            "{name} must bring a viewer back up with `pane zoom <id> --on`"
+        );
+        assert!(
+            !s.contains("--off"),
+            "{name} runs `zoom --off`, which flattens the overlay into a plain split"
+        );
+    }
+}
+
+#[test]
+fn windows_overlay_launcher_zooms_the_pane_it_splits() {
+    // Windows can't ask herdr for `--placement overlay` (absolute-path spawn, GH #58), so the
+    // launcher must build the same state itself: split, run the viewer, then zoom onto it.
+    let s = code_only(&read_script("open-file-viewer-overlay.ps1"));
+    let split = s
+        .find("'pane', 'split'")
+        .expect("must `pane split` the viewer pane");
+    let run = s
+        .find("pane run $np")
+        .expect("must `pane run` the viewer into it");
+    let zoom = s
+        .find("pane zoom $np --on")
+        .expect("must `pane zoom $np --on` after spawning");
+    assert!(
+        split < run && run < zoom,
+        "the Windows overlay launcher must split, then run the viewer, then zoom onto the pane"
+    );
+}

--- a/tests/launcher_ps1.rs
+++ b/tests/launcher_ps1.rs
@@ -1,6 +1,7 @@
 //! Parse-only test for the Windows launcher scripts (T-8 — AC-16).
 //!
-//! `scripts/open-file-viewer.ps1` and `scripts/open-file-viewer-tab.ps1` are thin glue over the
+//! `scripts/open-file-viewer.ps1`, `scripts/open-file-viewer-tab.ps1` and
+//! `scripts/open-file-viewer-overlay.ps1` are thin glue over the
 //! already-unit-tested, portable launch-decision logic (`src/launch.rs`). The end-to-end
 //! launch-or-focus-or-close toggle needs a live herdr on Windows and is reviewer-checked
 //! (AC-16); what we CAN cheaply assert here, hermetically, is that each script is syntactically
@@ -54,6 +55,11 @@ fn open_file_viewer_tab_ps1_parses() {
 }
 
 #[test]
+fn open_file_viewer_overlay_ps1_parses() {
+    assert_parses("open-file-viewer-overlay.ps1");
+}
+
+#[test]
 fn fetch_or_build_ps1_parses() {
     // Not a launcher, but the same hermetic parse-check is cheap insurance for the other
     // Windows-only script (T-7) — a syntax error there would otherwise only surface on a real
@@ -99,8 +105,8 @@ fn manifest_windows_action_commands_parse() {
 
     assert_eq!(
         payloads.len(),
-        2,
-        "expected exactly the two Windows action -Command payloads, found {}: {payloads:?}",
+        3,
+        "expected exactly the three Windows action -Command payloads, found {}: {payloads:?}",
         payloads.len()
     );
     for p in payloads {

--- a/tests/manifest.rs
+++ b/tests/manifest.rs
@@ -72,9 +72,9 @@ fn declares_at_least_one_action() {
 }
 
 #[test]
-fn declares_split_and_tab_open_actions() {
-    // The viewer can be summoned as a split pane or in its own tab; each action runs its
-    // dedicated launcher script.
+fn declares_split_tab_and_overlay_open_actions() {
+    // The viewer can be summoned as a split pane, in its own tab, or as an overlay over the
+    // current pane; each action runs its dedicated launcher script.
     let m = manifest();
     assert!(
         m.contains(r#"id = "open-file-viewer""#),
@@ -91,6 +91,14 @@ fn declares_split_and_tab_open_actions() {
     assert!(
         m.contains("scripts/open-file-viewer-tab.sh"),
         "tab action runs its launcher"
+    );
+    assert!(
+        m.contains(r#"id = "open-file-viewer-overlay""#),
+        "overlay action present"
+    );
+    assert!(
+        m.contains("scripts/open-file-viewer-overlay.sh"),
+        "overlay action runs its launcher"
     );
 }
 
@@ -180,6 +188,27 @@ fn open_file_viewer_tab_action_is_platform_gated_unix_and_windows() {
     assert!(
         m.contains("plugin list --json") && m.contains("'open-file-viewer-tab.ps1'"),
         "open-file-viewer-tab's Windows variant must locate the .ps1 via herdr's plugin root: {m}"
+    );
+}
+
+#[test]
+fn open_file_viewer_overlay_action_is_platform_gated_unix_and_windows() {
+    // Same shape as the split and tab pairs: a unix (bash .sh) variant and a Windows (PowerShell
+    // .ps1) variant under a DISTINCT id, each gated to its platform, the Windows one locating its
+    // launcher via herdr's own plugin root.
+    let m = manifest();
+    assert!(
+        m.contains("id = \"open-file-viewer-overlay\"\nplatforms = [\"linux\", \"macos\"]")
+            && m.contains("command = [\"bash\", \"scripts/open-file-viewer-overlay.sh\"]"),
+        "open-file-viewer-overlay's unix variant must be gated to [\"linux\", \"macos\"] and run the .sh launcher: {m}"
+    );
+    assert!(
+        m.contains("id = \"open-file-viewer-overlay-windows\"\nplatforms = [\"windows\"]"),
+        "open-file-viewer-overlay's Windows variant must use the distinct id open-file-viewer-overlay-windows, gated to [\"windows\"]: {m}"
+    );
+    assert!(
+        m.contains("plugin list --json") && m.contains("'open-file-viewer-overlay.ps1'"),
+        "open-file-viewer-overlay's Windows variant must locate the .ps1 via herdr's plugin root: {m}"
     );
 }
 


### PR DESCRIPTION
## Summary

Adds a third open action, `open-file-viewer-overlay`, that opens the viewer **over** the current pane instead of beside it (`open-file-viewer`) or in its own tab (`open-file-viewer-tab`).

It uses herdr's `overlay` placement, which is a split beside the active pane with the tab zoomed onto it: the viewer fills the tab, the layout underneath is untouched, and closing it puts the tab back. Useful for a quick look at a file without shrinking the pane you're working in. Today the only way to get this is a raw `[[keys.command]] type = "shell"` calling `herdr plugin pane open --placement overlay` by hand.

## Changes

- `scripts/open-file-viewer-overlay.sh` — launcher, same launch-or-focus-or-toggle shape as `open-file-viewer.sh`, scoped to the current tab. It reuses `--launch-decision` as-is (the decision only asks whether a `Files` pane exists in the focused pane's tab, so it doesn't care how that pane was placed — one viewer per tab across all three launchers, no new Rust). The one deliberate difference: FOCUS is `pane zoom <id> --on` alone. The split launcher follows it with `--off` to un-maximize back into the split, which here would flatten the overlay into a plain 50/50 split.
- `scripts/open-file-viewer-overlay.ps1` — Windows sibling. It can't ask herdr for `--placement overlay` (same absolute-path spawn reason as the other Windows launchers, #58), so it builds the state by hand: `pane split` + `pane run` + `pane rename Files` + `pane zoom --on`.
- `herdr-plugin.toml` — `open-file-viewer-overlay` (linux/macos) + `open-file-viewer-overlay-windows`, following the existing action pairs.
- Tests: `manifest.rs`, `launcher_content.rs`, `launcher_ps1.rs` extended to cover the new pair; new `tests/launcher_overlay.rs` pins that neither overlay launcher ever runs `zoom --off` and that the `.ps1` zooms the pane it splits; `docs_consistency.rs` adds the new script to the `--cwd` guard (#139) and a small anti-drift check that every `[[actions]]` id in the manifest has a `plugin_action` binding in `docs/summoning.md` / `docs/windows.md`.
- Docs: new section in `docs/summoning.md` (with a `prefix+alt+f` example), `docs/windows.md` action ids, README quick-start binding, `CHANGELOG.md` Unreleased entry.

No version bump — additive, and existing launchers are unchanged. The `overlay` placement has been available (and is the manifest default) since herdr 0.7.0, the manifest's `min_herdr_version`, per herdr's plugins doc at that tag, so the version floor doesn't move.

## Test plan

- [x] `cargo test` is green (full suite, including the new `launcher_overlay` tests)
- [x] `cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings` pass (`cargo audit` not run locally — no dependency changes)
- [x] Docs updated in this PR (CHANGELOG + `docs/summoning.md`, `docs/windows.md`, README)
- [x] Verified live on macOS, herdr 0.8.2, with the release binary from this branch: OPEN opens the viewer zoomed and focused → repeat press CLOSEs it; with the viewer un-zoomed and unfocused in the same tab, the decision is FOCUS and `zoom --on` brings it back as the overlay → repeat press CLOSEs it.
- [ ] Windows: **not verified on real hardware.** The `.ps1` mirrors `open-file-viewer.ps1` plus the zoom step and is covered by the parse/content tests, but I only have a Mac.

## Related

Doesn't overlap with #151 / #152 (this PR only adds files and new manifest entries). If #151 lands first, the overlay launcher should pick up its `"OPEN <pane_id>"` case as a follow-up so all three launchers stay consistent.
